### PR TITLE
feat: 7 Mid-Atlantic retirement locations + county-level ACA backfill

### DIFF
--- a/data/locations/us-albuquerque-nm/location.json
+++ b/data/locations/us-albuquerque-nm/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Bernalillo County, NM). BeWellNM — Albuquerque metro most competitive. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Bernalillo County",
+      "notes": "BeWellNM — Albuquerque metro most competitive.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-annandale-va/location.json
+++ b/data/locations/us-annandale-va/location.json
@@ -1,0 +1,90 @@
+{
+  "id": "us-annandale-va",
+  "name": "Annandale VA, USA",
+  "country": "United States",
+  "region": "Virginia",
+  "cities": ["Annandale", "Bailey's Crossroads", "Seven Corners"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 24, "summerHighF": 90, "rainyDaysPerYear": 112, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1850, "max": 2600, "typical": 2150, "type": "2-bedroom older SFH/townhome", "annualInflation": 0.035, "notes": "Older housing stock, immigrant commercial scene. ~25% cheaper than Fairfax City for comparable 2BR. Fairfax County." },
+    "groceries": { "min": 1300, "max": 1720, "typical": 1510, "annualInflation": 0.03, "notes": "Korean + Latino supermarkets (H Mart, Grand Mart) notably cheaper than Wegmans/Giant. Mixed shopper saves ~10% vs Fairfax average." },
+    "utilities": { "min": 270, "max": 440, "typical": 340, "annualInflation": 0.03, "notes": "Dominion Energy + Washington Gas + Fairfax Water." },
+    "healthcare": { "min": 550, "max": 850, "typical": 650, "notes": "Same Medicare baseline as Fairfax County. Inova Fairfax Hospital 8 min away.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 130, "max": 235, "typical": 175, "annualInflation": 0.04 },
+    "petDaycare": { "min": 320, "max": 500, "typical": 400, "annualInflation": 0.035 },
+    "petGrooming": { "min": 85, "max": 160, "typical": 120, "annualInflation": 0.03 },
+    "transportation": { "min": 240, "max": 480, "typical": 360, "annualInflation": 0.03, "notes": "Dunn Loring Metro (Orange) 10 min. I-495 + I-395 access. Better Metro proximity than Fairfax City." },
+    "entertainment": { "min": 420, "max": 620, "typical": 510, "annualInflation": 0.025, "notes": "Korean BBQ district (Little Seoul), diverse dining. Cable+1Gig included." },
+    "clothing": { "min": 100, "max": 240, "typical": 155, "annualInflation": 0.02 },
+    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 115, "max": 240, "typical": 165, "annualInflation": 0.025, "notes": "HOA, EZ-Pass, Fairfax County vehicle tax." },
+    "buffer": { "min": 800, "max": 800, "typical": 800, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile (macular degeneration, specialists at Inova/Johns Hopkins)." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets; stored value 0 by convention." },
+    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2300, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). NOVA marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0575, "type": "top-marginal",
+      "brackets": [
+        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
+        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+      ],
+      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Fairfax County 6% (4.3% state + 0.7% regional + 1% NOVA transit)" },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Fairfax County vehicle personal property ~$4.57/$100 assessed." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 1200,
+    "ssExempt": true,
+    "notes": "Fairfax County — same tax treatment as Fairfax City."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 9, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Inova Fairfax Medical Center (Level I trauma) 8 min away. Same healthcare infrastructure as Fairfax City.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300, "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Fairfax County",
+      "notes": "NOVA marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Metro pricing.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Verizon Fios, Cox)",
+    "dogFriendly": 7, "expatCommunity": 7, "englishPrevalence": 9, "safetyRating": 8,
+    "notes": "Strong Korean and Central/South American communities. Mason District Park, Lake Accotink nearby. Easier Metro access than Fairfax City."
+  },
+  "pros": [
+    "~25% cheaper rent than Fairfax City",
+    "Same Fairfax County tax treatment (SS exempt, retiree deductions)",
+    "Best grocery deal in NOVA via Korean/Latino supermarkets",
+    "Closer to DC than Fairfax City (Dunn Loring Metro)",
+    "Diverse dining and commercial scene",
+    "Same world-class healthcare (Inova)"
+  ],
+  "cons": [
+    "Older housing stock — may need more maintenance",
+    "I-495 traffic",
+    "Fewer single-family homes than outer NOVA suburbs",
+    "Still NOVA-premium vs national average"
+  ]
+}

--- a/data/locations/us-annapolis-md/location.json
+++ b/data/locations/us-annapolis-md/location.json
@@ -3,7 +3,12 @@
   "name": "Annapolis MD, USA",
   "country": "United States",
   "region": "Maryland",
-  "cities": ["Annapolis", "Arnold", "Severna Park", "Edgewater"],
+  "cities": [
+    "Annapolis",
+    "Arnold",
+    "Severna Park",
+    "Edgewater"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
   "visa": {
@@ -48,11 +53,11 @@
       "notes": "Medicare + Medigap baseline. Luminis Health Anne Arundel Medical Center; Johns Hopkins / Univ of MD specialists within 30 min."
     },
     "healthcarePreMedicare": {
-      "min": 1700,
-      "max": 2650,
+      "min": 1763,
+      "max": 2537,
       "typical": 2150,
       "annualInflation": 0.06,
-      "notes": "Maryland Health Connection silver plan benchmark for 2-adult household, both 55-64, before subsidies. MD marketplace typically cheaper than VA due to broader insurer participation."
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Anne Arundel County, MD). MD Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     },
     "insurance": {
       "min": 35,
@@ -144,13 +149,41 @@
     "federalIncomeTax": {
       "applies": true,
       "brackets": [
-        { "min": 0,      "max": 23850,  "rate": 0.10 },
-        { "min": 23850,  "max": 96950,  "rate": 0.12 },
-        { "min": 96950,  "max": 206700, "rate": 0.22 },
-        { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 },
-        { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null,   "rate": 0.37 }
+        {
+          "min": 0,
+          "max": 23850,
+          "rate": 0.1
+        },
+        {
+          "min": 23850,
+          "max": 96950,
+          "rate": 0.12
+        },
+        {
+          "min": 96950,
+          "max": 206700,
+          "rate": 0.22
+        },
+        {
+          "min": 206700,
+          "max": 394600,
+          "rate": 0.24
+        },
+        {
+          "min": 394600,
+          "max": 501050,
+          "rate": 0.32
+        },
+        {
+          "min": 501050,
+          "max": 751600,
+          "rate": 0.35
+        },
+        {
+          "min": 751600,
+          "max": null,
+          "rate": 0.37
+        }
       ],
       "standardDeduction": 30000
     },
@@ -158,14 +191,46 @@
       "rate": 0.078,
       "type": "combined-state-plus-county",
       "brackets": [
-        { "min": 0,      "max": 1000,   "rate": 0.0481 },
-        { "min": 1000,   "max": 2000,   "rate": 0.0581 },
-        { "min": 2000,   "max": 3000,   "rate": 0.0681 },
-        { "min": 3000,   "max": 100000, "rate": 0.0756 },
-        { "min": 100000, "max": 125000, "rate": 0.0781 },
-        { "min": 125000, "max": 150000, "rate": 0.0806 },
-        { "min": 150000, "max": 250000, "rate": 0.0831 },
-        { "min": 250000, "max": null,   "rate": 0.0856 }
+        {
+          "min": 0,
+          "max": 1000,
+          "rate": 0.0481
+        },
+        {
+          "min": 1000,
+          "max": 2000,
+          "rate": 0.0581
+        },
+        {
+          "min": 2000,
+          "max": 3000,
+          "rate": 0.0681
+        },
+        {
+          "min": 3000,
+          "max": 100000,
+          "rate": 0.0756
+        },
+        {
+          "min": 100000,
+          "max": 125000,
+          "rate": 0.0781
+        },
+        {
+          "min": 125000,
+          "max": 150000,
+          "rate": 0.0806
+        },
+        {
+          "min": 150000,
+          "max": 250000,
+          "rate": 0.0831
+        },
+        {
+          "min": 250000,
+          "max": null,
+          "rate": 0.0856
+        }
       ],
       "deduction": 5150,
       "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates above are combined state + Anne Arundel County piggyback (2.81%)."
@@ -194,8 +259,11 @@
     "acaMarketplace": {
       "benchmarkSilverMonthly2Adult": 2150,
       "benchmarkSilverMonthlySingle": 1075,
-      "notes": "Maryland Health Connection: CareFirst BlueCross, Kaiser Permanente, UnitedHealthcare. MD marketplace generally more competitive than VA.",
-      "premiumCapPctOfIncome": 0.085
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Anne Arundel County",
+      "notes": "MD Health Connection: CareFirst, Kaiser, UnitedHealthcare.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {

--- a/data/locations/us-armstrong-county-pa/location.json
+++ b/data/locations/us-armstrong-county-pa/location.json
@@ -135,6 +135,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2050,
+      "max": 2950,
+      "typical": 2500,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Armstrong County, PA). Rural Western PA — higher premiums, fewer insurers. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -142,7 +149,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2500,
+      "benchmarkSilverMonthlySingle": 1250,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Armstrong County",
+      "notes": "Rural Western PA — higher premiums, fewer insurers.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-asheville-nc/location.json
+++ b/data/locations/us-asheville-nc/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2091,
+      "max": 3009,
+      "typical": 2550,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Buncombe County, NC). Western NC — Blue Cross NC dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2550,
+      "benchmarkSilverMonthlySingle": 1275,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Buncombe County",
+      "notes": "Western NC — Blue Cross NC dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-atlanta/location.json
+++ b/data/locations/us-atlanta/location.json
@@ -179,6 +179,13 @@
       "max": 629,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fulton County, GA). Atlanta metro — Ambetter, Anthem, Kaiser compete. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -264,7 +271,16 @@
     "qualityRating": 8,
     "waitTimes": "varies",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Fulton County",
+      "notes": "Atlanta metro — Ambetter, Anthem, Kaiser compete.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (AT&T Fiber/Comcast)",

--- a/data/locations/us-austin/location.json
+++ b/data/locations/us-austin/location.json
@@ -181,6 +181,13 @@
       "max": 418,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Travis County, TX). Austin metro — Ambetter, Oscar, Blue Cross TX. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -252,7 +259,16 @@
     "waitTimes": "low-moderate",
     "dentalIncluded": false,
     "prescriptionCoverage": "Part D plan",
-    "notes": "Dell Seton Medical Center (Level I trauma), St. David's Medical Center, Ascension Seton network. UT Dell Medical School expanding. Good specialist access."
+    "notes": "Dell Seton Medical Center (Level I trauma), St. David's Medical Center, Ascension Seton network. UT Dell Medical School expanding. Good specialist access.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Travis County",
+      "notes": "Austin metro — Ambetter, Oscar, Blue Cross TX.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (AT&T Fiber, Google Fiber, Spectrum)",

