### PR TITLE
feat: Gainesville VA + Annapolis MD + ACA marketplace fields (recovery)

### DIFF
--- a/data/locations/us-annapolis-md/location.json
+++ b/data/locations/us-annapolis-md/location.json
@@ -1,0 +1,224 @@
+{
+  "id": "us-annapolis-md",
+  "name": "Annapolis MD, USA",
+  "country": "United States",
+  "region": "Maryland",
+  "cities": ["Annapolis", "Arnold", "Severna Park", "Edgewater"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 27,
+    "summerHighF": 88,
+    "rainyDaysPerYear": 114,
+    "meetsWarmWinterReq": false
+  },
+  "monthlyCosts": {
+    "rent": {
+      "min": 2000,
+      "max": 2850,
+      "typical": 2450,
+      "type": "2-bedroom SFH / townhome",
+      "annualInflation": 0.035,
+      "notes": "Waterfront premium near downtown; inland Parole / Riva / Edgewater cheaper. Still below Fairfax by ~15%."
+    },
+    "groceries": {
+      "min": 1300,
+      "max": 1700,
+      "typical": 1500,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Giant, Whole Foods. Mid-Atlantic pricing, slightly below Fairfax."
+    },
+    "utilities": {
+      "min": 260,
+      "max": 430,
+      "typical": 335,
+      "annualInflation": 0.03,
+      "notes": "BGE (electric + gas) + Annapolis Water / Anne Arundel County water + trash."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "annualInflation": 0.055,
+      "notes": "Medicare + Medigap baseline. Luminis Health Anne Arundel Medical Center; Johns Hopkins / Univ of MD specialists within 30 min."
+    },
+    "healthcarePreMedicare": {
+      "min": 1700,
+      "max": 2650,
+      "typical": 2150,
+      "annualInflation": 0.06,
+      "notes": "Maryland Health Connection silver plan benchmark for 2-adult household, both 55-64, before subsidies. MD marketplace typically cheaper than VA due to broader insurer participation."
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03,
+      "notes": "Slightly higher than inland VA due to coastal flood risk."
+    },
+    "petCare": {
+      "min": 130,
+      "max": 230,
+      "typical": 170,
+      "annualInflation": 0.04
+    },
+    "transportation": {
+      "min": 280,
+      "max": 520,
+      "typical": 400,
+      "annualInflation": 0.03,
+      "notes": "Car-dependent. Route 50 to DC (~35 mi), Bay Bridge eastbound tolls. No Metro; commuter bus to DC/Baltimore."
+    },
+    "entertainment": {
+      "min": 420,
+      "max": 620,
+      "typical": 510,
+      "annualInflation": 0.025,
+      "notes": "Comcast 1Gig, streaming, dining out. Historic downtown with waterfront restaurants (premium) and inland casual options."
+    },
+    "clothing": {
+      "min": 95,
+      "max": 230,
+      "typical": 150,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 45,
+      "max": 110,
+      "typical": 70,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 110,
+      "max": 230,
+      "typical": 165,
+      "annualInflation": 0.025,
+      "notes": "Bay Bridge E-ZPass tolls, marina fees if boating, HOA fees in some neighborhoods."
+    },
+    "buffer": {
+      "min": 750,
+      "max": 750,
+      "typical": 750,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile as Fairfax base. Specialists at Johns Hopkins / Univ of MD within 30 min."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from MD + Anne Arundel County brackets; stored value 0 by convention."
+    }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0,      "max": 23850,  "rate": 0.10 },
+        { "min": 23850,  "max": 96950,  "rate": 0.12 },
+        { "min": 96950,  "max": 206700, "rate": 0.22 },
+        { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 },
+        { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null,   "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.078,
+      "type": "combined-state-plus-county",
+      "brackets": [
+        { "min": 0,      "max": 1000,   "rate": 0.0481 },
+        { "min": 1000,   "max": 2000,   "rate": 0.0581 },
+        { "min": 2000,   "max": 3000,   "rate": 0.0681 },
+        { "min": 3000,   "max": 100000, "rate": 0.0756 },
+        { "min": 100000, "max": 125000, "rate": 0.0781 },
+        { "min": 125000, "max": 150000, "rate": 0.0806 },
+        { "min": 150000, "max": 250000, "rate": 0.0831 },
+        { "min": 250000, "max": null,   "rate": 0.0856 }
+      ],
+      "deduction": 5150,
+      "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates above are combined state + Anne Arundel County piggyback (2.81%)."
+    },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Maryland statewide 6%; no local add-ons."
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax — significant savings vs VA."
+    },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 0,
+    "ssExempt": true,
+    "notes": "MD is a moderately tax-friendly retirement state: SS exempt, pension exclusion, no vehicle property tax. Combined state+county rate higher than VA for upper-middle incomes."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 9,
+    "waitTimes": "low-moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
+    "notes": "Luminis Health Anne Arundel Medical Center, access to Johns Hopkins (Baltimore, ~30 mi) and Univ of MD Medical Center. Excellent coastal healthcare.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2150,
+      "benchmarkSilverMonthlySingle": 1075,
+      "notes": "Maryland Health Connection: CareFirst BlueCross, Kaiser Permanente, UnitedHealthcare. MD marketplace generally more competitive than VA.",
+      "premiumCapPctOfIncome": 0.085
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Comcast/Xfinity, Verizon Fios partial)",
+    "dogFriendly": 8,
+    "expatCommunity": 0,
+    "englishPrevalence": 10,
+    "safetyRating": 8,
+    "notes": "Historic waterfront, Chesapeake Bay sailing, US Naval Academy, Quiet Waters Park. Strong arts and culinary scene."
+  },
+  "pros": [
+    "~15% cheaper rent than Fairfax",
+    "No vehicle personal property tax (MD)",
+    "SS and partial pension tax-exempt in MD",
+    "Waterfront lifestyle and Chesapeake Bay access",
+    "Access to Johns Hopkins / Univ of MD specialists",
+    "Walkable historic downtown"
+  ],
+  "cons": [
+    "Higher combined state+county income tax than VA",
+    "Bay Bridge tolls + summer traffic on Route 50",
+    "Coastal flood insurance premium in low-lying areas",
+    "No Metro; longer commute to DC than Fairfax",
+    "Humid summers, nor'easter exposure"
+  ]
+}

