### PR TITLE
test: fix 15 broken baseline tests (webhook + billing + health + locations)

### DIFF
--- a/src/__tests__/routes-billing.test.ts
+++ b/src/__tests__/routes-billing.test.ts
@@ -1,18 +1,21 @@
 /**
- * Integration tests for billing routes (POST /api/billing/checkout, /portal, GET /status).
+ * Integration tests for billing routes:
+ *   POST /api/billing/checkout-feature  — one-time feature unlock
+ *   POST /api/billing/portal            — legacy Stripe Customer Portal
+ *   GET  /api/billing/status            — tier + unlocks + badges + release access
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 
-// Set env vars before any module imports (must be in vi.hoisted to run before ESM evaluation)
+// Set env vars before any module imports (must be in vi.hoisted to run before ESM evaluation).
 vi.hoisted(() => {
   process.env.STRIPE_SECRET_KEY = 'sk_test_fake';
-  process.env.STRIPE_PRICE_BASIC = 'price_basic_123';
-  process.env.STRIPE_PRICE_PREMIUM = 'price_premium_456';
+  process.env.STRIPE_PRICE_FEATURE_BASIC = 'price_feature_basic_123';
+  process.env.STRIPE_PRICE_FEATURE_PREMIUM = 'price_feature_premium_456';
   process.env.APP_URL = 'http://localhost:5173';
 });
 
-// Mock Stripe — use vi.hoisted so mock object is available in hoisted vi.mock factory
+// Mock Stripe — hoisted so the mock object is available in the vi.mock factory.
 const mockStripe = vi.hoisted(() => ({
   customers: { create: vi.fn() },
   checkout: { sessions: { create: vi.fn() } },
@@ -27,6 +30,22 @@ vi.mock('../db/prisma.js', () => ({
   default: {
     user: {
       update: vi.fn(),
+      updateMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    userFeatureUnlock: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    userReleasePurchase: {
+      findMany: vi.fn(),
+    },
+    dataRelease: {
+      findFirst: vi.fn(),
+    },
+    userBadge: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
     },
   },
 }));
@@ -47,11 +66,24 @@ import prisma from '../db/prisma.js';
 import { requireAuth } from '../middleware/auth.js';
 import billingRoutes from '../routes/billing.js';
 
+/** Default no-op mocks for `/status` multi-table query. */
+function primeStatusDefaults() {
+  (prisma.userFeatureUnlock.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (prisma.userReleasePurchase.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (prisma.dataRelease.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({ version: 1 });
+  (prisma.userBadge.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  (prisma.userBadge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+}
+
 describe('Billing routes', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
-    app = Fastify({ logger: false });
+    app = Fastify();
+    vi.clearAllMocks();
+    primeStatusDefaults();
+    // `ensureStripeCustomer` helper needs updateMany to exist and default to 1 row updated.
+    (prisma.user.updateMany as ReturnType<typeof vi.fn>).mockResolvedValue({ count: 1 });
     await app.register(billingRoutes, { prefix: '/api/billing' });
   });
 
@@ -60,12 +92,12 @@ describe('Billing routes', () => {
     vi.restoreAllMocks();
   });
 
-  // ─── POST /api/billing/checkout ──────────────────────────────────
+  // ─── POST /api/billing/checkout-feature ──────────────────────────
 
-  describe('POST /api/billing/checkout', () => {
-    it('creates checkout session for valid basic price', async () => {
+  describe('POST /api/billing/checkout-feature', () => {
+    it('creates checkout session for valid basic featureSet', async () => {
+      (prisma.userFeatureUnlock.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
       mockStripe.customers.create.mockResolvedValue({ id: 'cus_new_123' });
-      prisma.user.update.mockResolvedValue({});
       mockStripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/session_abc',
         id: 'cs_abc',
@@ -73,8 +105,8 @@ describe('Billing routes', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
-        payload: { priceId: 'price_basic_123' },
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'basic' },
         headers: { 'content-type': 'application/json' },
       });
 
@@ -84,9 +116,9 @@ describe('Billing routes', () => {
       expect(body.sessionId).toBe('cs_abc');
     });
 
-    it('creates checkout session for valid premium price', async () => {
+    it('creates checkout session for valid premium featureSet', async () => {
+      (prisma.userFeatureUnlock.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
       mockStripe.customers.create.mockResolvedValue({ id: 'cus_new_456' });
-      prisma.user.update.mockResolvedValue({});
       mockStripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/session_def',
         id: 'cs_def',
@@ -94,8 +126,8 @@ describe('Billing routes', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
-        payload: { priceId: 'price_premium_456' },
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'premium' },
         headers: { 'content-type': 'application/json' },
       });
 
@@ -104,22 +136,23 @@ describe('Billing routes', () => {
       expect(body.url).toContain('stripe.com');
     });
 
-    it('rejects invalid price ID', async () => {
+    it('rejects invalid featureSet enum value', async () => {
       const res = await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
-        payload: { priceId: 'price_invalid_999' },
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'not-a-tier' },
         headers: { 'content-type': 'application/json' },
       });
 
       expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res.payload).error).toBe('Invalid price ID');
+      // Plain-language envelope per Dyslexia F-007 / F-011.
+      expect(JSON.parse(res.payload).error).toBe('Validation failed');
     });
 
-    it('rejects missing price ID', async () => {
+    it('rejects missing featureSet', async () => {
       const res = await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
+        url: '/api/billing/checkout-feature',
         payload: {},
         headers: { 'content-type': 'application/json' },
       });
@@ -127,8 +160,24 @@ describe('Billing routes', () => {
       expect(res.statusCode).toBe(400);
     });
 
-    it('reuses existing Stripe customer ID', async () => {
-      // User already has a stripeCustomerId
+    it('returns 409 when feature is already unlocked', async () => {
+      (prisma.userFeatureUnlock.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+        userId: 'test-user-id',
+        featureSet: 'basic',
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'basic' },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(JSON.parse(res.payload).error).toContain('already unlocked');
+    });
+
+    it('reuses existing Stripe customer ID when present', async () => {
       (requireAuth as ReturnType<typeof vi.fn>).mockImplementationOnce(async (request) => {
         request.userId = 'test-user-id';
         request.user = {
@@ -138,7 +187,7 @@ describe('Billing routes', () => {
           stripeCustomerId: 'cus_existing_789',
         };
       });
-
+      (prisma.userFeatureUnlock.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
       mockStripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/session_ghi',
         id: 'cs_ghi',
@@ -146,23 +195,23 @@ describe('Billing routes', () => {
 
       const res = await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
-        payload: { priceId: 'price_basic_123' },
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'basic' },
         headers: { 'content-type': 'application/json' },
       });
 
       expect(res.statusCode).toBe(200);
-      // Should NOT create a new customer
+      // Should NOT create a new customer.
       expect(mockStripe.customers.create).not.toHaveBeenCalled();
-      // Checkout session should use existing customer
+      // Checkout session should use existing customer.
       expect(mockStripe.checkout.sessions.create).toHaveBeenCalledWith(
         expect.objectContaining({ customer: 'cus_existing_789' }),
       );
     });
 
-    it('creates Stripe customer for first-time subscriber', async () => {
+    it('creates Stripe customer via ensureStripeCustomer for first-time user', async () => {
+      (prisma.userFeatureUnlock.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
       mockStripe.customers.create.mockResolvedValue({ id: 'cus_brand_new' });
-      prisma.user.update.mockResolvedValue({});
       mockStripe.checkout.sessions.create.mockResolvedValue({
         url: 'https://checkout.stripe.com/s',
         id: 'cs_s',
@@ -170,8 +219,8 @@ describe('Billing routes', () => {
 
       await app.inject({
         method: 'POST',
-        url: '/api/billing/checkout',
-        payload: { priceId: 'price_basic_123' },
+        url: '/api/billing/checkout-feature',
+        payload: { featureSet: 'basic' },
         headers: { 'content-type': 'application/json' },
       });
 
@@ -181,8 +230,10 @@ describe('Billing routes', () => {
           metadata: { userId: 'test-user-id' },
         }),
       );
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'test-user-id' },
+      // The ensureStripeCustomer helper uses `updateMany where stripeCustomerId: null`
+      // as an optimistic-concurrency guard (SAST L-NEW-02).
+      expect(prisma.user.updateMany).toHaveBeenCalledWith({
+        where: { id: 'test-user-id', stripeCustomerId: null },
         data: { stripeCustomerId: 'cus_brand_new' },
       });
     });
@@ -229,28 +280,7 @@ describe('Billing routes', () => {
   // ─── GET /api/billing/status ─────────────────────────────────────
 
   describe('GET /api/billing/status', () => {
-    it('returns tier and masked customer ID for paid user', async () => {
-      (requireAuth as ReturnType<typeof vi.fn>).mockImplementationOnce(async (request) => {
-        request.userId = 'test-user-id';
-        request.user = {
-          id: 'test-user-id',
-          tier: 'premium',
-          stripeCustomerId: 'cus_real_id_here',
-        };
-      });
-
-      const res = await app.inject({
-        method: 'GET',
-        url: '/api/billing/status',
-      });
-
-      expect(res.statusCode).toBe(200);
-      const body = JSON.parse(res.payload);
-      expect(body.tier).toBe('premium');
-      expect(body.stripeCustomerId).toBe('***'); // masked
-    });
-
-    it('returns free tier with null customer for free user', async () => {
+    it('returns tier, masked customer ID, and empty unlocks for free user', async () => {
       const res = await app.inject({
         method: 'GET',
         url: '/api/billing/status',
@@ -260,6 +290,51 @@ describe('Billing routes', () => {
       const body = JSON.parse(res.payload);
       expect(body.tier).toBe('free');
       expect(body.stripeCustomerId).toBeNull();
+      expect(body.featureUnlocks).toEqual([]);
+      expect(body.purchasedReleases).toEqual([]);
+      expect(body.badges).toEqual([]);
+      expect(body.isFoundingMember).toBe(false);
+    });
+
+    it('masks the Stripe customer id for paid users', async () => {
+      (requireAuth as ReturnType<typeof vi.fn>).mockImplementationOnce(async (request) => {
+        request.userId = 'test-user-id';
+        request.user = {
+          id: 'test-user-id',
+          tier: 'premium',
+          stripeCustomerId: 'cus_real_id_here',
+        };
+      });
+      (prisma.userFeatureUnlock.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { featureSet: 'basic', unlockedVia: 'purchase' },
+        { featureSet: 'premium', unlockedVia: 'purchase' },
+      ]);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/billing/status',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.payload);
+      expect(body.tier).toBe('premium');
+      expect(body.stripeCustomerId).toBe('***');
+      expect(body.featureUnlocks).toEqual(['basic', 'premium']);
+    });
+
+    it('flags founding-member badge when present', async () => {
+      (prisma.userBadge.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        userId: 'test-user-id',
+        badgeKey: 'founding_member',
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/billing/status',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).isFoundingMember).toBe(true);
     });
 
     it('sets no-store cache header', async () => {

--- a/src/__tests__/routes-health.test.ts
+++ b/src/__tests__/routes-health.test.ts
@@ -54,6 +54,35 @@ describe('Health routes', () => {
     await app.register(healthRoutes, { prefix: '/api' });
   });
 
+  /**
+   * Helper: mark the next request as admin. The health route only exposes
+   * `encryption`, `auth`, `stripe`, and `memory` details to admin users
+   * (prevent info disclosure). Tests that want those branches need the
+   * decorated `request.user.tier = 'admin'`.
+   */
+  function injectAsAdmin(url: string) {
+    return app.inject({
+      method: 'GET',
+      url,
+      // Fastify's `.inject()` supports `server` + `cookies` + `headers`;
+      // we pipe the admin tier through a request header that the hook
+      // below converts into `request.user`.
+      headers: { 'x-test-tier': 'admin' },
+    });
+  }
+
+  // Register the hook once — idempotent: onRequest runs per-request and
+  // honors the test's `x-test-tier` header to fake the admin gate.
+  beforeEach(() => {
+    app.addHook('onRequest', (req, _reply, done) => {
+      const tier = req.headers['x-test-tier'];
+      if (tier) {
+        (req as unknown as { user: { tier: string } }).user = { tier: String(tier) };
+      }
+      done();
+    });
+  });
+
   afterEach(async () => {
     await app.close();
     vi.restoreAllMocks();
@@ -96,12 +125,15 @@ describe('Health routes', () => {
       expect(body.memory).toBeUndefined();
     });
 
-    it('reports encryption warning when authenticated and key not set', async () => {
+    it('reports encryption warning when admin and key not set', async () => {
+      // Encryption / auth / stripe / memory details are admin-only (info
+      // disclosure hardening). Mark the request as admin via the test
+      // helper.
       prisma.$queryRaw.mockResolvedValue([{ result: 1 }]);
-      (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({ userId: 'user_123' });
+      (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({ userId: 'user_admin' });
       delete process.env.ENCRYPTION_MASTER_KEY;
 
-      const res = await app.inject({ method: 'GET', url: '/api/health' });
+      const res = await injectAsAdmin('/api/health');
       const body = JSON.parse(res.payload);
       expect(body.checks.encryption.status).toBe('warning');
     });
@@ -115,11 +147,12 @@ describe('Health routes', () => {
       expect(body.checks.redis.status).toBe('info');
     });
 
-    it('includes memory stats for authenticated users', async () => {
+    it('includes memory stats for admin users', async () => {
+      // Memory stats are admin-only (info disclosure hardening).
       prisma.$queryRaw.mockResolvedValue([{ result: 1 }]);
-      (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({ userId: 'user_123' });
+      (getAuth as ReturnType<typeof vi.fn>).mockReturnValue({ userId: 'user_admin' });
 
-      const res = await app.inject({ method: 'GET', url: '/api/health' });
+      const res = await injectAsAdmin('/api/health');
       const body = JSON.parse(res.payload);
       expect(body.memory).toBeDefined();
       expect(body.memory.rss).toMatch(/MB$/);

--- a/src/__tests__/routes-locations.test.ts
+++ b/src/__tests__/routes-locations.test.ts
@@ -158,12 +158,22 @@ describe('GET /api/locations/:id', () => {
   });
 
   it('returns full location data with version', async () => {
+    // The route pulls `name` / `country` / `region` / `currency` /
+    // `monthlyCostTotal` / `updatedAt` from the top-level Prisma row
+    // (denormalized search columns), and merges `locationData` underneath.
+    // Test fixture must supply both.
     (prisma.adminLocation.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
       id: 'fairfax-va',
       version: 3,
+      name: 'Fairfax, VA',
+      country: 'United States',
+      region: 'Virginia',
+      currency: 'USD',
+      monthlyCostTotal: 4500,
+      updatedAt: new Date('2026-01-15'),
       locationData: {
         name: 'Fairfax, VA',
-        country: 'USA',
+        country: 'United States',
         monthlyCosts: { rent: { typical: 2200 } },
       },
     });

--- a/src/__tests__/routes-webhooks.test.ts
+++ b/src/__tests__/routes-webhooks.test.ts
@@ -179,10 +179,15 @@ describe('Webhook routes', () => {
     });
   });
 
-  // ─── customer.subscription.updated ───────────────────────────────
+  // ─── customer.subscription.updated (legacy — no-op for grandfathered) ──
+  //
+  // The billing model moved from subscriptions to one-time feature unlocks.
+  // The legacy subscription.* events are now **acknowledged but never
+  // change user tiers** — grandfathered users retain access regardless of
+  // their subscription lifecycle. The handler just logs and returns 200.
 
-  describe('customer.subscription.updated', () => {
-    it('updates tier when subscription is active', async () => {
+  describe('customer.subscription.updated (legacy no-op)', () => {
+    it('acknowledges active subscription without touching tiers', async () => {
       const event = makeEvent('customer.subscription.updated', {
         customer: 'cus_abc',
         status: 'active',
@@ -190,19 +195,14 @@ describe('Webhook routes', () => {
       });
 
       mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      prisma.user.update.mockResolvedValue({});
 
       const res = await postWebhook();
 
       expect(res.statusCode).toBe(200);
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-1' },
-        data: { tier: 'premium' },
-      });
+      expect(prisma.user.update).not.toHaveBeenCalled();
     });
 
-    it('downgrades to free when subscription is not active', async () => {
+    it('acknowledges past_due subscription without downgrading', async () => {
       const event = makeEvent('customer.subscription.updated', {
         customer: 'cus_abc',
         status: 'past_due',
@@ -210,47 +210,23 @@ describe('Webhook routes', () => {
       });
 
       mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      prisma.user.update.mockResolvedValue({});
 
       const res = await postWebhook();
 
       expect(res.statusCode).toBe(200);
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-1' },
-        data: { tier: 'free' },
-      });
+      expect(prisma.user.update).not.toHaveBeenCalled();
     });
   });
 
-  // ─── customer.subscription.deleted ───────────────────────────────
+  // ─── customer.subscription.deleted (legacy — no-op for grandfathered) ──
 
-  describe('customer.subscription.deleted', () => {
-    it('reverts user to free tier on cancellation', async () => {
+  describe('customer.subscription.deleted (legacy no-op)', () => {
+    it('acknowledges cancellation without reverting tier', async () => {
       const event = makeEvent('customer.subscription.deleted', {
         customer: 'cus_abc',
       });
 
       mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.user.findFirst.mockResolvedValue({ id: 'user-1' });
-      prisma.user.update.mockResolvedValue({});
-
-      const res = await postWebhook();
-
-      expect(res.statusCode).toBe(200);
-      expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-1' },
-        data: { tier: 'free' },
-      });
-    });
-
-    it('handles user not found gracefully', async () => {
-      const event = makeEvent('customer.subscription.deleted', {
-        customer: 'cus_gone',
-      });
-
-      mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.user.findFirst.mockResolvedValue(null);
 
       const res = await postWebhook();
 
@@ -286,7 +262,11 @@ describe('Webhook routes', () => {
       });
 
       mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.processedEvent.findUnique.mockResolvedValue({ eventId: event.id });
+      // Idempotency uses insert-first with unique-constraint catch: when
+      // the event already exists, `processedEvent.create` throws P2002.
+      prisma.processedEvent.create.mockRejectedValue(
+        Object.assign(new Error('duplicate'), { code: 'P2002' }),
+      );
 
       const res = await postWebhook();
 
@@ -302,7 +282,6 @@ describe('Webhook routes', () => {
       });
 
       mockStripe.webhooks.constructEvent.mockReturnValue(event);
-      prisma.processedEvent.findUnique.mockResolvedValue(null);
       prisma.processedEvent.create.mockResolvedValue({});
 
       const res = await postWebhook();


### PR DESCRIPTION
## Summary
Closes the final test-drift gap on retirement-api master. All 15 pre-existing test failures identified during the 2026-04-20 lockdown work are now passing: **35,383 passing / 0 failing** (was 35,367 / 15).

Pairs with [retirement-api #24](https://github.com/justice8096/retirement-api/pull/24) (tax law fixes) and the earlier [#12 lockdown](https://github.com/justice8096/retirement-api/pull/12). After this lands, the \`lint-and-test (20)\` and \`lint-and-test (22)\` CI jobs should go green — then a small follow-up re-adds them to the required-status-checks list.

## What drifted

| File | Fail count | Root cause |
|---|---|---|
| \`routes-billing.test.ts\` | 8 | Billing model changed from subscriptions (\`POST /checkout\` + \`priceId\`) to one-time feature unlocks (\`POST /checkout-feature\` + \`featureSet\`). Tests never updated. |
| \`routes-webhooks.test.ts\` | 4 | Legacy \`customer.subscription.*\` events are now documented no-ops for grandfathered users. Tests still expected \`prisma.user.update\` calls. Also: idempotency uses \`create + catch P2002\` now, not \`findUnique\` + \`create\`. |
| \`routes-health.test.ts\` | 2 | \`encryption\` / \`memory\` / \`auth\` / \`stripe\` fields are admin-only now (info-disclosure hardening). Tests expected them at "authenticated" tier. |
| \`routes-locations.test.ts\` | 1 | \`GET /:id\` pulls \`name\` / \`country\` / \`region\` from denormalized top-level Prisma columns, not \`locationData\`. Test fixture only populated the nested copy. |

## Fixes

### Billing (13 cases, all green)
- Switched URL: \`/api/billing/checkout\` → \`/api/billing/checkout-feature\`.
- Payload: \`{ priceId }\` → \`{ featureSet: 'basic' | 'premium' }\`.
- Added mocks for \`userFeatureUnlock.findUnique\` (existence gate), the multi-table \`/status\` query (\`userFeatureUnlock.findMany\`, \`userReleasePurchase.findMany\`, \`dataRelease.findFirst\`, \`userBadge.findMany\` / \`findFirst\`), and \`prisma.user.updateMany\` for the \`ensureStripeCustomer\` optimistic-concurrency path (SAST L-NEW-02).
- New 409-\"already unlocked\" test.
- New founding-member-badge test for the status endpoint.

### Webhooks (13 cases, all green)
- Inverted the \`subscription.updated\` / \`.deleted\` tests to assert no tier change — matches \"grandfathered users retain access\" policy.
- Idempotency: switched to \`processedEvent.create.mockRejectedValue(P2002)\` — the current insert-first pattern.

### Health (11 cases, all green)
- Added a \`beforeEach\` hook that reads an \`x-test-tier\` request header and decorates \`request.user.tier\` accordingly.
- New helper: \`injectAsAdmin(url)\`.
- Updated the two admin-gated tests (encryption warning, memory stats) to use it.

### Locations (18 cases, all green)
- Added the top-level denormalized columns (\`name\`, \`country\`, \`region\`, \`currency\`, \`monthlyCostTotal\`, \`updatedAt\`) to the \`findUnique\` fixture.

## Test plan
- [x] \`npm test\` passes 35,383 / 35,383
- [x] \`npm run typecheck\` clean
- [x] No test file grew from passing to failing

## Follow-up
Small PR to re-add \`lint-and-test (20)\` + \`lint-and-test (22)\` to master's required status checks. Currently relaxed to let the lockdown PR land around the broken tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)