--- a/data/locations/us-baltimore-md/location.json
+++ b/data/locations/us-baltimore-md/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1681,
+      "max": 2419,
+      "typical": 2050,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Baltimore City, MD). Baltimore metro — most competitive marketplace in MD. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2050,
+      "benchmarkSilverMonthlySingle": 1025,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Baltimore City",
+      "notes": "Baltimore metro — most competitive marketplace in MD.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-birmingham-al/location.json
+++ b/data/locations/us-birmingham-al/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2173,
+      "max": 3127,
+      "typical": 2650,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Jefferson County, AL). BCBS Alabama dominant — limited marketplace competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2650,
+      "benchmarkSilverMonthlySingle": 1325,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Jefferson County",
+      "notes": "BCBS Alabama dominant — limited marketplace competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-bowie-md/location.json
+++ b/data/locations/us-bowie-md/location.json
@@ -1,0 +1,98 @@
+{
+  "id": "us-bowie-md",
+  "name": "Bowie MD, USA",
+  "country": "United States",
+  "region": "Maryland",
+  "cities": ["Bowie", "Belair", "Mitchellville"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 26, "summerHighF": 88, "rainyDaysPerYear": 113, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1850, "max": 2600, "typical": 2150, "type": "2-bedroom SFH / townhome", "annualInflation": 0.035, "notes": "Prince George's County — Belair, Mitchellville, Saddlebrook subdivisions. Mid-priced MD suburb; cheaper than Annapolis, more than Baltimore." },
+    "groceries": { "min": 1280, "max": 1680, "typical": 1460, "annualInflation": 0.03, "notes": "Wegmans, Giant, Safeway, Harris Teeter. Similar to Annapolis pricing." },
+    "utilities": { "min": 260, "max": 420, "typical": 335, "annualInflation": 0.03, "notes": "BGE or Pepco electric + Washington Gas + WSSC or City water/sewer." },
+    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Doctors Community Medical Center (Luminis Health), UM Bowie Health Center. Johns Hopkins ~30 mi north.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 125, "max": 225, "typical": 165, "annualInflation": 0.04 },
+    "petDaycare": { "min": 300, "max": 475, "typical": 385, "annualInflation": 0.035 },
+    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
+    "transportation": { "min": 280, "max": 520, "typical": 395, "annualInflation": 0.03, "notes": "MARC Penn Line at Bowie State to DC (~40 min). US Route 50 to Annapolis/DC. Capital Beltway access. Car-dependent outside rail corridor." },
+    "entertainment": { "min": 410, "max": 600, "typical": 495, "annualInflation": 0.025, "notes": "Allen Pond Park, Bowie Town Center, NASA Goddard Visitor Center nearby. Cable+1Gig typical." },
+    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
+    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 110, "max": 230, "typical": 160, "annualInflation": 0.025, "notes": "HOA common in Bowie subdivisions. ICC/Route 200 and Bay Bridge tolls. PG County taxes relatively high." },
+    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialists at Johns Hopkins (Baltimore, ~30 mi) or Univ of MD Medical Center (DC/Baltimore)." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Prince George's County brackets." },
+    "healthcarePreMedicare": { "min": 1750, "max": 2700, "typical": 2200, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince George's County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0795, "type": "combined-state-plus-county",
+      "brackets": [
+        { "min": 0, "max": 1000, "rate": 0.0520 },
+        { "min": 1000, "max": 2000, "rate": 0.0620 },
+        { "min": 2000, "max": 3000, "rate": 0.0720 },
+        { "min": 3000, "max": 100000, "rate": 0.0795 },
+        { "min": 100000, "max": 125000, "rate": 0.0820 },
+        { "min": 125000, "max": 150000, "rate": 0.0845 },
+        { "min": 150000, "max": 250000, "rate": 0.0870 },
+        { "min": 250000, "max": null, "rate": 0.0895 }
+      ],
+      "deduction": 5150,
+      "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates are combined MD state + Prince George's County piggyback (3.20% — highest county rate in MD)."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax — significant savings vs VA." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 0,
+    "ssExempt": true,
+    "notes": "MD tax benefits (SS exempt, pension exclusion, no vehicle tax) offset by PG County piggyback — highest county rate in MD (3.20%)."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 8, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Luminis Health Doctors Community Medical Center, UM Bowie Health Center, Prince George's Hospital Center. Access to Johns Hopkins (Baltimore, ~30 mi) and Univ of MD Medical Center.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2200, "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Prince George's County",
+      "notes": "Maryland Health Connection: CareFirst BlueCross, Kaiser Permanente, UnitedHealthcare. PG County rating area — similar to Anne Arundel.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Comcast/Xfinity, Verizon Fios partial)",
+    "dogFriendly": 8, "expatCommunity": 2, "englishPrevalence": 10, "safetyRating": 7,
+    "notes": "Allen Pond Park, Bowie Baysox minor league baseball, NASA Goddard Visitor Center. Planned community (William Levitt 1960s). Good schools reputation. Strong historic African-American community."
+  },
+  "pros": [
+    "~20% cheaper rent than Fairfax",
+    "Maryland tax benefits: SS exempt, pension exclusion, no vehicle personal property tax",
+    "MARC Penn Line commuter rail to DC (~40 min)",
+    "Between DC and Annapolis — central to regional amenities",
+    "Johns Hopkins + Univ of MD specialist access within 30 min",
+    "Planned community with established schools + parks"
+  ],
+  "cons": [
+    "Highest county piggyback rate in MD (3.20%) — combined state+county up to 8.95%",
+    "Car-dependent outside MARC corridor",
+    "Bay Bridge / Route 50 summer traffic",
+    "PG County has higher crime perception than Anne Arundel",
+    "Limited walkable downtown compared to Annapolis"
+  ]
+}

--- a/data/locations/us-camden-nj/location.json
+++ b/data/locations/us-camden-nj/location.json
@@ -166,6 +166,13 @@
       "max": 592,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 2009,
+      "max": 2891,
+      "typical": 2450,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Camden County, NJ). Southern NJ — Ambetter, AmeriHealth, Oscar, Horizon. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -261,7 +268,16 @@
     "qualityRating": 8,
     "waitTimes": "moderate",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2450,
+      "benchmarkSilverMonthlySingle": 1225,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Camden County",
+      "notes": "Southern NJ — Ambetter, AmeriHealth, Oscar, Horizon.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Comcast Xfinity)",

--- a/data/locations/us-catonsville-md/location.json
+++ b/data/locations/us-catonsville-md/location.json
@@ -1,0 +1,101 @@
+{
+  "id": "us-catonsville-md",
+  "name": "Catonsville MD, USA",
+  "country": "United States",
+  "region": "Maryland",
+  "cities": ["Catonsville", "Oella", "Arbutus"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 25, "summerHighF": 88, "rainyDaysPerYear": 114, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1750, "max": 2450, "typical": 2050, "type": "2-bedroom older SFH / townhome", "annualInflation": 0.035, "notes": "Baltimore County — mature tree-lined neighborhoods along Frederick Road corridor, historic Oella (mill village) to south. UMBC + Catonsville Community College keep area vibrant." },
+    "groceries": { "min": 1270, "max": 1670, "typical": 1445, "annualInflation": 0.03, "notes": "Wegmans, Giant, Harris Teeter, Trader Joe's, H Mart (Korean). Strong grocery variety for the price point." },
+    "utilities": { "min": 255, "max": 415, "typical": 330, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + Baltimore County DPW water/sewer." },
+    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. UM St. Agnes Hospital 5 min, Johns Hopkins campus 15 min, UM Medical Center (Baltimore) 15 min. Exceptional specialist density.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 125, "max": 225, "typical": 165, "annualInflation": 0.04 },
+    "petDaycare": { "min": 300, "max": 475, "typical": 385, "annualInflation": 0.035 },
+    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
+    "transportation": { "min": 275, "max": 510, "typical": 390, "annualInflation": 0.03, "notes": "MTA bus to Baltimore. Light Rail 15 min (via car). I-95/I-695 access. BWI 20 min. No direct MARC station; Penn Line at Baltimore Penn Station 15 min." },
+    "entertainment": { "min": 415, "max": 605, "typical": 500, "annualInflation": 0.025, "notes": "Walkable Frederick Road commercial strip, Patapsco Valley State Park trails, UMBC events + Fine Arts shows, Catonsville Arts District. Cable+1Gig typical." },
+    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
+    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 110, "max": 225, "typical": 160, "annualInflation": 0.025, "notes": "Fewer HOAs than newer MD suburbs. I-95 + ICC tolls. Baltimore County piggyback 3.20%." },
+    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. World-class specialist access: UM St. Agnes in town, Johns Hopkins + UM Medical Center 15 min. One of the best healthcare locations for complex retirees." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Baltimore County brackets." },
+    "healthcarePreMedicare": { "min": 1700, "max": 2600, "typical": 2100, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Baltimore County, MD). Maryland Health Connection — Baltimore metro competitive marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0795, "type": "combined-state-plus-county",
+      "brackets": [
+        { "min": 0, "max": 1000, "rate": 0.0520 },
+        { "min": 1000, "max": 2000, "rate": 0.0620 },
+        { "min": 2000, "max": 3000, "rate": 0.0720 },
+        { "min": 3000, "max": 100000, "rate": 0.0795 },
+        { "min": 100000, "max": 125000, "rate": 0.0820 },
+        { "min": 125000, "max": 150000, "rate": 0.0845 },
+        { "min": 150000, "max": 250000, "rate": 0.0870 },
+        { "min": 250000, "max": null, "rate": 0.0895 }
+      ],
+      "deduction": 5150,
+      "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Combined MD state + Baltimore County piggyback (3.20%)."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 0,
+    "ssExempt": true,
+    "notes": "MD tax benefits (SS exempt, pension exclusion, no vehicle tax). Baltimore County piggyback 3.20%."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Outstanding healthcare density: UM St. Agnes Hospital in town (5 min), Johns Hopkins Bayview + Hopkins main campus 15-20 min, UM Medical Center (Baltimore) 15 min, GBMC 20 min. Excellent for complex retiree medical needs.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2100, "benchmarkSilverMonthlySingle": 1050,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Baltimore County",
+      "notes": "Maryland Health Connection — Baltimore County rating area (competitive metro marketplace).",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Comcast/Xfinity)",
+    "dogFriendly": 9, "expatCommunity": 4, "englishPrevalence": 10, "safetyRating": 8,
+    "notes": "Walkable Frederick Road commercial district with local restaurants, breweries, and the historic Catonsville Lumber. Patapsco Valley State Park trails literally in town. UMBC campus cultural events. Strong schools and mature tree-lined neighborhoods. Historic Oella mill village walkable from downtown."
+  },
+  "pros": [
+    "~$2,500/mo cheaper than Fairfax while keeping walkable-town character",
+    "MD tax benefits: SS exempt, pension exclusion, no vehicle property tax",
+    "World-class healthcare (St. Agnes in town, Johns Hopkins + UM 15 min)",
+    "Walkable Frederick Road commercial strip — real pedestrian life",
+    "Patapsco Valley State Park trails in town",
+    "UMBC campus = cultural events, continuing education, Fine Arts",
+    "Mature tree-lined neighborhoods, less strip-mall feel than outer MD suburbs",
+    "Diverse community"
+  ],
+  "cons": [
+    "Baltimore County piggyback 3.20% — tied for highest in MD",
+    "No direct MARC station (15 min to Penn Station)",
+    "~55 mi from Fairfax — longer drive than Bowie",
+    "Not on the water (unlike Annapolis)",
+    "Some older housing requires maintenance",
+    "Baltimore metro reputation concerns (though Catonsville itself is safe)"
+  ]
+}

--- a/data/locations/us-charlotte-amalie-vi/location.json
+++ b/data/locations/us-charlotte-amalie-vi/location.json
@@ -141,6 +141,13 @@
       "max": 850,
       "annualInflation": 0.055,
       "notes": "Specialist travel to Puerto Rico or mainland common."
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (St Thomas, VI). USVI BCBS — no federal ACA marketplace, no subsidies. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -148,7 +155,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Moderate to long; specialists limited",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "St Thomas",
+      "notes": "USVI BCBS — no federal ACA marketplace, no subsidies.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 1Gbps (Viya)",

--- a/data/locations/us-cherry-hill/location.json
+++ b/data/locations/us-cherry-hill/location.json
@@ -180,6 +180,13 @@
       "max": 592,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 2009,
+      "max": 2891,
+      "typical": 2450,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Camden County, NJ). Southern NJ — same rating area as Camden. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -275,7 +282,16 @@
     "qualityRating": 9,
     "waitTimes": "low-moderate",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2450,
+      "benchmarkSilverMonthlySingle": 1225,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Camden County",
+      "notes": "Southern NJ — same rating area as Camden.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps+ available (Verizon Fios/Comcast)",

--- a/data/locations/us-chesapeake-va/location.json
+++ b/data/locations/us-chesapeake-va/location.json
@@ -154,6 +154,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Chesapeake City, VA). Hampton Roads — Sentara dominant, Optima Health available. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -246,7 +253,16 @@
     "waitTimes": "Short to moderate",
     "dentalIncluded": false,
     "prescriptionCoverage": "Via insurance plan",
-    "notes": "Chesapeake Regional Medical Center (310 beds, Level III trauma). Sentara hospitals in Norfolk/Virginia Beach within 20 minutes. Naval Medical Center Portsmouth nearby for eligible veterans."
+    "notes": "Chesapeake Regional Medical Center (310 beds, Level III trauma). Sentara hospitals in Norfolk/Virginia Beach within 20 minutes. Naval Medical Center Portsmouth nearby for eligible veterans.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Chesapeake City",
+      "notes": "Hampton Roads — Sentara dominant, Optima Health available.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Cox, Verizon Fios)",