--- a/data/locations/us-baltimore-md/location.json
+++ b/data/locations/us-baltimore-md/location.json
@@ -2,7 +2,7 @@
   "id": "us-baltimore-md",
   "name": "Baltimore, MD",
   "country": "United States",
-  "region": "US Mid-Atlantic",
+  "region": "Maryland",
   "cities": [
     "Baltimore"
   ],

--- a/data/locations/us-gainesville-va/location.json
+++ b/data/locations/us-gainesville-va/location.json
@@ -1,0 +1,221 @@
+{
+  "id": "us-gainesville-va",
+  "name": "Gainesville VA, USA",
+  "country": "United States",
+  "region": "Virginia",
+  "cities": ["Gainesville", "Haymarket", "Bristow"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 23,
+    "summerHighF": 89,
+    "rainyDaysPerYear": 108,
+    "meetsWarmWinterReq": false
+  },
+  "monthlyCosts": {
+    "rent": {
+      "min": 1950,
+      "max": 2700,
+      "typical": 2300,
+      "type": "2-bedroom townhome / SFH",
+      "annualInflation": 0.035,
+      "notes": "Prince William County, newer subdivisions (Heritage Hunt, Virginia Oaks). Cheaper than Fairfax but longer commute east."
+    },
+    "groceries": {
+      "min": 1250,
+      "max": 1650,
+      "typical": 1450,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Harris Teeter, Giant. Roughly 10% below Fairfax-area pricing."
+    },
+    "utilities": {
+      "min": 250,
+      "max": 410,
+      "typical": 320,
+      "annualInflation": 0.03,
+      "notes": "NOVEC electric + Washington Gas + PWC Service Authority water/sewer + trash."
+    },
+    "healthcare": {
+      "min": 550,
+      "max": 850,
+      "typical": 650,
+      "annualInflation": 0.055,
+      "notes": "Same Medicare Part B + Medigap baseline as Fairfax. Novant UVA Health in Haymarket; Inova in Manassas."
+    },
+    "healthcarePreMedicare": {
+      "min": 1800,
+      "max": 2800,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver plan benchmark for 2-adult household, both 55-64, before subsidies. PWC marketplace 2025 — slightly cheaper than Fairfax due to competition."
+    },
+    "insurance": {
+      "min": 30,
+      "max": 50,
+      "typical": 40,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 120,
+      "max": 220,
+      "typical": 160,
+      "annualInflation": 0.04,
+      "notes": "Suburban vet pricing, slightly below Fairfax."
+    },
+    "transportation": {
+      "min": 320,
+      "max": 600,
+      "typical": 450,
+      "annualInflation": 0.03,
+      "notes": "Car-dependent. I-66 HOV/toll lanes to DC. VRE Manassas line at Broad Run adds commuter option. Higher fuel use than Fairfax."
+    },
+    "entertainment": {
+      "min": 380,
+      "max": 580,
+      "typical": 460,
+      "annualInflation": 0.025,
+      "notes": "Verizon Fios 1Gig, streaming bundle, dining out (fewer restaurants than Fairfax)."
+    },
+    "clothing": {
+      "min": 90,
+      "max": 220,
+      "typical": 140,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 40,
+      "max": 95,
+      "typical": 60,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02,
+      "notes": "T-Mobile 55+ Essentials. Same plan as Fairfax."
+    },
+    "miscellaneous": {
+      "min": 100,
+      "max": 220,
+      "typical": 150,
+      "annualInflation": 0.025,
+      "notes": "HOA dues common in Gainesville subdivisions, EZ-Pass tolls, PWC vehicle decal."
+    },
+    "buffer": {
+      "min": 700,
+      "max": 700,
+      "typical": 700,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile as Fairfax base; specialist availability slightly lower, may travel to Fairfax/DC."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from VA brackets; stored value 0 by convention."
+    }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0,      "max": 23850,  "rate": 0.10 },
+        { "min": 23850,  "max": 96950,  "rate": 0.12 },
+        { "min": 96950,  "max": 206700, "rate": 0.22 },
+        { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 },
+        { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null,   "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0575,
+      "type": "top-marginal",
+      "brackets": [
+        { "min": 0,     "max": 3000,  "rate": 0.02 },
+        { "min": 3000,  "max": 5000,  "rate": 0.03 },
+        { "min": 5000,  "max": 17000, "rate": 0.05 },
+        { "min": 17000, "max": null,  "rate": 0.0575 }
+      ],
+      "deduction": 24000,
+      "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+    },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Prince William County 6% (4.3% state + 0.7% regional + 1% NOVA transit)"
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. PWC vehicle personal property ~$3.70/$100 assessed — slightly below Fairfax."
+    },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 1100,
+    "ssExempt": true,
+    "notes": "Same VA tax treatment as Fairfax. Lower PWC property tax rate offsets newer-car assessments."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 7,
+    "waitTimes": "moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
+    "notes": "Novant UVA Health System Prince William (Haymarket), Sentara Northern Virginia Medical Center. Inova Fair Oaks/Fairfax ~25 min for specialty care.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "notes": "Anthem, CareFirst, Kaiser Permanente in Prince William. Slightly lower sticker than Fairfax.",
+      "premiumCapPctOfIncome": 0.085
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Verizon Fios, Comcast/Xfinity)",
+    "dogFriendly": 8,
+    "expatCommunity": 0,
+    "englishPrevalence": 10,
+    "safetyRating": 8,
+    "notes": "Bull Run Mountains, Manassas Battlefield nearby. Quieter than inner-NOVA; suburban family feel."
+  },
+  "pros": [
+    "~20% cheaper rent than Fairfax",
+    "Same VA tax treatment (SS exempt, retiree deductions)",
+    "Lower PWC property tax rate",
+    "Quieter suburban environment",
+    "VRE commuter rail to DC available",
+    "Access to Bull Run Mountains and wineries"
+  ],
+  "cons": [
+    "Longer commute to DC / inner NOVA",
+    "Car-dependent, I-66 traffic during rush",
+    "Fewer restaurants and cultural amenities than Fairfax",
+    "Cold winters (23°F lows)",
+    "Specialty healthcare may require drive to Fairfax/DC"
+  ]
+}

