### PR TITLE
chore: go public + lock down repo (LICENSE, Dependabot, CODEOWNERS, branch protection)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ─── Database ─────────────────────────────────────────────────────────────
-DATABASE_URL=postgresql://retirement:password@localhost:5432/retirement_saas
+DATABASE_URL=postgresql://retirement:<GENERATE_STRONG_PASSWORD>@localhost:5432/retirement_saas
 POSTGRES_DB=retirement_saas
 POSTGRES_USER=retirement
 POSTGRES_PASSWORD=<GENERATE_STRONG_PASSWORD>

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS — every PR auto-requests review from the listed owner(s).
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Format: `<path-pattern> @<owner> [@<owner> …]`
+# First matching rule wins (so put most-specific rules at the bottom).
+
+# Default: everything requires owner review.
+*                                            @justice8096
+
+# Especially sensitive areas — same owner, listed explicitly so intent is clear.
+/LICENSE                                     @justice8096
+/SECURITY.md                                 @justice8096
+/docs/adr/**                                 @justice8096
+/.github/**                                  @justice8096
+/prisma/migrations/**                        @justice8096
+/src/middleware/auth.ts                      @justice8096
+/src/middleware/encryption.ts                @justice8096
+/src/middleware/sanitize.ts                  @justice8096
+/src/lib/stripe-customer.ts                  @justice8096
+/src/routes/webhooks.ts                      @justice8096

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot — automated dependency update PRs.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Production + dev npm dependencies.
+  # Grouped updates keep the PR volume manageable; security advisories still
+  # open individual PRs via automated-security-fixes (configured in repo settings).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+    reviewers:
+      - justice8096
+    commit-message:
+      prefix: chore(deps)
+      include: scope
+    groups:
+      fastify:
+        patterns:
+          - "fastify"
+          - "@fastify/*"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+      clerk:
+        patterns:
+          - "@clerk/*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      dev-tooling:
+        dependency-type: development
+        patterns:
+          - "typescript"
+          - "tsx"
+          - "vitest"
+          - "@types/*"
+
+  # GitHub Actions — pin SHAs, update tags weekly.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - justice8096
+    commit-message:
+      prefix: chore(ci)
+
+  # Dockerfile base-image updates.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - justice8096
+    commit-message:
+      prefix: chore(docker)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- PR template. Delete sections that don't apply. -->
+
+## Summary
+<!-- What this PR does and why. One or two sentences. -->
+
+## Change type
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor / cleanup
+- [ ] Security
+- [ ] Docs / audits
+- [ ] Dependency bump
+- [ ] Other
+
+## Test plan
+- [ ] `npm run typecheck` clean
+- [ ] `npm test` passes (or noted delta vs baseline)
+- [ ] `npm run test:shared` passes
+- [ ] Manual verification (describe):
+- [ ] No new audit findings introduced
+
+## Audit impact
+<!-- If this touches security, accessibility, or governance, name the
+finding / ADR / audit section that applies. -->
+
+## Breaking changes
+- [ ] No breaking changes
+- [ ] Breaking change — describe migration:
+
+## Checklist
+- [ ] No secrets added (grep for `sk_live_`, `whsec_live_`, etc.)
+- [ ] No silent downgrades to existing security posture
+- [ ] `CHANGELOG.md` updated if user-visible behavior changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [20, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -45,7 +45,7 @@ jobs:
     # LLM-Compliance roadmap Dimension 4 (Supply Chain) — path to SLSA L1.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -55,7 +55,7 @@ jobs:
       - name: Generate CycloneDX SBOM
         run: npm sbom --sbom-format cyclonedx --sbom-type application > sbom.json
       - name: Upload SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom-cyclonedx
           path: sbom.json
@@ -64,10 +64,10 @@ jobs:
   security-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -118,23 +118,23 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e # v3
 
   docker-security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: Dockerfile
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,53 @@
+Copyright (c) 2026 Justice Chase. All rights reserved.
+
+This repository is publicly readable but is NOT open source.
+
+No license, express or implied, is granted to any person or entity to use,
+copy, modify, merge, publish, distribute, sublicense, sell, host as a
+service, or create derivative works from this software (including its
+source code, configuration, documentation, data, audits, and architecture
+decision records), in whole or in part, without the prior written
+authorization of the copyright holder.
+
+Permitted actions (automatic):
+
+  - Viewing the source code and documentation on GitHub.
+  - Forking this repository via GitHub's built-in fork mechanism for the
+    purpose of submitting pull requests back to this repository. A GitHub
+    fork does not convey any copyright license beyond what is required to
+    operate GitHub's user interface.
+
+All other uses — including, without limitation:
+
+  - Running the software (compiled or interpreted) for any purpose,
+    whether personal, educational, commercial, or otherwise;
+  - Hosting the software as a service, whether paid or free;
+  - Extracting, transcribing, or re-publishing any portion of the source
+    code, data, audits, or documentation in another project or medium;
+  - Training, fine-tuning, or benchmarking machine-learning models on
+    any portion of this repository's contents;
+  - Distributing compiled or translated versions;
+
+require prior written authorization from the copyright holder.
+
+To request authorization, contact: justice8096@gmail.com.
+
+CONTRIBUTIONS. If you submit a pull request or other contribution to this
+repository, you agree that your contribution is licensed to the copyright
+holder under the same terms as this LICENSE, and you grant the copyright
+holder a perpetual, worldwide, royalty-free license to use, modify, and
+re-license your contribution. If you are not able to grant this license,
+do not submit the contribution.
+
+NO WARRANTY. This software is provided "AS IS" and without warranty of
+any kind, express or implied, including but not limited to the warranties
+of merchantability, fitness for a particular purpose, and noninfringement.
+In no event shall the copyright holder be liable for any claim, damages,
+or other liability arising from the software or its use.
+
+EXTRACTED COMPONENTS. Individual components may, from time to time, be
+extracted into separate repositories under Creative Commons Zero (CC0 1.0
+Universal). Those components are governed by their own LICENSE files in
+their own repositories; this LICENSE does not apply to them. The presence
+of such an extract does not grant any license to this repository's
+contents beyond what is stated above.

--- a/README.md
+++ b/README.md
@@ -247,8 +247,18 @@ OWASP LLM Top 10 2025, ISO 27001) is audited and scored:
 
 ## License
 
-Not yet assigned. Treat the code as proprietary until the maintainer selects
-and commits a LICENSE file.
+**All Rights Reserved.** This repository is publicly readable but is not
+open source. Running, modifying, redistributing, or hosting this software
+requires prior written authorization from the copyright holder. See
+[`LICENSE`](LICENSE) for full terms.
+
+Individual UI components may, from time to time, be extracted into
+separate repositories under **[Creative Commons Zero (CC0 1.0
+Universal)](https://creativecommons.org/publicdomain/zero/1.0/)**. Those
+extracts are governed by their own LICENSE files and are freely reusable;
+the parent repository you are reading now is not.
+
+For licensing enquiries: `justice8096@gmail.com`.
 
 ---
 


### PR DESCRIPTION
## Summary

Flip `retirement-api` to **public** visibility and put it behind a full
lock-down so only authorized contributors can land changes on `master`.
The audit history already in `audits/` is part of the public posture —
concrete evidence of the project's security + accessibility commitments.

## What this PR ships (code)

- **`LICENSE`** — custom "All Rights Reserved." Source is publicly
  readable, but running / modifying / redistributing / hosting requires
  prior written authorization. Extraction plan for CC0 UI components
  noted. Contribution clause licenses any incoming PR back to the
  copyright holder.
- **README license section** — replaces "Not yet assigned" with explicit
  ARR language + pointer to future CC0 extracts.
- **`.env.example`** — last literal `password` removed; `DATABASE_URL`
  now uses `<GENERATE_STRONG_PASSWORD>` to match the Redis lines.
- **`.github/dependabot.yml`** — weekly npm / github-actions / docker
  updates, grouped by framework family.
- **`.github/CODEOWNERS`** — auto-request review on every PR; sensitive
  paths (`LICENSE`, `SECURITY.md`, `auth.ts`, `webhooks.ts`,
  `prisma/migrations/`) listed explicitly.
- **`.github/pull_request_template.md`** — test-plan + audit-impact +
  no-secrets checklist.
- **CI workflow SHA-pinned** — every `uses:` upgraded from tag (`@v4`) to
  commit SHA + tag trailing-comment. Prevents tag-pointer mutation
  attacks of the `tj-actions/changed-files` class.

## What this PR ships (repo settings applied via gh CLI)

Already applied to the live repo before this PR was opened (so the
incoming PR itself runs under the new rules):

- Visibility: **PUBLIC**
- Dependabot: vulnerability alerts + automated security fixes ON
- Secret scanning: ON
- **Secret scanning push protection: ON** (blocks commits containing
  detected secrets at push time)
- Private vulnerability reporting: ON
- Merge strategies: **squash-only** (merge-commit + rebase-merge
  disabled)
- `deleteBranchOnMerge`: ON
- Actions: `allowed_actions=selected` (GitHub-owned + verified creators
  + `hadolint/hadolint-action@*`); **SHA pinning required**

## Branch protection on `master` (applied via gh API)

- Pull requests required; direct push blocked.
- **1 approving review** required before merge.
- **Code-owner review required** (CODEOWNERS auto-request).
- **Dismiss stale reviews** when new commits arrive.
- **5 required status checks** must pass:
  `lint-and-test (20)`, `lint-and-test (22)`, `security-audit`,
  `sbom`, `codeql-analysis`.
- `strict: true` — PR must be up-to-date with `master` before merging.
- **Linear history required** (squash-only aligns with this).
- **No force-pushes, no deletions.**
- **Required conversation resolution** before merge.
- `enforce_admins: false` — so the admin can still emergency-bypass if
  CI itself is broken. Flip to `true` once the workflow has been stable
  for a few cycles.

## Why public

- The `audits/` folder (7 reports per cycle × 2 cycles so far) is
  concrete evidence of the project's security + accessibility posture.
  Keeping it private hides that proof.
- All Rights Reserved license protects the code from reuse regardless of
  visibility. GitHub's fork-button is a platform permission, not a
  copyright grant — forkers still can't legally use the fork.
- Secret scanning + push protection + branch protection are free on
  public repos. This was the simpler path than paying for GitHub Pro.

## Pre-public safety verified

- `.env` never committed — `git log --all -- .env` empty.
- No `sk_live_` / `whsec_live_` / `pk_live_` strings in source tree.
- All `sk_test_` matches in history are documentation references
  (audits, SECURITY.md, OPS.md), not live keys.
- Clerk test key already rotated on 2026-04-20 per `docs/OPS.md` §1.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Repo visibility verified PUBLIC via `gh repo view`
- [x] Branch protection rule verified via `gh api branches/master/protection`
- [ ] First PR merge under new rules works (this PR is the test)
- [ ] Dependabot PRs start arriving on the next Monday 09:00 ET tick
- [ ] Secret scanning / push protection blocks a test commit (optional manual check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)