--- a/data/locations/us-chicago-il/location.json
+++ b/data/locations/us-chicago-il/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Cook County, IL). Chicago metro — Blue Cross IL dominant, Ambetter + Oscar compete. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Cook County",
+      "notes": "Chicago metro — Blue Cross IL dominant, Ambetter + Oscar compete.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-christiansted-vi/location.json
+++ b/data/locations/us-christiansted-vi/location.json
@@ -137,6 +137,13 @@
       "max": 780,
       "annualInflation": 0.055,
       "notes": "Specialist care often requires travel to STT, PR, or mainland."
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (St Croix, VI). USVI BCBS — no federal ACA marketplace, no subsidies. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -144,7 +151,16 @@
     "qualityRating": 4,
     "dentalIncluded": false,
     "waitTimes": "Long for specialists; common to fly out",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "St Croix",
+      "notes": "USVI BCBS — no federal ACA marketplace, no subsidies.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 1Gbps (Viya)",

--- a/data/locations/us-cleveland-oh/location.json
+++ b/data/locations/us-cleveland-oh/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Cuyahoga County, OH). Cleveland metro — Medical Mutual, Anthem, CareSource. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Cuyahoga County",
+      "notes": "Cleveland metro — Medical Mutual, Anthem, CareSource.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-dallas-tx/location.json
+++ b/data/locations/us-dallas-tx/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Dallas County, TX). DFW — highly competitive marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Dallas County",
+      "notes": "DFW — highly competitive marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-dededo-gu/location.json
+++ b/data/locations/us-dededo-gu/location.json
@@ -136,6 +136,13 @@
       "min": 260,
       "max": 720,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1804,
+      "max": 2596,
+      "typical": 2200,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Guam, GU). Guam — TakeCare, NetCare local plans. No ACA marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -143,7 +150,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Moderate to long for specialists",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2200,
+      "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "Guam",
+      "notes": "Guam — TakeCare, NetCare local plans. No ACA marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 1Gbps (GTA, IT&E)",

--- a/data/locations/us-denver-co/location.json
+++ b/data/locations/us-denver-co/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1722,
+      "max": 2478,
+      "typical": 2100,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Denver County, CO). Connect for Health CO — reinsurance reduces premiums 20%+. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2100,
+      "benchmarkSilverMonthlySingle": 1050,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Denver County",
+      "notes": "Connect for Health CO — reinsurance reduces premiums 20%+.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-elkridge-md/location.json
+++ b/data/locations/us-elkridge-md/location.json
@@ -1,0 +1,99 @@
+{
+  "id": "us-elkridge-md",
+  "name": "Elkridge MD, USA",
+  "country": "United States",
+  "region": "Maryland",
+  "cities": ["Elkridge", "Jessup", "Savage"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 25, "summerHighF": 88, "rainyDaysPerYear": 114, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1900, "max": 2700, "typical": 2250, "type": "2-bedroom townhome / SFH", "annualInflation": 0.035, "notes": "Howard County — affluent commuter suburb between DC and Baltimore. Cheaper than Columbia/Ellicott City but premium for MD. Newer townhome developments along US-1 corridor." },
+    "groceries": { "min": 1300, "max": 1680, "typical": 1480, "annualInflation": 0.03, "notes": "Wegmans, Giant, Whole Foods, Harris Teeter. Slightly above Baltimore but similar to Annapolis." },
+    "utilities": { "min": 265, "max": 425, "typical": 340, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + Howard County DPW water/sewer." },
+    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Howard County General Hospital (Johns Hopkins affiliate), UM Baltimore Washington Medical Center 15 min. Direct Johns Hopkins access 20 min.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 130, "max": 230, "typical": 170, "annualInflation": 0.04 },
+    "petDaycare": { "min": 310, "max": 490, "typical": 395, "annualInflation": 0.035 },
+    "petGrooming": { "min": 85, "max": 160, "typical": 120, "annualInflation": 0.03 },
+    "transportation": { "min": 290, "max": 540, "typical": 410, "annualInflation": 0.03, "notes": "MARC Camden Line at Dorsey/Savage stations to DC Union Station (~45 min). I-95 corridor. BWI Airport 10 min. Capital Beltway access." },
+    "entertainment": { "min": 420, "max": 615, "typical": 505, "annualInflation": 0.025, "notes": "Patapsco Valley State Park, Arundel Mills shopping, Blob's Park. Cable+1Gig typical (Comcast/Xfinity, Verizon Fios)." },
+    "clothing": { "min": 95, "max": 235, "typical": 155, "annualInflation": 0.02 },
+    "personalCare": { "min": 45, "max": 108, "typical": 70, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 115, "max": 235, "typical": 165, "annualInflation": 0.025, "notes": "HOA common in townhome communities. I-95 + ICC tolls. Howard County piggyback 3.20%." },
+    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Excellent specialist access: Johns Hopkins (20 min), Howard County General (Hopkins affiliate), UM BWMC." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Howard County brackets." },
+    "healthcarePreMedicare": { "min": 1750, "max": 2700, "typical": 2200, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Howard County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0795, "type": "combined-state-plus-county",
+      "brackets": [
+        { "min": 0, "max": 1000, "rate": 0.0520 },
+        { "min": 1000, "max": 2000, "rate": 0.0620 },
+        { "min": 2000, "max": 3000, "rate": 0.0720 },
+        { "min": 3000, "max": 100000, "rate": 0.0795 },
+        { "min": 100000, "max": 125000, "rate": 0.0820 },
+        { "min": 125000, "max": 150000, "rate": 0.0845 },
+        { "min": 150000, "max": 250000, "rate": 0.0870 },
+        { "min": 250000, "max": null, "rate": 0.0895 }
+      ],
+      "deduction": 5150,
+      "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Combined MD state + Howard County piggyback (3.20% — tied for highest in MD)."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 0,
+    "ssExempt": true,
+    "notes": "MD tax benefits (SS exempt, pension exclusion, no vehicle tax). Howard County piggyback 3.20% tied for highest in MD."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Exceptional healthcare access: Howard County General (Johns Hopkins affiliate), UM Baltimore Washington Medical Center, full Johns Hopkins system 20 min. One of best healthcare-access locations in the region.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2200, "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Howard County",
+      "notes": "Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Howard County rating area — competitive marketplace.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Comcast/Xfinity, Verizon Fios)",
+    "dogFriendly": 8, "expatCommunity": 3, "englishPrevalence": 10, "safetyRating": 9,
+    "notes": "Patapsco Valley State Park trails, Arundel Mills mega-mall, Live! Casino. Strong Howard County schools reputation. Diverse demographics. BWI Airport 10 min."
+  },
+  "pros": [
+    "~20% cheaper rent than Fairfax",
+    "MD tax benefits: SS exempt, pension exclusion, no vehicle personal property tax",
+    "Exceptional healthcare access (Johns Hopkins + UM within 20 min)",
+    "MARC Camden Line to DC (~45 min)",
+    "BWI Airport 10 min — easy regional + international flights",
+    "Howard County schools + safety reputation",
+    "Central between DC + Baltimore — access to both metros"
+  ],
+  "cons": [
+    "Howard County piggyback 3.20% — tied for highest in MD",
+    "I-95 traffic can be brutal; Capital Beltway worse",
+    "Affluent area — premium pricing on services",
+    "Limited walkable core (car-dependent outside MARC corridor)",
+    "~40 mi from Fairfax — further than closer VA alternatives"
+  ]
+}

--- a/data/locations/us-florida/location.json
+++ b/data/locations/us-florida/location.json
@@ -175,6 +175,13 @@
       "max": 418,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (statewide, FL). Statewide average; varies by county from ~$2,300 (Miami) to $2,500 (rural panhandle). Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -245,7 +252,16 @@
     "qualityRating": 8,
     "waitTimes": "varies",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "statewide",
+      "notes": "Statewide average; varies by county from ~$2,300 (Miami) to $2,500 (rural panhandle).",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available in metro areas",

--- a/data/locations/us-fort-lauderdale-fl/location.json
+++ b/data/locations/us-fort-lauderdale-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Broward County, FL). Broward — Ambetter, Florida Blue, Molina compete. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Broward County",
+      "notes": "Broward — Ambetter, Florida Blue, Molina compete.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-fort-wayne-in/location.json
+++ b/data/locations/us-fort-wayne-in/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2091,
+      "max": 3009,
+      "typical": 2550,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Allen County, IN). NE Indiana — Anthem dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2550,
+      "benchmarkSilverMonthlySingle": 1275,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Allen County",
+      "notes": "NE Indiana — Anthem dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-fort-worth-tx/location.json
+++ b/data/locations/us-fort-worth-tx/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Tarrant County, TX). DFW — same rating area as Dallas. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Tarrant County",
+      "notes": "DFW — same rating area as Dallas.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-gainesville-va/location.json
+++ b/data/locations/us-gainesville-va/location.json
@@ -3,7 +3,11 @@
   "name": "Gainesville VA, USA",
   "country": "United States",
   "region": "Virginia",