--- a/data/locations/us-virginia/location.json
+++ b/data/locations/us-virginia/location.json
@@ -79,6 +79,13 @@
       "notes": "Medicare Part B ($174.70/mo) + Medigap Plan G (~$200/mo x2 people) + Part D (~$45/mo x2) + dental/vision plans. Higher premiums reflect macular degeneration specialist coverage and frequent monitoring needs.",
       "annualInflation": 0.055
     },
+    "healthcarePreMedicare": {
+      "min": 1800,
+      "max": 2800,
+      "typical": 2300,
+      "notes": "ACA silver plan benchmark for 2-adult household, both 55-64, before subsidies. Marketplace pricing Fairfax County 2025. Subsidies reduce this dramatically at lower MAGI.",
+      "annualInflation": 0.06
+    },
     "insurance": {
       "min": 35,
       "max": 55,
@@ -273,7 +280,13 @@
     "waitTimes": "low-moderate",
     "dentalIncluded": false,
     "prescriptionCoverage": "Part D plan",
-    "notes": "Inova Fairfax Medical Center (Level I trauma), Virginia Hospital Center, access to Johns Hopkins/Georgetown specialists. Excellent healthcare infrastructure."
+    "notes": "Inova Fairfax Medical Center (Level I trauma), Virginia Hospital Center, access to Johns Hopkins/Georgetown specialists. Excellent healthcare infrastructure.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "notes": "Anthem HealthKeepers, CareFirst BlueCross BlueShield, Kaiser Permanente active in Fairfax marketplace. Silver benchmark for 2 adults age 60.",
+      "premiumCapPctOfIncome": 0.085
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps+ widely available (Verizon Fios, Cox)",

--- a/tools/insert-new-locations.mjs
+++ b/tools/insert-new-locations.mjs
@@ -1,0 +1,74 @@
+/**
+ * Upsert specific location JSON files into AdminLocation.
+ * Usage: node tools/insert-new-locations.mjs us-gainesville-va us-annapolis-md
+ */
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const prisma = new PrismaClient();
+
+const ids = process.argv.slice(2);
+if (!ids.length) {
+  console.error('Usage: node insert-new-locations.mjs <id> [<id>...]');
+  process.exit(1);
+}
+
+// Category keys that are alternates — only one of them counts toward the
+// rollup total. `healthcarePreMedicare` swaps in for `healthcare` at runtime
+// based on household age; summing both would double-count.
+const ALTERNATE_KEYS = new Set(['healthcarePreMedicare']);
+
+function extractSearchFields(loc) {
+  let monthlyCostTotal = 0;
+  if (loc.monthlyCosts) {
+    for (const [key, val] of Object.entries(loc.monthlyCosts)) {
+      if (ALTERNATE_KEYS.has(key)) continue;
+      if (val && typeof val.typical === 'number') monthlyCostTotal += val.typical;
+    }
+  }
+  return {
+    name: loc.name || '',
+    country: loc.country || '',
+    region: loc.region || '',
+    currency: loc.currency || 'USD',
+    monthlyCostTotal: Math.round(monthlyCostTotal),
+  };
+}
+
+let created = 0, updated = 0;
+for (const id of ids) {
+  const path = join(__dirname, '..', 'data', 'locations', id, 'location.json');
+  const loc = JSON.parse(readFileSync(path, 'utf-8'));
+  const search = extractSearchFields(loc);
+  const existing = await prisma.adminLocation.findUnique({ where: { id: loc.id } });
+  if (existing) {
+    const newVersion = existing.version + 1;
+    await prisma.$transaction(async (tx) => {
+      await tx.adminLocation.update({
+        where: { id: loc.id },
+        data: { locationData: loc, version: newVersion, ...search },
+      });
+      await tx.adminLocationHistory.create({
+        data: { locationId: loc.id, version: newVersion, locationData: loc, changedBy: 'insert-new-locations' },
+      });
+    });
+    updated++;
+    console.log(`  ↻ updated ${loc.name}  (${search.monthlyCostTotal}/mo)`);
+  } else {
+    await prisma.$transaction(async (tx) => {
+      await tx.adminLocation.create({
+        data: { id: loc.id, version: 1, locationData: loc, ...search },
+      });
+      await tx.adminLocationHistory.create({
+        data: { locationId: loc.id, version: 1, locationData: loc, changedBy: 'insert-new-locations' },
+      });
+    });
+    created++;
+    console.log(`  + created ${loc.name}  (${search.monthlyCostTotal}/mo)`);
+  }
+}
+console.log(`\nDone: ${created} created, ${updated} updated.`);
+await prisma.$disconnect();


### PR DESCRIPTION
Recovers commit 6d9a18a which was orphaned when PR #6 was merged before the push landed in the PR branch.

## Summary
- Added us-gainesville-va (Prince William County) and us-annapolis-md (Anne Arundel County) with full monthlyCosts + federal/state tax brackets (MD uses combined state + county piggyback)
- Fixed us-baltimore-md region from 'US Mid-Atlantic' to 'Maryland' for filter consistency
- Added healthcarePreMedicare category (alternate — excluded from default rollup sums) to Fairfax, Gainesville, Annapolis with ACA silver benchmark pricing
- Added healthcare.acaMarketplace block on the same three locations: benchmark silver (2-adult + single), premium cap %, insurer notes
- tools/insert-new-locations.mjs: Prisma upsert tool that treats healthcarePreMedicare as alternate so monthlyCostTotal doesn't double-count healthcare

## Test plan
- [ ] Locations Overview: Maryland filter shows both Annapolis + Baltimore
- [ ] Gainesville VA and Annapolis MD load with reasonable monthly totals
- [ ] Fairfax shows healthcarePreMedicare in its data when fetched via /api/locations/us-virginia
- [ ] Frontend HealthcareService picks up the ACA marketplace info correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)