-  "cities": ["Gainesville", "Haymarket", "Bristow"],
+  "cities": [
+    "Gainesville",
+    "Haymarket",
+    "Bristow"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
   "visa": {
@@ -48,11 +52,11 @@
       "notes": "Same Medicare Part B + Medigap baseline as Fairfax. Novant UVA Health in Haymarket; Inova in Manassas."
     },
     "healthcarePreMedicare": {
-      "min": 1800,
-      "max": 2800,
+      "min": 1845,
+      "max": 2655,
       "typical": 2250,
       "annualInflation": 0.06,
-      "notes": "ACA silver plan benchmark for 2-adult household, both 55-64, before subsidies. PWC marketplace 2025 — slightly cheaper than Fairfax due to competition."
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince William County, VA). PWC marketplace — similar to Fairfax with slightly more competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     },
     "insurance": {
       "min": 30,
@@ -145,13 +149,41 @@
     "federalIncomeTax": {
       "applies": true,
       "brackets": [
-        { "min": 0,      "max": 23850,  "rate": 0.10 },
-        { "min": 23850,  "max": 96950,  "rate": 0.12 },
-        { "min": 96950,  "max": 206700, "rate": 0.22 },
-        { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 },
-        { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null,   "rate": 0.37 }
+        {
+          "min": 0,
+          "max": 23850,
+          "rate": 0.1
+        },
+        {
+          "min": 23850,
+          "max": 96950,
+          "rate": 0.12
+        },
+        {
+          "min": 96950,
+          "max": 206700,
+          "rate": 0.22
+        },
+        {
+          "min": 206700,
+          "max": 394600,
+          "rate": 0.24
+        },
+        {
+          "min": 394600,
+          "max": 501050,
+          "rate": 0.32
+        },
+        {
+          "min": 501050,
+          "max": 751600,
+          "rate": 0.35
+        },
+        {
+          "min": 751600,
+          "max": null,
+          "rate": 0.37
+        }
       ],
       "standardDeduction": 30000
     },
@@ -159,10 +191,26 @@
       "rate": 0.0575,
       "type": "top-marginal",
       "brackets": [
-        { "min": 0,     "max": 3000,  "rate": 0.02 },
-        { "min": 3000,  "max": 5000,  "rate": 0.03 },
-        { "min": 5000,  "max": 17000, "rate": 0.05 },
-        { "min": 17000, "max": null,  "rate": 0.0575 }
+        {
+          "min": 0,
+          "max": 3000,
+          "rate": 0.02
+        },
+        {
+          "min": 3000,
+          "max": 5000,
+          "rate": 0.03
+        },
+        {
+          "min": 5000,
+          "max": 17000,
+          "rate": 0.05
+        },
+        {
+          "min": 17000,
+          "max": null,
+          "rate": 0.0575
+        }
       ],
       "deduction": 24000,
       "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
@@ -191,8 +239,11 @@
     "acaMarketplace": {
       "benchmarkSilverMonthly2Adult": 2250,
       "benchmarkSilverMonthlySingle": 1125,
-      "notes": "Anthem, CareFirst, Kaiser Permanente in Prince William. Slightly lower sticker than Fairfax.",
-      "premiumCapPctOfIncome": 0.085
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Prince William County",
+      "notes": "PWC marketplace — similar to Fairfax with slightly more competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {

--- a/data/locations/us-glen-burnie-md/location.json
+++ b/data/locations/us-glen-burnie-md/location.json
@@ -1,0 +1,100 @@
+{
+  "id": "us-glen-burnie-md",
+  "name": "Glen Burnie MD, USA",
+  "country": "United States",
+  "region": "Maryland",
+  "cities": ["Glen Burnie", "Ferndale", "Brooklyn Park", "Linthicum"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 26, "summerHighF": 88, "rainyDaysPerYear": 113, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1600, "max": 2250, "typical": 1900, "type": "2-bedroom townhome / older SFH", "annualInflation": 0.035, "notes": "Anne Arundel County — older working-class suburb, established neighborhoods. Among cheapest viable rent in MD metro area. BWI airport + Glen Burnie Town Center shopping." },
+    "groceries": { "min": 1230, "max": 1620, "typical": 1410, "annualInflation": 0.03, "notes": "Giant, Safeway, Weis. Budget-friendly; Aldi + Lidl nearby for further savings." },
+    "utilities": { "min": 250, "max": 410, "typical": 320, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + AACO water/sewer." },
+    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. UM Baltimore Washington Medical Center in town — major regional hospital with Level II trauma, heart, cancer centers. Johns Hopkins 20 min.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 120, "max": 215, "typical": 160, "annualInflation": 0.04 },
+    "petDaycare": { "min": 295, "max": 465, "typical": 375, "annualInflation": 0.035 },
+    "petGrooming": { "min": 80, "max": 150, "typical": 115, "annualInflation": 0.03 },
+    "transportation": { "min": 270, "max": 500, "typical": 380, "annualInflation": 0.03, "notes": "Light RailLink from Glen Burnie to downtown Baltimore (~30 min). BWI Airport 5 min. I-97 to Annapolis, I-295 to DC. MARC Penn Line at BWI Rail Station." },
+    "entertainment": { "min": 390, "max": 580, "typical": 475, "annualInflation": 0.025, "notes": "Glen Burnie Town Center, Arundel Mills (10 min), Marley Creek trails. Cable+1Gig typical (Comcast)." },
+    "clothing": { "min": 90, "max": 220, "typical": 145, "annualInflation": 0.02 },
+    "personalCare": { "min": 40, "max": 100, "typical": 65, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 100, "max": 215, "typical": 150, "annualInflation": 0.025, "notes": "HOA in some developments. I-95 + ICC tolls. Fewer HOA communities than newer MD suburbs." },
+    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Excellent specialist access: UM BWMC in town, Johns Hopkins 20 min, UM Medical Center (Baltimore) 15 min." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Anne Arundel County brackets." },
+    "healthcarePreMedicare": { "min": 1700, "max": 2650, "typical": 2150, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Anne Arundel County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.078, "type": "combined-state-plus-county",
+      "brackets": [
+        { "min": 0, "max": 1000, "rate": 0.0481 },
+        { "min": 1000, "max": 2000, "rate": 0.0581 },
+        { "min": 2000, "max": 3000, "rate": 0.0681 },
+        { "min": 3000, "max": 100000, "rate": 0.0756 },
+        { "min": 100000, "max": 125000, "rate": 0.0781 },
+        { "min": 125000, "max": 150000, "rate": 0.0806 },
+        { "min": 150000, "max": 250000, "rate": 0.0831 },
+        { "min": 250000, "max": null, "rate": 0.0856 }
+      ],
+      "deduction": 5150,
+      "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates are combined state + Anne Arundel County piggyback (2.81% — lower than Baltimore/Howard/PG counties at 3.20%)."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 0,
+    "ssExempt": true,
+    "notes": "MD tax benefits (SS exempt, pension exclusion, no vehicle tax). Anne Arundel piggyback 2.81% — saves ~0.4% MAGI vs Baltimore-area counties."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Exceptional healthcare value: UM Baltimore Washington Medical Center in town (Level II trauma, 370 beds, heart/cancer/orthopedic centers), Johns Hopkins 20 min, UM Medical Center (Baltimore) 15 min. World-class care at suburban prices.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2150, "benchmarkSilverMonthlySingle": 1075,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Anne Arundel County",
+      "notes": "Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Anne Arundel rating area.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Comcast/Xfinity)",
+    "dogFriendly": 8, "expatCommunity": 4, "englishPrevalence": 10, "safetyRating": 7,
+    "notes": "BWI Airport 5 min — travel convenience. Light Rail to Baltimore downtown. Older established working-class to middle-class suburb. Diverse demographics. Quiet residential pockets between commercial corridors."
+  },
+  "pros": [
+    "Cheapest viable MD retirement area near Baltimore/Annapolis metros",
+    "Anne Arundel County piggyback 2.81% — saves ~$300–420/yr tax vs 3.20% counties",
+    "UM Baltimore Washington Medical Center IN TOWN — major regional hospital",
+    "BWI Airport 5 min — outstanding travel convenience",
+    "Light RailLink to Baltimore downtown (~30 min)",
+    "MD tax benefits: SS exempt, pension exclusion, no vehicle tax",
+    "No bay-bridge premium (unlike Annapolis)"
+  ],
+  "cons": [
+    "Working-class suburb — less charm than Annapolis or Catonsville",
+    "Car-dependent outside Light Rail corridor",
+    "I-97 + Route 2 traffic during commute hours",
+    "Airport noise near BWI flight paths",
+    "~45 mi from Fairfax — longer drive than Bowie or Annapolis",
+    "Limited walkable downtown core"
+  ]
+}

--- a/data/locations/us-grand-forks-nd/location.json
+++ b/data/locations/us-grand-forks-nd/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2214,
+      "max": 3186,
+      "typical": 2700,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Grand Forks County, ND). BCBS ND dominant — limited insurer competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2700,
+      "benchmarkSilverMonthlySingle": 1350,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Grand Forks County",
+      "notes": "BCBS ND dominant — limited insurer competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-hagatna-gu/location.json
+++ b/data/locations/us-hagatna-gu/location.json
@@ -140,6 +140,13 @@
       "max": 740,
       "annualInflation": 0.055,
       "notes": "Specialist medevac to Hawaii or Philippines common."
+    },
+    "healthcarePreMedicare": {
+      "min": 1804,
+      "max": 2596,
+      "typical": 2200,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Guam, GU). Guam local private plans. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -147,7 +154,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Moderate to long for specialists",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2200,
+      "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "Guam",
+      "notes": "Guam local private plans.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 1Gbps (GTA, IT&E)",

--- a/data/locations/us-killeen-tx/location.json
+++ b/data/locations/us-killeen-tx/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Bell County, TX). Central TX — moderate competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Bell County",
+      "notes": "Central TX — moderate competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-lapeer-mi/location.json
+++ b/data/locations/us-lapeer-mi/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Lapeer County, MI). Thumb of MI — BCBSM dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Lapeer County",
+      "notes": "Thumb of MI — BCBSM dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-little-rock-ar/location.json
+++ b/data/locations/us-little-rock-ar/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2050,
+      "max": 2950,
+      "typical": 2500,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Pulaski County, AR). Arkansas — single-insurer-dominant in many counties. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2500,
+      "benchmarkSilverMonthlySingle": 1250,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Pulaski County",
+      "notes": "Arkansas — single-insurer-dominant in many counties.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-lorain-oh/location.json
+++ b/data/locations/us-lorain-oh/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Lorain County, OH). NE Ohio — similar to Cleveland rating area. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Lorain County",
+      "notes": "NE Ohio — similar to Cleveland rating area.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-lorton-va/location.json
+++ b/data/locations/us-lorton-va/location.json
@@ -1,0 +1,90 @@
+{
+  "id": "us-lorton-va",
+  "name": "Lorton VA, USA",
+  "country": "United States",
+  "region": "Virginia",
+  "cities": ["Lorton", "Fort Belvoir"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 25, "summerHighF": 89, "rainyDaysPerYear": 110, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1900, "max": 2650, "typical": 2200, "type": "2-bedroom newer townhome/SFH", "annualInflation": 0.035, "notes": "Newer townhome developments (Laurel Hill, Lorton Station). Southern Fairfax County." },
+    "groceries": { "min": 1300, "max": 1700, "typical": 1490, "annualInflation": 0.03, "notes": "Wegmans, Giant, Harris Teeter. Similar to Fairfax pricing." },
+    "utilities": { "min": 260, "max": 420, "typical": 330, "annualInflation": 0.03 },
+    "healthcare": { "min": 550, "max": 850, "typical": 650, "notes": "Fairfax County Medicare baseline. Inova Mt Vernon 10 min, Inova Fairfax 20 min.", "annualInflation": 0.055 },
+    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 120, "max": 220, "typical": 170, "annualInflation": 0.04 },
+    "petDaycare": { "min": 310, "max": 490, "typical": 395, "annualInflation": 0.035 },
+    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
+    "transportation": { "min": 300, "max": 550, "typical": 420, "annualInflation": 0.03, "notes": "Lorton VRE station (Fredericksburg line) to DC. I-95 + Fairfax County Pkwy access. Longer DC commute than Fairfax City." },
+    "entertainment": { "min": 400, "max": 590, "typical": 480, "annualInflation": 0.025, "notes": "Workhouse Arts Center (former prison), Occoquan Regional Park. Cable+1Gig." },
+    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
+    "personalCare": { "min": 42, "max": 100, "typical": 65, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 110, "max": 230, "typical": 160, "annualInflation": 0.025, "notes": "HOA common in Laurel Hill subdivisions. I-95 Express Lanes tolls." },
+    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialists at Inova Fairfax + Johns Hopkins." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets." },
+    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2300, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0575, "type": "top-marginal",
+      "brackets": [
+        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
+        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+      ],
+      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Fairfax County 6%" },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Fairfax County vehicle tax ~$4.57/$100." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 1200,
+    "ssExempt": true,
+    "notes": "Same Fairfax County tax as Fairfax City."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 8, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Inova Mount Vernon Hospital 10 min (community hospital), Inova Fairfax 20 min for specialty.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300, "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Fairfax County",
+      "notes": "NOVA marketplace same as Fairfax.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Verizon Fios, Cox, Xfinity)",
+    "dogFriendly": 9, "expatCommunity": 3, "englishPrevalence": 10, "safetyRating": 8,
+    "notes": "Occoquan River access, Workhouse Arts Center, Laurel Hill Golf Club. Quieter than inner NOVA; suburban family feel."
+  },
+  "pros": [
+    "~23% cheaper rent than Fairfax City",
+    "Same Fairfax County tax benefits (SS exempt, 65+ deduction)",
+    "Newer housing stock than Annandale",
+    "VRE commuter rail to DC available",
+    "Waterfront + golf + arts amenities",
+    "Quieter suburban environment"
+  ],
+  "cons": [
+    "Longer DC commute (I-95 or VRE)",
+    "Fewer dining/shopping options than Fairfax City",
+    "Some neighborhoods have heavy HOAs",
+    "Limited public transit beyond VRE"
+  ]
+}

--- a/data/locations/us-lynchburg-va/location.json
+++ b/data/locations/us-lynchburg-va/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Lynchburg City, VA). Central VA — limited insurer competition vs NOVA. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Lynchburg City",
+      "notes": "Central VA — limited insurer competition vs NOVA.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-manassas-va/location.json
+++ b/data/locations/us-manassas-va/location.json
@@ -1,0 +1,90 @@
+{
+  "id": "us-manassas-va",
+  "name": "Manassas VA, USA",
+  "country": "United States",
+  "region": "Virginia",
+  "cities": ["Manassas", "Manassas Park"],
+  "currency": "USD",
+  "exchangeRate": 1,
+  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
+  "climate": { "winterLowF": 23, "summerHighF": 89, "rainyDaysPerYear": 108, "meetsWarmWinterReq": false },
+  "monthlyCosts": {
+    "rent": { "min": 1700, "max": 2400, "typical": 1950, "type": "2-bedroom townhome/older SFH", "annualInflation": 0.035, "notes": "Independent city + Prince William County surround. Historic downtown. ~32% cheaper than Fairfax." },
+    "groceries": { "min": 1250, "max": 1650, "typical": 1430, "annualInflation": 0.03, "notes": "Giant, Wegmans, Harris Teeter. ~10% below Fairfax averages." },
+    "utilities": { "min": 240, "max": 400, "typical": 315, "annualInflation": 0.03, "notes": "NOVEC electric + Washington Gas + City of Manassas water/sewer." },
+    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Novant UVA Health System Prince William (Haymarket) 10 min, Sentara Northern Virginia Medical Center in Manassas.", "annualInflation": 0.055 },
+    "insurance": { "min": 30, "max": 50, "typical": 40, "type": "renter's insurance", "annualInflation": 0.03 },
+    "petCare": { "min": 110, "max": 205, "typical": 155, "annualInflation": 0.04 },
+    "petDaycare": { "min": 290, "max": 460, "typical": 370, "annualInflation": 0.035 },
+    "petGrooming": { "min": 80, "max": 145, "typical": 110, "annualInflation": 0.03 },
+    "transportation": { "min": 320, "max": 580, "typical": 450, "annualInflation": 0.03, "notes": "VRE Manassas line to DC (~60 min). I-66 to DC ~1hr in traffic. Higher fuel use than inner NOVA." },
+    "entertainment": { "min": 370, "max": 560, "typical": 450, "annualInflation": 0.025, "notes": "Manassas National Battlefield Park, historic downtown. Cable+1Gig typical." },
+    "clothing": { "min": 90, "max": 215, "typical": 140, "annualInflation": 0.02 },
+    "personalCare": { "min": 40, "max": 95, "typical": 60, "annualInflation": 0.02 },
+    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
+    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
+    "miscellaneous": { "min": 100, "max": 215, "typical": 150, "annualInflation": 0.025, "notes": "HOA in subdivisions, I-66 Express Lanes tolls, PWC vehicle decal." },
+    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
+    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialty care may require trip to Fairfax/DC." },
+    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
+    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets." },
+    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2250, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince William County, VA). PWC marketplace — slightly cheaper than Fairfax. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+  },
+  "taxes": {
+    "federalIncomeTax": {
+      "applies": true,
+      "brackets": [
+        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
+        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
+        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
+        { "min": 751600, "max": null, "rate": 0.37 }
+      ],
+      "standardDeduction": 30000
+    },
+    "stateIncomeTax": {
+      "rate": 0.0575, "type": "top-marginal",
+      "brackets": [
+        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
+        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+      ],
+      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+    },
+    "salesTax": { "rate": 0.06, "notes": "Prince William County / City of Manassas 6% (4.3% state + 0.7% regional + 1% NOVA transit)" },
+    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. PWC vehicle personal property ~$3.70/$100 assessed — slightly below Fairfax." },
+    "socialCharges": null,
+    "vatRate": 0,
+    "estVehicleTax": 1100,
+    "ssExempt": true,
+    "notes": "VA tax treatment same as Fairfax; lower PWC property tax rate."
+  },
+  "healthcare": {
+    "system": "Medicare (at 65) + private supplement",
+    "qualityRating": 7, "waitTimes": "moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "notes": "Novant UVA Health Prince William (Haymarket) + Sentara NOVA Medical Center. Inova Fair Oaks ~25 min for specialty.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250, "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085, "rateArea": "Prince William County",
+      "notes": "PWC marketplace — similar to Fairfax with slightly more competition.",
+      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
+  },
+  "lifestyle": {
+    "internetSpeed": "1Gbps widely available (Verizon Fios, Comcast)",
+    "dogFriendly": 8, "expatCommunity": 4, "englishPrevalence": 9, "safetyRating": 7,
+    "notes": "Manassas National Battlefield Park, historic Old Town Manassas, Bull Run Mountains. Strong Latino community. Quieter suburban/small-city feel."
+  },
+  "pros": [
+    "~32% cheaper rent than Fairfax — biggest price drop within 30 miles",
+    "Same VA tax treatment (SS exempt, 65+ deduction)",
+    "Lower PWC vehicle tax rate",
+    "VRE Manassas line to DC",
+    "Historic Old Town Manassas walkable downtown",
+    "Novant UVA Health + Sentara hospitals in town"
+  ],
+  "cons": [
+    "Longest commute to Fairfax/DC (~45–60 min)",
+    "Fewer dining/cultural options than inner NOVA",
+    "Specialty healthcare may require Fairfax/DC trip",
+    "I-66 + VRE traffic/crowding at peak"
+  ]
+}

--- a/data/locations/us-miami-fl/location.json
+++ b/data/locations/us-miami-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Miami-Dade County, FL). Miami-Dade — most competitive FL marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Miami-Dade County",
+      "notes": "Miami-Dade — most competitive FL marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-milwaukee-wi/location.json
+++ b/data/locations/us-milwaukee-wi/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2050,
+      "max": 2950,
+      "typical": 2500,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Milwaukee County, WI). Milwaukee metro — Anthem, Quartz, Dean Health. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2500,
+      "benchmarkSilverMonthlySingle": 1250,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Milwaukee County",
+      "notes": "Milwaukee metro — Anthem, Quartz, Dean Health.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-minneapolis-mn/location.json
+++ b/data/locations/us-minneapolis-mn/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Hennepin County, MN). MNsure — Twin Cities most competitive in MN. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Hennepin County",
+      "notes": "MNsure — Twin Cities most competitive in MN.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-nashville-tn/location.json
+++ b/data/locations/us-nashville-tn/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Davidson County, TN). Nashville metro — Ambetter, BlueCross TN compete. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Davidson County",
+      "notes": "Nashville metro — Ambetter, BlueCross TN compete.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-new-york-city/location.json
+++ b/data/locations/us-new-york-city/location.json
@@ -182,6 +182,13 @@
       "max": 749,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1722,
+      "max": 2478,
+      "typical": 2100,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (NYC metro, NY). NY State of Health — Essential Plan covers low/mid income separately. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -316,7 +323,16 @@
     "waitTimes": "low",
     "dentalIncluded": false,
     "prescriptionCoverage": "Part D plan",
-    "notes": "World-class healthcare: NYU Langone, Mount Sinai, NewYork-Presbyterian, Memorial Sloan Kettering. EPIC program helps NY seniors with drug costs. Excellent specialist access."
+    "notes": "World-class healthcare: NYU Langone, Mount Sinai, NewYork-Presbyterian, Memorial Sloan Kettering. EPIC program helps NY seniors with drug costs. Excellent specialist access.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2100,
+      "benchmarkSilverMonthlySingle": 1050,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "NYC metro",
+      "notes": "NY State of Health — Essential Plan covers low/mid income separately.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps+ widely available (Verizon Fios, Spectrum)",

--- a/data/locations/us-norfolk-va/location.json
+++ b/data/locations/us-norfolk-va/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Norfolk City, VA). Hampton Roads marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Norfolk City",
+      "notes": "Hampton Roads marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-oakland-county-mi/location.json
+++ b/data/locations/us-oakland-county-mi/location.json
@@ -137,6 +137,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Oakland County, MI). Metro Detroit — BCBSM + Priority Health + Molina. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -144,7 +151,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Oakland County",
+      "notes": "Metro Detroit — BCBSM + Priority Health + Molina.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-pago-pago-as/location.json
+++ b/data/locations/us-pago-pago-as/location.json
@@ -142,6 +142,13 @@
       "max": 880,
       "annualInflation": 0.055,
       "notes": "Specialist care routinely requires travel to Honolulu (5.5h flight)."
+    },
+    "healthcarePreMedicare": {
+      "min": 1640,
+      "max": 2360,
+      "typical": 2000,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (American Samoa, AS). LBJ Tropical Medical Center. Very limited private coverage. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -149,7 +156,16 @@
     "qualityRating": 3,
     "dentalIncluded": false,
     "waitTimes": "Long; medevac to Honolulu common for complex cases",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2000,
+      "benchmarkSilverMonthlySingle": 1000,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "American Samoa",
+      "notes": "LBJ Tropical Medical Center. Very limited private coverage.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 100Mbps (ASTCA, BlueSky); fiber growing",

--- a/data/locations/us-palm-bay-fl/location.json
+++ b/data/locations/us-palm-bay-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Brevard County, FL). Space Coast — moderate competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Brevard County",
+      "notes": "Space Coast — moderate competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-philadelphia/location.json
+++ b/data/locations/us-philadelphia/location.json
@@ -176,6 +176,13 @@
       "max": 418,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Philadelphia County, PA). Pennie — Philadelphia metro most competitive in PA. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -252,7 +259,16 @@
     "qualityRating": 9,
     "waitTimes": "low-moderate",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Philadelphia County",
+      "notes": "Pennie — Philadelphia metro most competitive in PA.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps+ available (Verizon Fios/Comcast)",

--- a/data/locations/us-pittsburgh-pa/location.json
+++ b/data/locations/us-pittsburgh-pa/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Allegheny County, PA). Pennie — Pittsburgh metro, Highmark + UPMC. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Allegheny County",
+      "notes": "Pennie — Pittsburgh metro, Highmark + UPMC.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-ponce-pr/location.json
+++ b/data/locations/us-ponce-pr/location.json
@@ -134,6 +134,13 @@
       "min": 200,
       "max": 580,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1312,
+      "max": 1888,
+      "typical": 1600,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Ponce, PR). Mi Salud (PR state-run). Lower costs than mainland. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Moderate; specialists may require travel to San Juan",
-    "prescriptionCoverage": "Medicare Part D or private plan"
+    "prescriptionCoverage": "Medicare Part D or private plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 1600,
+      "benchmarkSilverMonthlySingle": 800,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "Ponce",
+      "notes": "Mi Salud (PR state-run). Lower costs than mainland.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Liberty, Claro)",

--- a/data/locations/us-port-huron-mi/location.json
+++ b/data/locations/us-port-huron-mi/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2009,
+      "max": 2891,
+      "typical": 2450,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (St Clair County, MI). Eastern MI — BCBSM dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2450,
+      "benchmarkSilverMonthlySingle": 1225,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "St Clair County",
+      "notes": "Eastern MI — BCBSM dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-portsmouth-va/location.json
+++ b/data/locations/us-portsmouth-va/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Portsmouth City, VA). Hampton Roads marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Portsmouth City",
+      "notes": "Hampton Roads marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-quincy-fl/location.json
+++ b/data/locations/us-quincy-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2050,
+      "max": 2950,
+      "typical": 2500,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Gadsden County, FL). North FL panhandle — limited competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2500,
+      "benchmarkSilverMonthlySingle": 1250,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Gadsden County",
+      "notes": "North FL panhandle — limited competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-raleigh/location.json
+++ b/data/locations/us-raleigh/location.json
@@ -179,6 +179,13 @@
       "max": 592,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Wake County, NC). Raleigh-Durham — competitive metro marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -254,7 +261,16 @@
     "qualityRating": 9,
     "waitTimes": "varies",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Wake County",
+      "notes": "Raleigh-Durham — competitive metro marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Google Fiber/AT&T Fiber)",

--- a/data/locations/us-richmond/location.json
+++ b/data/locations/us-richmond/location.json
@@ -176,6 +176,13 @@
       "max": 592,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Henrico County, VA). Richmond metro — Anthem, Sentara compete. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -266,7 +273,16 @@
     "qualityRating": 8,
     "waitTimes": "varies",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Henrico County",
+      "notes": "Richmond metro — Anthem, Sentara compete.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps+ available (Verizon Fios/Comcast)",

--- a/data/locations/us-saint-paul-mn/location.json
+++ b/data/locations/us-saint-paul-mn/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Ramsey County, MN). Twin Cities — similar to Hennepin. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 9,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Ramsey County",
+      "notes": "Twin Cities — similar to Hennepin.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-saipan-mp/location.json
+++ b/data/locations/us-saipan-mp/location.json
@@ -141,6 +141,13 @@
       "max": 800,
       "annualInflation": 0.055,
       "notes": "Specialist travel to Guam, Hawaii, or Philippines frequent."
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Saipan, MP). Northern Marianas — limited private coverage. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -148,7 +155,16 @@
     "qualityRating": 4,
     "dentalIncluded": false,
     "waitTimes": "Long for specialists; medevac common",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "Saipan",
+      "notes": "Northern Marianas — limited private coverage.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 1Gbps (IT&E fiber)",

--- a/data/locations/us-san-juan-pr/location.json
+++ b/data/locations/us-san-juan-pr/location.json
@@ -140,6 +140,13 @@
       "min": 220,
       "max": 650,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1312,
+      "max": 1888,
+      "typical": 1600,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (San Juan, PR). Mi Salud — better infrastructure than rural PR. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -147,7 +154,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Moderate; short in private, longer in public",
-    "prescriptionCoverage": "Medicare Part D or private plan"
+    "prescriptionCoverage": "Medicare Part D or private plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 1600,
+      "benchmarkSilverMonthlySingle": 800,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "San Juan",
+      "notes": "Mi Salud — better infrastructure than rural PR.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Liberty, Claro)",

--- a/data/locations/us-san-marcos-tx/location.json
+++ b/data/locations/us-san-marcos-tx/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Hays County, TX). Austin-San Antonio corridor. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Hays County",
+      "notes": "Austin-San Antonio corridor.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-savannah/location.json
+++ b/data/locations/us-savannah/location.json
@@ -176,6 +176,13 @@
       "max": 629,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 2009,
+      "max": 2891,
+      "typical": 2450,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Chatham County, GA). Coastal GA — moderate competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -261,7 +268,16 @@
     "qualityRating": 7,
     "waitTimes": "varies",
     "dentalIncluded": false,
-    "prescriptionCoverage": "Part D plan"
+    "prescriptionCoverage": "Part D plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2450,
+      "benchmarkSilverMonthlySingle": 1225,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Chatham County",
+      "notes": "Coastal GA — moderate competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Comcast/AT&T Fiber)",

--- a/data/locations/us-skowhegan-me/location.json
+++ b/data/locations/us-skowhegan-me/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2214,
+      "max": 3186,
+      "typical": 2700,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Somerset County, ME). Rural central ME — Harvard Pilgrim, Community Health Options. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 5,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2700,
+      "benchmarkSilverMonthlySingle": 1350,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Somerset County",
+      "notes": "Rural central ME — Harvard Pilgrim, Community Health Options.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-st-augustine-fl/location.json
+++ b/data/locations/us-st-augustine-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1968,
+      "max": 2832,
+      "typical": 2400,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (St Johns County, FL). NE FL — Florida Blue dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2400,
+      "benchmarkSilverMonthlySingle": 1200,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "St Johns County",
+      "notes": "NE FL — Florida Blue dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-st-petersburg-fl/location.json
+++ b/data/locations/us-st-petersburg-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1927,
+      "max": 2773,
+      "typical": 2350,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Pinellas County, FL). Tampa Bay metro — competitive. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2350,
+      "benchmarkSilverMonthlySingle": 1175,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Pinellas County",
+      "notes": "Tampa Bay metro — competitive.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-summerville/location.json
+++ b/data/locations/us-summerville/location.json
@@ -181,6 +181,13 @@
       "max": 611,
       "annualInflation": 0.02,
       "notes": "Estimated monthly income tax on $72,000/yr household income. Based on jurisdiction's effective retiree rate; excludes sales/VAT/property tax."
+    },
+    "healthcarePreMedicare": {
+      "min": 2091,
+      "max": 3009,
+      "typical": 2550,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Dorchester County, SC). Charleston metro SC — BlueCross BlueShield SC dominant. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "taxes": {
@@ -268,7 +275,16 @@
     "waitTimes": "moderate",
     "dentalIncluded": false,
     "prescriptionCoverage": "Part D plan",
-    "notes": "Summerville Medical Center (Roper St. Francis). MUSC (Medical University of SC) 30 min in Charleston — nationally ranked teaching hospital. Trident Medical Center in North Charleston."
+    "notes": "Summerville Medical Center (Roper St. Francis). MUSC (Medical University of SC) 30 min in Charleston — nationally ranked teaching hospital. Trident Medical Center in North Charleston.",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2550,
+      "benchmarkSilverMonthlySingle": 1275,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Dorchester County",
+      "notes": "Charleston metro SC — BlueCross BlueShield SC dominant.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available (Comcast/Home Telecom Fiber)",

--- a/data/locations/us-tafuna-as/location.json
+++ b/data/locations/us-tafuna-as/location.json
@@ -136,6 +136,13 @@
       "min": 310,
       "max": 820,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1640,
+      "max": 2360,
+      "typical": 2000,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (American Samoa, AS). LBJ Tropical Medical Center coverage. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -143,7 +150,16 @@
     "qualityRating": 3,
     "dentalIncluded": false,
     "waitTimes": "Long; medevac to Honolulu common",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2000,
+      "benchmarkSilverMonthlySingle": 1000,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "American Samoa",
+      "notes": "LBJ Tropical Medical Center coverage.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 100Mbps (ASTCA, BlueSky)",

--- a/data/locations/us-tampa-fl/location.json
+++ b/data/locations/us-tampa-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Hillsborough County, FL). Tampa Bay metro — multiple insurers. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Hillsborough County",
+      "notes": "Tampa Bay metro — multiple insurers.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-tinian-mp/location.json
+++ b/data/locations/us-tinian-mp/location.json
@@ -138,6 +138,13 @@
       "max": 860,
       "annualInflation": 0.055,
       "notes": "Serious care requires travel to Saipan or Guam (boat/flight)."
+    },
+    "healthcarePreMedicare": {
+      "min": 1886,
+      "max": 2714,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Tinian, MP). Remote NMI — limited medical infrastructure. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -145,7 +152,16 @@
     "qualityRating": 3,
     "dentalIncluded": false,
     "waitTimes": "Limited on-island — most specialists off-island",
-    "prescriptionCoverage": "Medicare Part D or private"
+    "prescriptionCoverage": "Medicare Part D or private",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0,
+      "rateArea": "Tinian",
+      "notes": "Remote NMI — limited medical infrastructure.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "Up to 100Mbps (IT&E); fiber limited",

--- a/data/locations/us-virginia-beach-va/location.json
+++ b/data/locations/us-virginia-beach-va/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 1845,
+      "max": 2655,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Virginia Beach City, VA). Coastal VA — competitive marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 8,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Virginia Beach City",
+      "notes": "Coastal VA — competitive marketplace.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-virginia/location.json
+++ b/data/locations/us-virginia/location.json
@@ -80,11 +80,11 @@
       "annualInflation": 0.055
     },
     "healthcarePreMedicare": {
-      "min": 1800,
-      "max": 2800,
+      "min": 1886,
+      "max": 2714,
       "typical": 2300,
-      "notes": "ACA silver plan benchmark for 2-adult household, both 55-64, before subsidies. Marketplace pricing Fairfax County 2025. Subsidies reduce this dramatically at lower MAGI.",
-      "annualInflation": 0.06
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). NOVA marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Metro pricing. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     },
     "insurance": {
       "min": 35,
@@ -284,8 +284,11 @@
     "acaMarketplace": {
       "benchmarkSilverMonthly2Adult": 2300,
       "benchmarkSilverMonthlySingle": 1150,
-      "notes": "Anthem HealthKeepers, CareFirst BlueCross BlueShield, Kaiser Permanente active in Fairfax marketplace. Silver benchmark for 2 adults age 60.",
-      "premiumCapPctOfIncome": 0.085
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Fairfax County",
+      "notes": "NOVA marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Metro pricing.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {

--- a/data/locations/us-williamsport-pa/location.json
+++ b/data/locations/us-williamsport-pa/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2050,
+      "max": 2950,
+      "typical": 2500,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Lycoming County, PA). Rural North-Central PA — limited competition. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 6,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2500,
+      "benchmarkSilverMonthlySingle": 1250,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Lycoming County",
+      "notes": "Rural North-Central PA — limited competition.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/data/locations/us-yulee-fl/location.json
+++ b/data/locations/us-yulee-fl/location.json
@@ -134,6 +134,13 @@
       "typical": 350,
       "max": 600,
       "annualInflation": 0.055
+    },
+    "healthcarePreMedicare": {
+      "min": 2009,
+      "max": 2891,
+      "typical": 2450,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Nassau County, FL). Rural NE FL — fewer insurers than Jacksonville metro. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "healthcare": {
@@ -141,7 +148,16 @@
     "qualityRating": 7,
     "dentalIncluded": false,
     "waitTimes": "Short to moderate",
-    "prescriptionCoverage": "Via insurance plan"
+    "prescriptionCoverage": "Via insurance plan",
+    "acaMarketplace": {
+      "benchmarkSilverMonthly2Adult": 2450,
+      "benchmarkSilverMonthlySingle": 1225,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Nassau County",
+      "notes": "Rural NE FL — fewer insurers than Jacksonville metro.",
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps available",

--- a/tools/backfill-aca.mjs
+++ b/tools/backfill-aca.mjs
@@ -1,0 +1,346 @@
+/**
+ * Backfill healthcarePreMedicare + healthcare.acaMarketplace on every US
+ * location. Uses state-level 2024/2025 benchmark silver pricing for a
+ * 2-adult household age 60. Idempotent — re-running on already-backfilled
+ * locations updates the values to match the latest STATE_PREMIUMS table.
+ *
+ * Run:   node tools/backfill-aca.mjs [--dry-run]
+ */
+import { PrismaClient } from '@prisma/client';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(__dirname, '..', 'data', 'locations');
+const prisma = new PrismaClient();
+const dryRun = process.argv.includes('--dry-run');
+
+/**
+ * State → { silver2Adult, silverSingle, notes } for a 60yo couple. Numbers
+ * pulled from KFF / healthcare.gov 2024/2025 benchmark silver averages.
+ * ±10% location-to-location variation is expected; these are state midpoints.
+ */
+const STATE_PREMIUMS = {
+  AL: { two: 2700, one: 1400, notes: 'Alabama marketplace — Blue Cross Blue Shield dominant insurer.' },
+  AK: { two: 3200, one: 1650, notes: 'Alaska marketplace — limited insurers, high costs.' },
+  AR: { two: 2500, one: 1300, notes: 'Arkansas marketplace.' },
+  AZ: { two: 2300, one: 1200, notes: 'Arizona marketplace — multiple insurers.' },
+  CA: { two: 2900, one: 1500, notes: 'Covered California — varies heavily by region.' },
+  CO: { two: 2200, one: 1150, notes: 'Connect for Health Colorado — reinsurance program lowers premiums.' },
+  CT: { two: 3000, one: 1550, notes: 'Access Health CT.' },
+  DC: { two: 2400, one: 1250, notes: 'DC Health Link.' },
+  DE: { two: 2700, one: 1400, notes: 'Delaware marketplace.' },
+  FL: { two: 2400, one: 1250, notes: 'Florida marketplace — most competitive in Miami/Broward.' },
+  GA: { two: 2500, one: 1300, notes: 'Georgia Access.' },
+  HI: { two: 2200, one: 1150, notes: 'Hawaii marketplace.' },
+  IA: { two: 2700, one: 1400, notes: 'Iowa marketplace — single insurer in many counties.' },
+  ID: { two: 2300, one: 1200, notes: 'Your Health Idaho.' },
+  IL: { two: 2400, one: 1250, notes: 'Get Covered Illinois.' },
+  IN: { two: 2600, one: 1350, notes: 'Indiana marketplace.' },
+  KS: { two: 2500, one: 1300, notes: 'Kansas marketplace.' },
+  KY: { two: 2500, one: 1300, notes: 'Kynect.' },
+  LA: { two: 2400, one: 1250, notes: 'Louisiana marketplace.' },
+  MA: { two: 2000, one: 1050, notes: 'MA Health Connector — unique regulated marketplace, lowest premiums in US.' },
+  MD: { two: 2150, one: 1075, notes: 'Maryland Health Connection — reinsurance reduces premiums.' },
+  ME: { two: 2600, one: 1350, notes: 'CoverME.' },
+  MI: { two: 2400, one: 1250, notes: 'Michigan marketplace.' },
+  MN: { two: 2300, one: 1200, notes: 'MNsure — MinnesotaCare covers below 200% FPL separately.' },
+  MO: { two: 2600, one: 1350, notes: 'Missouri marketplace.' },
+  MS: { two: 2800, one: 1450, notes: 'Mississippi marketplace — limited competition.' },
+  MT: { two: 2500, one: 1300, notes: 'Montana marketplace.' },
+  NC: { two: 2500, one: 1300, notes: 'North Carolina marketplace.' },
+  ND: { two: 2700, one: 1400, notes: 'North Dakota marketplace — limited insurers.' },
+  NE: { two: 2700, one: 1400, notes: 'Nebraska marketplace.' },
+  NH: { two: 2600, one: 1350, notes: 'New Hampshire marketplace.' },
+  NJ: { two: 2500, one: 1300, notes: 'Get Covered NJ — state reinsurance program.' },
+  NM: { two: 2400, one: 1250, notes: 'BeWellNM.' },
+  NV: { two: 2300, one: 1200, notes: 'Nevada Health Link.' },
+  NY: { two: 2100, one: 1100, notes: 'NY State of Health — NY Essential Plan covers 138-250% FPL free/low-cost.' },
+  OH: { two: 2300, one: 1200, notes: 'Ohio marketplace.' },
+  OK: { two: 2600, one: 1350, notes: 'Oklahoma marketplace.' },
+  OR: { two: 2300, one: 1200, notes: 'Oregon Health Insurance Marketplace.' },
+  PA: { two: 2400, one: 1250, notes: 'Pennie — PA state-based marketplace with reinsurance.' },
+  RI: { two: 2500, one: 1300, notes: 'HealthSource RI.' },
+  SC: { two: 2600, one: 1350, notes: 'South Carolina marketplace.' },
+  SD: { two: 2800, one: 1450, notes: 'South Dakota marketplace — limited insurers.' },
+  TN: { two: 2400, one: 1250, notes: 'Tennessee marketplace.' },
+  TX: { two: 2300, one: 1200, notes: 'Texas marketplace — large metros are most competitive.' },
+  UT: { two: 2300, one: 1200, notes: 'Utah marketplace.' },
+  VA: { two: 2300, one: 1150, notes: 'Virginia Insurance Marketplace (state-based 2024+).' },
+  VT: { two: 2800, one: 1450, notes: 'Vermont Health Connect.' },
+  WA: { two: 2200, one: 1150, notes: 'Washington Healthplanfinder — state reinsurance.' },
+  WI: { two: 2600, one: 1350, notes: 'Wisconsin marketplace.' },
+  WV: { two: 2900, one: 1500, notes: 'West Virginia marketplace — rural premium heavy.' },
+  WY: { two: 3000, one: 1550, notes: 'Wyoming marketplace — limited insurers, highest premiums in US.' },
+
+  // Territories — NOT on federal ACA exchange. These use local health systems
+  // (Puerto Rico Health Insurance, USVI BlueCross, Guam Regional Medical) and
+  // typical private plan costs for a 2-adult household. No federal subsidy cap.
+  PR: { two: 1600, one: 800,  notes: 'Puerto Rico — Mi Salud (ACA-like but state-run). Lower costs than mainland.', territory: true },
+  VI: { two: 2400, one: 1250, notes: 'USVI BlueCross BlueShield — no federal ACA marketplace.', territory: true },
+  GU: { two: 2200, one: 1150, notes: 'Guam — local private plans (TakeCare, NetCare). No ACA marketplace.', territory: true },
+  MP: { two: 2300, one: 1200, notes: 'Northern Mariana Islands — limited private coverage.', territory: true },
+  AS: { two: 2000, one: 1050, notes: 'American Samoa — LBJ Tropical Medical Center, limited private coverage.', territory: true },
+};
+
+/**
+ * Explicit mapping for location IDs that don't have a `-xx` state suffix
+ * or where the suffix is ambiguous (e.g. `us-virginia` is Fairfax, not the
+ * whole state). Keys are the full location id.
+ */
+const ID_TO_STATE = {
+  'us-virginia': 'VA',
+  'us-florida': 'FL',
+  'us-atlanta': 'GA',
+  'us-austin': 'TX',
+  'us-raleigh': 'NC',
+  'us-richmond': 'VA',
+  'us-savannah': 'GA',
+  'us-summerville': 'SC',
+  'us-cherry-hill': 'NJ',
+  'us-philadelphia': 'PA',
+  'us-new-york-city': 'NY',
+};
+
+function stateFromId(id) {
+  if (ID_TO_STATE[id]) return ID_TO_STATE[id];
+  const match = id.match(/-([a-z]{2})$/);
+  if (match) return match[1].toUpperCase();
+  return null;
+}
+
+/**
+ * Per-location ACA benchmark silver overrides keyed by full location id.
+ * Values are estimated county/rating-area level pricing for a 2-adult
+ * household both ~age 60, derived from 2024/2025 marketplace patterns.
+ * ±15% accuracy vs. a real healthcare.gov quote — verify specific ZIP
+ * before making a relocation decision based on the number.
+ *
+ * When a location id appears here, its values override the state default.
+ */
+const LOCATION_PREMIUMS = {
+  // Virginia — state avg $2,300; Fairfax urban slightly above, rural below
+  'us-virginia':          { two: 2300, one: 1150, county: 'Fairfax County',         notes: 'NOVA marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Metro pricing.' },
+  'us-annandale-va':      { two: 2300, one: 1150, county: 'Fairfax County',         notes: 'Same Fairfax County rating area as Fairfax City.' },
+  'us-lorton-va':         { two: 2300, one: 1150, county: 'Fairfax County',         notes: 'Southern Fairfax County — same rating area as Fairfax.' },
+  'us-manassas-va':       { two: 2250, one: 1125, county: 'Prince William County',  notes: 'PWC marketplace — similar to Fairfax with slightly more competition.' },
+  'us-gainesville-va':    { two: 2250, one: 1125, county: 'Prince William County',  notes: 'PWC marketplace — similar to Fairfax with slightly more competition.' },
+  'us-chesapeake-va':     { two: 2250, one: 1125, county: 'Chesapeake City',        notes: 'Hampton Roads — Sentara dominant, Optima Health available.' },
+  'us-lynchburg-va':      { two: 2400, one: 1200, county: 'Lynchburg City',         notes: 'Central VA — limited insurer competition vs NOVA.' },
+  'us-norfolk-va':        { two: 2250, one: 1125, county: 'Norfolk City',           notes: 'Hampton Roads marketplace.' },
+  'us-portsmouth-va':     { two: 2300, one: 1150, county: 'Portsmouth City',        notes: 'Hampton Roads marketplace.' },
+  'us-richmond':          { two: 2300, one: 1150, county: 'Henrico County',         notes: 'Richmond metro — Anthem, Sentara compete.' },
+  'us-virginia-beach-va': { two: 2250, one: 1125, county: 'Virginia Beach City',    notes: 'Coastal VA — competitive marketplace.' },
+
+  // Maryland — state reinsurance program lowers premiums; urban vs rural modest
+  'us-annapolis-md':      { two: 2150, one: 1075, county: 'Anne Arundel County',    notes: 'MD Health Connection: CareFirst, Kaiser, UnitedHealthcare.' },
+  'us-baltimore-md':      { two: 2050, one: 1025, county: 'Baltimore City',         notes: 'Baltimore metro — most competitive marketplace in MD.' },
+  'us-bowie-md':          { two: 2200, one: 1100, county: 'Prince George\'s County', notes: 'MD Health Connection: CareFirst, Kaiser, UnitedHealthcare. PG County rating area.' },
+  'us-elkridge-md':       { two: 2200, one: 1100, county: 'Howard County',          notes: 'MD Health Connection — Howard County rating area (competitive).' },
+  'us-glen-burnie-md':    { two: 2150, one: 1075, county: 'Anne Arundel County',    notes: 'MD Health Connection — Anne Arundel rating area.' },
+  'us-catonsville-md':    { two: 2100, one: 1050, county: 'Baltimore County',       notes: 'MD Health Connection — Baltimore County rating area (competitive).' },
+
+  // Florida — statewide FL location is a weighted mix; metro/rural spread
+  'us-florida':           { two: 2400, one: 1200, county: 'statewide',              notes: 'Statewide average; varies by county from ~$2,300 (Miami) to $2,500 (rural panhandle).' },
+  'us-fort-lauderdale-fl':{ two: 2300, one: 1150, county: 'Broward County',         notes: 'Broward — Ambetter, Florida Blue, Molina compete.' },
+  'us-miami-fl':          { two: 2300, one: 1150, county: 'Miami-Dade County',      notes: 'Miami-Dade — most competitive FL marketplace.' },
+  'us-palm-bay-fl':       { two: 2400, one: 1200, county: 'Brevard County',         notes: 'Space Coast — moderate competition.' },
+  'us-quincy-fl':         { two: 2500, one: 1250, county: 'Gadsden County',         notes: 'North FL panhandle — limited competition.' },
+  'us-st-augustine-fl':   { two: 2400, one: 1200, county: 'St Johns County',        notes: 'NE FL — Florida Blue dominant.' },
+  'us-st-petersburg-fl':  { two: 2350, one: 1175, county: 'Pinellas County',        notes: 'Tampa Bay metro — competitive.' },
+  'us-tampa-fl':          { two: 2300, one: 1150, county: 'Hillsborough County',    notes: 'Tampa Bay metro — multiple insurers.' },
+  'us-yulee-fl':          { two: 2450, one: 1225, county: 'Nassau County',          notes: 'Rural NE FL — fewer insurers than Jacksonville metro.' },
+
+  // Pennsylvania — Pennie (state marketplace) + reinsurance
+  'us-philadelphia':      { two: 2300, one: 1150, county: 'Philadelphia County',    notes: 'Pennie — Philadelphia metro most competitive in PA.' },
+  'us-pittsburgh-pa':     { two: 2250, one: 1125, county: 'Allegheny County',       notes: 'Pennie — Pittsburgh metro, Highmark + UPMC.' },
+  'us-armstrong-county-pa':{ two:2500, one: 1250, county: 'Armstrong County',       notes: 'Rural Western PA — higher premiums, fewer insurers.' },
+  'us-williamsport-pa':   { two: 2500, one: 1250, county: 'Lycoming County',        notes: 'Rural North-Central PA — limited competition.' },
+
+  // North Carolina
+  'us-asheville-nc':      { two: 2550, one: 1275, county: 'Buncombe County',        notes: 'Western NC — Blue Cross NC dominant.' },
+  'us-raleigh':           { two: 2400, one: 1200, county: 'Wake County',            notes: 'Raleigh-Durham — competitive metro marketplace.' },
+
+  // South Carolina
+  'us-summerville':       { two: 2550, one: 1275, county: 'Dorchester County',      notes: 'Charleston metro SC — BlueCross BlueShield SC dominant.' },
+
+  // Georgia
+  'us-atlanta':           { two: 2400, one: 1200, county: 'Fulton County',          notes: 'Atlanta metro — Ambetter, Anthem, Kaiser compete.' },
+  'us-savannah':          { two: 2450, one: 1225, county: 'Chatham County',         notes: 'Coastal GA — moderate competition.' },
+
+  // Alabama
+  'us-birmingham-al':     { two: 2650, one: 1325, county: 'Jefferson County',       notes: 'BCBS Alabama dominant — limited marketplace competition.' },
+
+  // Tennessee
+  'us-nashville-tn':      { two: 2350, one: 1175, county: 'Davidson County',        notes: 'Nashville metro — Ambetter, BlueCross TN compete.' },
+
+  // Texas — state avg $2,300; metros competitive
+  'us-austin':            { two: 2250, one: 1125, county: 'Travis County',          notes: 'Austin metro — Ambetter, Oscar, Blue Cross TX.' },
+  'us-dallas-tx':         { two: 2250, one: 1125, county: 'Dallas County',          notes: 'DFW — highly competitive marketplace.' },
+  'us-fort-worth-tx':     { two: 2250, one: 1125, county: 'Tarrant County',         notes: 'DFW — same rating area as Dallas.' },
+  'us-killeen-tx':        { two: 2350, one: 1175, county: 'Bell County',            notes: 'Central TX — moderate competition.' },
+  'us-san-marcos-tx':     { two: 2300, one: 1150, county: 'Hays County',            notes: 'Austin-San Antonio corridor.' },
+
+  // Arkansas
+  'us-little-rock-ar':    { two: 2500, one: 1250, county: 'Pulaski County',         notes: 'Arkansas — single-insurer-dominant in many counties.' },
+
+  // New Mexico
+  'us-albuquerque-nm':    { two: 2350, one: 1175, county: 'Bernalillo County',      notes: 'BeWellNM — Albuquerque metro most competitive.' },
+
+  // Illinois
+  'us-chicago-il':        { two: 2350, one: 1175, county: 'Cook County',            notes: 'Chicago metro — Blue Cross IL dominant, Ambetter + Oscar compete.' },
+
+  // Ohio
+  'us-cleveland-oh':      { two: 2250, one: 1125, county: 'Cuyahoga County',        notes: 'Cleveland metro — Medical Mutual, Anthem, CareSource.' },
+  'us-lorain-oh':         { two: 2300, one: 1150, county: 'Lorain County',          notes: 'NE Ohio — similar to Cleveland rating area.' },
+
+  // Indiana
+  'us-fort-wayne-in':     { two: 2550, one: 1275, county: 'Allen County',           notes: 'NE Indiana — Anthem dominant.' },
+
+  // Michigan
+  'us-lapeer-mi':         { two: 2400, one: 1200, county: 'Lapeer County',          notes: 'Thumb of MI — BCBSM dominant.' },
+  'us-oakland-county-mi': { two: 2350, one: 1175, county: 'Oakland County',         notes: 'Metro Detroit — BCBSM + Priority Health + Molina.' },
+  'us-port-huron-mi':     { two: 2450, one: 1225, county: 'St Clair County',        notes: 'Eastern MI — BCBSM dominant.' },
+
+  // Wisconsin
+  'us-milwaukee-wi':      { two: 2500, one: 1250, county: 'Milwaukee County',       notes: 'Milwaukee metro — Anthem, Quartz, Dean Health.' },
+
+  // Minnesota
+  'us-minneapolis-mn':    { two: 2250, one: 1125, county: 'Hennepin County',        notes: 'MNsure — Twin Cities most competitive in MN.' },
+  'us-saint-paul-mn':     { two: 2300, one: 1150, county: 'Ramsey County',          notes: 'Twin Cities — similar to Hennepin.' },
+
+  // North Dakota
+  'us-grand-forks-nd':    { two: 2700, one: 1350, county: 'Grand Forks County',     notes: 'BCBS ND dominant — limited insurer competition.' },
+
+  // Maine
+  'us-skowhegan-me':      { two: 2700, one: 1350, county: 'Somerset County',        notes: 'Rural central ME — Harvard Pilgrim, Community Health Options.' },
+
+  // New Jersey — Get Covered NJ with reinsurance
+  'us-camden-nj':         { two: 2450, one: 1225, county: 'Camden County',          notes: 'Southern NJ — Ambetter, AmeriHealth, Oscar, Horizon.' },
+  'us-cherry-hill':       { two: 2450, one: 1225, county: 'Camden County',          notes: 'Southern NJ — same rating area as Camden.' },
+
+  // New York — Essential Plan covers 138-250% FPL; cheapest silver in US for higher earners
+  'us-new-york-city':     { two: 2100, one: 1050, county: 'NYC metro',              notes: 'NY State of Health — Essential Plan covers low/mid income separately.' },
+
+  // Colorado — reinsurance program
+  'us-denver-co':         { two: 2100, one: 1050, county: 'Denver County',          notes: 'Connect for Health CO — reinsurance reduces premiums 20%+.' },
+
+  // US Territories — not on federal ACA marketplace
+  'us-charlotte-amalie-vi': { two: 2400, one: 1200, county: 'St Thomas',            notes: 'USVI BCBS — no federal ACA marketplace, no subsidies.', territory: true },
+  'us-christiansted-vi':  { two: 2400, one: 1200, county: 'St Croix',               notes: 'USVI BCBS — no federal ACA marketplace, no subsidies.', territory: true },
+  'us-dededo-gu':         { two: 2200, one: 1100, county: 'Guam',                   notes: 'Guam — TakeCare, NetCare local plans. No ACA marketplace.', territory: true },
+  'us-hagatna-gu':        { two: 2200, one: 1100, county: 'Guam',                   notes: 'Guam local private plans.', territory: true },
+  'us-pago-pago-as':      { two: 2000, one: 1000, county: 'American Samoa',         notes: 'LBJ Tropical Medical Center. Very limited private coverage.', territory: true },
+  'us-ponce-pr':          { two: 1600, one: 800,  county: 'Ponce',                  notes: 'Mi Salud (PR state-run). Lower costs than mainland.', territory: true },
+  'us-saipan-mp':         { two: 2300, one: 1150, county: 'Saipan',                 notes: 'Northern Marianas — limited private coverage.', territory: true },
+  'us-san-juan-pr':       { two: 1600, one: 800,  county: 'San Juan',               notes: 'Mi Salud — better infrastructure than rural PR.', territory: true },
+  'us-tafuna-as':         { two: 2000, one: 1000, county: 'American Samoa',         notes: 'LBJ Tropical Medical Center coverage.', territory: true },
+  'us-tinian-mp':         { two: 2300, one: 1150, county: 'Tinian',                 notes: 'Remote NMI — limited medical infrastructure.', territory: true },
+};
+
+const dirs = readdirSync(DATA_DIR).filter(d => d.startsWith('us-'));
+let updated = 0, skipped = 0, unknown = 0;
+const touchedIds = [];
+
+for (const dir of dirs) {
+  const file = join(DATA_DIR, dir, 'location.json');
+  if (!existsSync(file)) continue;
+  const loc = JSON.parse(readFileSync(file, 'utf-8'));
+  const state = stateFromId(loc.id);
+
+  // Per-location (county-level) override takes priority over state avg.
+  const override = LOCATION_PREMIUMS[loc.id];
+  const premium = override ?? (state ? STATE_PREMIUMS[state] : null);
+  const level = override ? 'county' : 'state';
+
+  if (!premium) {
+    console.log(`  ?  ${loc.id} — no premium data (state=${state ?? '—'})`);
+    unknown++;
+    continue;
+  }
+
+  const source = override
+    ? `${override.county}, ${state}`
+    : `${state} state average`;
+  const disclaimer = 'Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number.';
+
+  // Ensure monthlyCosts.healthcarePreMedicare
+  loc.monthlyCosts ??= {};
+  loc.monthlyCosts.healthcarePreMedicare = {
+    min: Math.round(premium.two * 0.82),
+    max: Math.round(premium.two * 1.18),
+    typical: premium.two,
+    annualInflation: 0.06,
+    notes: `ACA silver benchmark for 2-adult household both age ~60, before subsidies. ${level === 'county' ? 'County-level' : 'State-level'} estimate (${source}). ${premium.notes} ${disclaimer}`,
+  };
+
+  // Ensure healthcare.acaMarketplace
+  loc.healthcare ??= {};
+  loc.healthcare.acaMarketplace = {
+    benchmarkSilverMonthly2Adult: premium.two,
+    benchmarkSilverMonthlySingle: premium.one,
+    premiumCapPctOfIncome: premium.territory ? 0 : 0.085,
+    rateArea: override?.county ?? undefined,
+    notes: premium.notes,
+    estimationLevel: level,
+    disclaimer,
+  };
+
+  if (!dryRun) {
+    writeFileSync(file, JSON.stringify(loc, null, 2) + '\n', 'utf-8');
+  }
+  updated++;
+  touchedIds.push(loc.id);
+  console.log(`  ↻  ${loc.id}  (${level}, ${source}, $${premium.two}/mo)`);
+}
+
+console.log(`\n${dryRun ? 'DRY RUN — ' : ''}${updated} updated, ${skipped} skipped, ${unknown} unknown-state.`);
+
+if (!dryRun && touchedIds.length) {
+  // Reseed DB via the AdminLocation upsert pattern (matches insert-new-locations.mjs).
+  const ALTERNATE_KEYS = new Set(['healthcarePreMedicare']);
+  function extractSearchFields(l) {
+    let total = 0;
+    for (const [key, val] of Object.entries(l.monthlyCosts ?? {})) {
+      if (ALTERNATE_KEYS.has(key)) continue;
+      if (val && typeof val.typical === 'number') total += val.typical;
+    }
+    return {
+      name: l.name || '',
+      country: l.country || '',
+      region: l.region || '',
+      currency: l.currency || 'USD',
+      monthlyCostTotal: Math.round(total),
+    };
+  }
+
+  console.log(`\nReseeding ${touchedIds.length} locations into DB...`);
+  for (const id of touchedIds) {
+    const loc = JSON.parse(readFileSync(join(DATA_DIR, id, 'location.json'), 'utf-8'));
+    const search = extractSearchFields(loc);
+    const existing = await prisma.adminLocation.findUnique({ where: { id } });
+    if (existing) {
+      const newVersion = existing.version + 1;
+      await prisma.$transaction(async (tx) => {
+        await tx.adminLocation.update({
+          where: { id }, data: { locationData: loc, version: newVersion, ...search },
+        });
+        await tx.adminLocationHistory.create({
+          data: { locationId: id, version: newVersion, locationData: loc, changedBy: 'backfill-aca' },
+        });
+      });
+    } else {
+      await prisma.$transaction(async (tx) => {
+        await tx.adminLocation.create({ data: { id, version: 1, locationData: loc, ...search } });
+        await tx.adminLocationHistory.create({
+          data: { locationId: id, version: 1, locationData: loc, changedBy: 'backfill-aca' },
+        });
+      });
+    }
+  }
+  console.log(`✓ Reseed complete.`);
+}
+
+await prisma.$disconnect();

--- a/tools/check-household.mjs
+++ b/tools/check-household.mjs
@@ -1,0 +1,22 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+const profiles = await prisma.householdProfile.findMany({
+  include: { members: { orderBy: { sortOrder: 'asc' } } },
+});
+
+console.log(`Found ${profiles.length} household profile(s):\n`);
+for (const p of profiles) {
+  console.log(`  userId: ${p.userId}`);
+  console.log(`  planningStartYear: ${p.planningStartYear}`);
+  console.log(`  adultsCount: ${p.adultsCount}`);
+  console.log(`  targetAnnualIncome (encrypted): ${p.targetAnnualIncome ? '[set]' : 'null'}`);
+  console.log(`  members (${p.members.length}):`);
+  for (const m of p.members) {
+    const age = new Date().getFullYear() - (m.birthYear ?? 0);
+    console.log(`    - ${m.name || '(unnamed)'} · role=${m.role} · birthYear=${m.birthYear} · age=${age} · ssClaimAge=${m.ssClaimAge}`);
+  }
+  console.log();
+}
+
+await prisma.$disconnect();


### PR DESCRIPTION
## Summary

Adds 7 retirement-candidate locations around the DC/Baltimore metros and expands county-level ACA benchmark data via the backfill tool.

### New locations

**Virginia** (3):
- us-annandale-va — Fairfax County, 5 mi east of Fairfax City, Korean/Latino grocery scene
- us-lorton-va — southern Fairfax County, newer townhomes
- us-manassas-va — Prince William County, VRE commuter rail, historic downtown

**Maryland** (4):
- us-bowie-md — Prince George's County, MARC Penn Line to DC
- us-elkridge-md — Howard County, JHU affiliate hospital + BWI access
- us-glen-burnie-md — Anne Arundel County, UM BWMC in town, cheapest MD at ~\$7,563/mo
- us-catonsville-md — Baltimore County, walkable Frederick Road, dense hospital access

All have federal + state tax brackets (MD combined state+county piggyback), full `monthlyCosts` matching the Fairfax retiree profile, and county-level `healthcarePreMedicare` + `acaMarketplace` blocks.

### tools/backfill-aca.mjs
- `LOCATION_PREMIUMS` map grew to cover the 7 new entries with county rating-area metadata
- `estimationLevel: 'county'` on every entry so the frontend can show a precision badge
- State-level fallback retained for locations without explicit county data

## Test plan
- [ ] \`GET /api/locations?fields=full&limit=200\` returns all 7 new locations
- [ ] Maryland region filter shows 5 entries (Annapolis + Baltimore + Bowie + Elkridge + Glen Burnie + Catonsville)
- [ ] Virginia region filter shows all VA including 3 new (Annandale/Lorton/Manassas)
- [ ] Each location's \`taxes.stateIncomeTax.brackets\` applies correctly in the frontend \`computeIncomeTax\`
- [ ] Each location has \`healthcare.acaMarketplace.benchmarkSilverMonthly2Adult\` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)