### PR TITLE
fix(law): strip 2025 federal-bracket overrides from 31 seed JSONs

### DIFF
--- a/data/locations/france-brittany/location.json
+++ b/data/locations/france-brittany/location.json
@@ -190,44 +190,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/france-lyon/location.json
+++ b/data/locations/france-lyon/location.json
@@ -178,44 +178,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/france-montpellier/location.json
+++ b/data/locations/france-montpellier/location.json
@@ -179,44 +179,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/france-toulouse/location.json
+++ b/data/locations/france-toulouse/location.json
@@ -186,44 +186,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/ireland-waterford/location.json
+++ b/data/locations/ireland-waterford/location.json
@@ -191,44 +191,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/panama-boquete/location.json
+++ b/data/locations/panama-boquete/location.json
@@ -185,45 +185,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0,

--- a/data/locations/panama-city/location.json
+++ b/data/locations/panama-city/location.json
@@ -182,45 +182,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0,

--- a/data/locations/portugal-lisbon/location.json
+++ b/data/locations/portugal-lisbon/location.json
@@ -184,44 +184,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/spain-alicante/location.json
+++ b/data/locations/spain-alicante/location.json
@@ -185,44 +185,6 @@
   "taxes": {
     "federalIncomeTax": {
       "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000,
       "foreignTaxCredit": true
     },
     "stateIncomeTax": {

--- a/data/locations/us-annandale-va/location.json
+++ b/data/locations/us-annandale-va/location.json
@@ -3,54 +3,198 @@
   "name": "Annandale VA, USA",
   "country": "United States",
   "region": "Virginia",
-  "cities": ["Annandale", "Bailey's Crossroads", "Seven Corners"],
+  "cities": [
+    "Annandale",
+    "Bailey's Crossroads",
+    "Seven Corners"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 24, "summerHighF": 90, "rainyDaysPerYear": 112, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 24,
+    "summerHighF": 90,
+    "rainyDaysPerYear": 112,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1850, "max": 2600, "typical": 2150, "type": "2-bedroom older SFH/townhome", "annualInflation": 0.035, "notes": "Older housing stock, immigrant commercial scene. ~25% cheaper than Fairfax City for comparable 2BR. Fairfax County." },
-    "groceries": { "min": 1300, "max": 1720, "typical": 1510, "annualInflation": 0.03, "notes": "Korean + Latino supermarkets (H Mart, Grand Mart) notably cheaper than Wegmans/Giant. Mixed shopper saves ~10% vs Fairfax average." },
-    "utilities": { "min": 270, "max": 440, "typical": 340, "annualInflation": 0.03, "notes": "Dominion Energy + Washington Gas + Fairfax Water." },
-    "healthcare": { "min": 550, "max": 850, "typical": 650, "notes": "Same Medicare baseline as Fairfax County. Inova Fairfax Hospital 8 min away.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 130, "max": 235, "typical": 175, "annualInflation": 0.04 },
-    "petDaycare": { "min": 320, "max": 500, "typical": 400, "annualInflation": 0.035 },
-    "petGrooming": { "min": 85, "max": 160, "typical": 120, "annualInflation": 0.03 },
-    "transportation": { "min": 240, "max": 480, "typical": 360, "annualInflation": 0.03, "notes": "Dunn Loring Metro (Orange line) 10 min. Interstate 495 + Interstate 395 access. Better Metro proximity than Fairfax City." },
-    "entertainment": { "min": 420, "max": 620, "typical": 510, "annualInflation": 0.025, "notes": "Korean BBQ district (Little Seoul), diverse dining. Cable+1Gig included." },
-    "clothing": { "min": 100, "max": 240, "typical": 155, "annualInflation": 0.02 },
-    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 115, "max": 240, "typical": 165, "annualInflation": 0.025, "notes": "HOA (homeowners association) dues, EZ-Pass tolls, Fairfax County vehicle tax." },
-    "buffer": { "min": 800, "max": 800, "typical": 800, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile (macular degeneration, specialists at Inova/Johns Hopkins)." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets; stored value 0 by convention." },
-    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2300, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). Northern Virginia (NOVA) marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1850,
+      "max": 2600,
+      "typical": 2150,
+      "type": "2-bedroom older SFH/townhome",
+      "annualInflation": 0.035,
+      "notes": "Older housing stock, immigrant commercial scene. ~25% cheaper than Fairfax City for comparable 2BR. Fairfax County."
+    },
+    "groceries": {
+      "min": 1300,
+      "max": 1720,
+      "typical": 1510,
+      "annualInflation": 0.03,
+      "notes": "Korean + Latino supermarkets (H Mart, Grand Mart) notably cheaper than Wegmans/Giant. Mixed shopper saves ~10% vs Fairfax average."
+    },
+    "utilities": {
+      "min": 270,
+      "max": 440,
+      "typical": 340,
+      "annualInflation": 0.03,
+      "notes": "Dominion Energy + Washington Gas + Fairfax Water."
+    },
+    "healthcare": {
+      "min": 550,
+      "max": 850,
+      "typical": 650,
+      "notes": "Same Medicare baseline as Fairfax County. Inova Fairfax Hospital 8 min away.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 130,
+      "max": 235,
+      "typical": 175,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 320,
+      "max": 500,
+      "typical": 400,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 85,
+      "max": 160,
+      "typical": 120,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 240,
+      "max": 480,
+      "typical": 360,
+      "annualInflation": 0.03,
+      "notes": "Dunn Loring Metro (Orange line) 10 min. Interstate 495 + Interstate 395 access. Better Metro proximity than Fairfax City."
+    },
+    "entertainment": {
+      "min": 420,
+      "max": 620,
+      "typical": 510,
+      "annualInflation": 0.025,
+      "notes": "Korean BBQ district (Little Seoul), diverse dining. Cable+1Gig included."
+    },
+    "clothing": {
+      "min": 100,
+      "max": 240,
+      "typical": 155,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 45,
+      "max": 105,
+      "typical": 68,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 115,
+      "max": 240,
+      "typical": 165,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) dues, EZ-Pass tolls, Fairfax County vehicle tax."
+    },
+    "buffer": {
+      "min": 800,
+      "max": 800,
+      "typical": 800,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile (macular degeneration, specialists at Inova/Johns Hopkins)."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from VA brackets; stored value 0 by convention."
+    },
+    "healthcarePreMedicare": {
+      "min": 1800,
+      "max": 2800,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). Northern Virginia (NOVA) marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0575, "type": "top-marginal",
+      "rate": 0.0575,
+      "type": "top-marginal",
       "brackets": [
-        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
-        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+        {
+          "min": 0,
+          "max": 3000,
+          "rate": 0.02
+        },
+        {
+          "min": 3000,
+          "max": 5000,
+          "rate": 0.03
+        },
+        {
+          "min": 5000,
+          "max": 17000,
+          "rate": 0.05
+        },
+        {
+          "min": 17000,
+          "max": null,
+          "rate": 0.0575
+        }
       ],
-      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+      "deduction": 24000,
+      "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
     },
-    "salesTax": { "rate": 0.06, "notes": "Fairfax County 6% (4.3% state + 0.7% regional + 1% Northern Virginia (NOVA) transit)" },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Fairfax County vehicle personal property ~$4.57/$100 assessed." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Fairfax County 6% (4.3% state + 0.7% regional + 1% Northern Virginia (NOVA) transit)"
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Fairfax County vehicle personal property ~$4.57/$100 assessed."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 1200,
@@ -59,18 +203,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 9, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 9,
+    "waitTimes": "low-moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Inova Fairfax Medical Center (Level I trauma) 8 min away. Same healthcare infrastructure as Fairfax City.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2300, "benchmarkSilverMonthlySingle": 1150,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Fairfax County",
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Fairfax County",
       "notes": "Northern Virginia (NOVA) marketplace: Anthem HealthKeepers, CareFirst, Kaiser. Metro pricing.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Verizon Fios, Cox)",
-    "dogFriendly": 7, "expatCommunity": 7, "englishPrevalence": 9, "safetyRating": 8,
+    "dogFriendly": 7,
+    "expatCommunity": 7,
+    "englishPrevalence": 9,
+    "safetyRating": 8,
     "notes": "Strong Korean and Central/South American communities. Mason District Park, Lake Accotink nearby. Easier Metro access than Fairfax City."
   },
   "pros": [

--- a/data/locations/us-annapolis-md/location.json
+++ b/data/locations/us-annapolis-md/location.json
@@ -161,45 +161,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.078,

--- a/data/locations/us-atlanta/location.json
+++ b/data/locations/us-atlanta/location.json
@@ -190,45 +190,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0549,

--- a/data/locations/us-austin/location.json
+++ b/data/locations/us-austin/location.json
@@ -192,45 +192,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0,

--- a/data/locations/us-bowie-md/location.json
+++ b/data/locations/us-bowie-md/location.json
@@ -3,61 +3,218 @@
   "name": "Bowie MD, USA",
   "country": "United States",
   "region": "Maryland",
-  "cities": ["Bowie", "Belair", "Mitchellville"],
+  "cities": [
+    "Bowie",
+    "Belair",
+    "Mitchellville"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 26, "summerHighF": 88, "rainyDaysPerYear": 113, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 26,
+    "summerHighF": 88,
+    "rainyDaysPerYear": 113,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1850, "max": 2600, "typical": 2150, "type": "2-bedroom SFH / townhome", "annualInflation": 0.035, "notes": "Prince George's County — Belair, Mitchellville, Saddlebrook subdivisions. Mid-priced MD suburb; cheaper than Annapolis, more than Baltimore." },
-    "groceries": { "min": 1280, "max": 1680, "typical": 1460, "annualInflation": 0.03, "notes": "Wegmans, Giant, Safeway, Harris Teeter. Similar to Annapolis pricing." },
-    "utilities": { "min": 260, "max": 420, "typical": 335, "annualInflation": 0.03, "notes": "BGE or Pepco electric + Washington Gas + WSSC or City water/sewer." },
-    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Doctors Community Medical Center (Luminis Health), UM Bowie Health Center. Johns Hopkins ~30 mi north.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 125, "max": 225, "typical": 165, "annualInflation": 0.04 },
-    "petDaycare": { "min": 300, "max": 475, "typical": 385, "annualInflation": 0.035 },
-    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
-    "transportation": { "min": 280, "max": 520, "typical": 395, "annualInflation": 0.03, "notes": "MARC (Maryland Area Regional Commuter) Penn Line at Bowie State to DC (~40 min). US Route 50 to Annapolis/DC. Capital Beltway access. Car-dependent outside rail corridor." },
-    "entertainment": { "min": 410, "max": 600, "typical": 495, "annualInflation": 0.025, "notes": "Allen Pond Park, Bowie Town Center, NASA Goddard Visitor Center nearby. Cable+1Gig typical." },
-    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
-    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 110, "max": 230, "typical": 160, "annualInflation": 0.025, "notes": "HOA (homeowners association) common in Bowie subdivisions. ICC (Intercounty Connector toll road)/Route 200 and Bay Bridge tolls. Prince George's County (PG County) taxes relatively high." },
-    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialists at Johns Hopkins (Baltimore, ~30 mi) or Univ of MD Medical Center (DC/Baltimore)." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Prince George's County brackets." },
-    "healthcarePreMedicare": { "min": 1750, "max": 2700, "typical": 2200, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince George's County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1850,
+      "max": 2600,
+      "typical": 2150,
+      "type": "2-bedroom SFH / townhome",
+      "annualInflation": 0.035,
+      "notes": "Prince George's County — Belair, Mitchellville, Saddlebrook subdivisions. Mid-priced MD suburb; cheaper than Annapolis, more than Baltimore."
+    },
+    "groceries": {
+      "min": 1280,
+      "max": 1680,
+      "typical": 1460,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Giant, Safeway, Harris Teeter. Similar to Annapolis pricing."
+    },
+    "utilities": {
+      "min": 260,
+      "max": 420,
+      "typical": 335,
+      "annualInflation": 0.03,
+      "notes": "BGE or Pepco electric + Washington Gas + WSSC or City water/sewer."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "notes": "Medicare baseline. Doctors Community Medical Center (Luminis Health), UM Bowie Health Center. Johns Hopkins ~30 mi north.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 125,
+      "max": 225,
+      "typical": 165,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 300,
+      "max": 475,
+      "typical": 385,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 85,
+      "max": 155,
+      "typical": 115,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 280,
+      "max": 520,
+      "typical": 395,
+      "annualInflation": 0.03,
+      "notes": "MARC (Maryland Area Regional Commuter) Penn Line at Bowie State to DC (~40 min). US Route 50 to Annapolis/DC. Capital Beltway access. Car-dependent outside rail corridor."
+    },
+    "entertainment": {
+      "min": 410,
+      "max": 600,
+      "typical": 495,
+      "annualInflation": 0.025,
+      "notes": "Allen Pond Park, Bowie Town Center, NASA Goddard Visitor Center nearby. Cable+1Gig typical."
+    },
+    "clothing": {
+      "min": 95,
+      "max": 230,
+      "typical": 150,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 45,
+      "max": 105,
+      "typical": 68,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 110,
+      "max": 230,
+      "typical": 160,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) common in Bowie subdivisions. ICC (Intercounty Connector toll road)/Route 200 and Bay Bridge tolls. Prince George's County (PG County) taxes relatively high."
+    },
+    "buffer": {
+      "min": 750,
+      "max": 750,
+      "typical": 750,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. Specialists at Johns Hopkins (Baltimore, ~30 mi) or Univ of MD Medical Center (DC/Baltimore)."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from MD + Prince George's County brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1750,
+      "max": 2700,
+      "typical": 2200,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince George's County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0795, "type": "combined-state-plus-county",
+      "rate": 0.0795,
+      "type": "combined-state-plus-county",
       "brackets": [
-        { "min": 0, "max": 1000, "rate": 0.0520 },
-        { "min": 1000, "max": 2000, "rate": 0.0620 },
-        { "min": 2000, "max": 3000, "rate": 0.0720 },
-        { "min": 3000, "max": 100000, "rate": 0.0795 },
-        { "min": 100000, "max": 125000, "rate": 0.0820 },
-        { "min": 125000, "max": 150000, "rate": 0.0845 },
-        { "min": 150000, "max": 250000, "rate": 0.0870 },
-        { "min": 250000, "max": null, "rate": 0.0895 }
+        {
+          "min": 0,
+          "max": 1000,
+          "rate": 0.052
+        },
+        {
+          "min": 1000,
+          "max": 2000,
+          "rate": 0.062
+        },
+        {
+          "min": 2000,
+          "max": 3000,
+          "rate": 0.072
+        },
+        {
+          "min": 3000,
+          "max": 100000,
+          "rate": 0.0795
+        },
+        {
+          "min": 100000,
+          "max": 125000,
+          "rate": 0.082
+        },
+        {
+          "min": 125000,
+          "max": 150000,
+          "rate": 0.0845
+        },
+        {
+          "min": 150000,
+          "max": 250000,
+          "rate": 0.087
+        },
+        {
+          "min": 250000,
+          "max": null,
+          "rate": 0.0895
+        }
       ],
       "deduction": 5150,
       "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates are combined MD state + Prince George's County piggyback (3.20% — highest county rate in MD)."
     },
-    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax — significant savings vs VA." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Maryland statewide 6%; no local add-ons."
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax — significant savings vs VA."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 0,
@@ -66,18 +223,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 8, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 8,
+    "waitTimes": "low-moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Luminis Health Doctors Community Medical Center, UM Bowie Health Center, Prince George's Hospital Center. Access to Johns Hopkins (Baltimore, ~30 mi) and Univ of MD Medical Center.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2200, "benchmarkSilverMonthlySingle": 1100,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Prince George's County",
+      "benchmarkSilverMonthly2Adult": 2200,
+      "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Prince George's County",
       "notes": "Maryland Health Connection: CareFirst BlueCross, Kaiser Permanente, UnitedHealthcare. Prince George's County (PG County) rating area — similar to Anne Arundel.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Comcast/Xfinity, Verizon Fios partial)",
-    "dogFriendly": 8, "expatCommunity": 2, "englishPrevalence": 10, "safetyRating": 7,
+    "dogFriendly": 8,
+    "expatCommunity": 2,
+    "englishPrevalence": 10,
+    "safetyRating": 7,
     "notes": "Allen Pond Park, Bowie Baysox minor league baseball, NASA Goddard Visitor Center. Planned community (William Levitt 1960s). Good schools reputation. Strong historic African-American community."
   },
   "pros": [

--- a/data/locations/us-camden-nj/location.json
+++ b/data/locations/us-camden-nj/location.json
@@ -191,45 +191,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0637,

--- a/data/locations/us-catonsville-md/location.json
+++ b/data/locations/us-catonsville-md/location.json
@@ -3,61 +3,218 @@
   "name": "Catonsville MD, USA",
   "country": "United States",
   "region": "Maryland",
-  "cities": ["Catonsville", "Oella", "Arbutus"],
+  "cities": [
+    "Catonsville",
+    "Oella",
+    "Arbutus"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 25, "summerHighF": 88, "rainyDaysPerYear": 114, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 25,
+    "summerHighF": 88,
+    "rainyDaysPerYear": 114,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1750, "max": 2450, "typical": 2050, "type": "2-bedroom older SFH / townhome", "annualInflation": 0.035, "notes": "Baltimore County — mature tree-lined neighborhoods along Frederick Road corridor, historic Oella (mill village) to south. UMBC (University of Maryland, Baltimore County) + Catonsville Community College keep area vibrant." },
-    "groceries": { "min": 1270, "max": 1670, "typical": 1445, "annualInflation": 0.03, "notes": "Wegmans, Giant, Harris Teeter, Trader Joe's, H Mart (Korean). Strong grocery variety for the price point." },
-    "utilities": { "min": 255, "max": 415, "typical": 330, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + Baltimore County DPW water/sewer." },
-    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. UM St. Agnes Hospital 5 min, Johns Hopkins campus 15 min, UM Medical Center (Baltimore) 15 min. Exceptional specialist density.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 125, "max": 225, "typical": 165, "annualInflation": 0.04 },
-    "petDaycare": { "min": 300, "max": 475, "typical": 385, "annualInflation": 0.035 },
-    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
-    "transportation": { "min": 275, "max": 510, "typical": 390, "annualInflation": 0.03, "notes": "MTA (Maryland Transit Administration) bus to Baltimore. Light Rail 15 min (via car). Interstate 95/Interstate 695 access. BWI (Baltimore-Washington International airport) 20 min. No direct MARC station; Penn Line at Baltimore Penn Station 15 min." },
-    "entertainment": { "min": 415, "max": 605, "typical": 500, "annualInflation": 0.025, "notes": "Walkable Frederick Road commercial strip, Patapsco Valley State Park trails, UMBC (University of Maryland, Baltimore County) events + Fine Arts shows, Catonsville Arts District. Cable+1Gig typical." },
-    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
-    "personalCare": { "min": 45, "max": 105, "typical": 68, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 110, "max": 225, "typical": 160, "annualInflation": 0.025, "notes": "Fewer HOAs (homeowners associations) than newer MD suburbs. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Baltimore County piggyback 3.20%." },
-    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. World-class specialist access: UM St. Agnes in town, Johns Hopkins + UM Medical Center 15 min. One of the best healthcare locations for complex retirees." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Baltimore County brackets." },
-    "healthcarePreMedicare": { "min": 1700, "max": 2600, "typical": 2100, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Baltimore County, MD). Maryland Health Connection — Baltimore metro competitive marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1750,
+      "max": 2450,
+      "typical": 2050,
+      "type": "2-bedroom older SFH / townhome",
+      "annualInflation": 0.035,
+      "notes": "Baltimore County — mature tree-lined neighborhoods along Frederick Road corridor, historic Oella (mill village) to south. UMBC (University of Maryland, Baltimore County) + Catonsville Community College keep area vibrant."
+    },
+    "groceries": {
+      "min": 1270,
+      "max": 1670,
+      "typical": 1445,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Giant, Harris Teeter, Trader Joe's, H Mart (Korean). Strong grocery variety for the price point."
+    },
+    "utilities": {
+      "min": 255,
+      "max": 415,
+      "typical": 330,
+      "annualInflation": 0.03,
+      "notes": "BGE electric + Washington Gas + Baltimore County DPW water/sewer."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "notes": "Medicare baseline. UM St. Agnes Hospital 5 min, Johns Hopkins campus 15 min, UM Medical Center (Baltimore) 15 min. Exceptional specialist density.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 125,
+      "max": 225,
+      "typical": 165,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 300,
+      "max": 475,
+      "typical": 385,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 85,
+      "max": 155,
+      "typical": 115,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 275,
+      "max": 510,
+      "typical": 390,
+      "annualInflation": 0.03,
+      "notes": "MTA (Maryland Transit Administration) bus to Baltimore. Light Rail 15 min (via car). Interstate 95/Interstate 695 access. BWI (Baltimore-Washington International airport) 20 min. No direct MARC station; Penn Line at Baltimore Penn Station 15 min."
+    },
+    "entertainment": {
+      "min": 415,
+      "max": 605,
+      "typical": 500,
+      "annualInflation": 0.025,
+      "notes": "Walkable Frederick Road commercial strip, Patapsco Valley State Park trails, UMBC (University of Maryland, Baltimore County) events + Fine Arts shows, Catonsville Arts District. Cable+1Gig typical."
+    },
+    "clothing": {
+      "min": 95,
+      "max": 230,
+      "typical": 150,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 45,
+      "max": 105,
+      "typical": 68,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 110,
+      "max": 225,
+      "typical": 160,
+      "annualInflation": 0.025,
+      "notes": "Fewer HOAs (homeowners associations) than newer MD suburbs. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Baltimore County piggyback 3.20%."
+    },
+    "buffer": {
+      "min": 750,
+      "max": 750,
+      "typical": 750,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. World-class specialist access: UM St. Agnes in town, Johns Hopkins + UM Medical Center 15 min. One of the best healthcare locations for complex retirees."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from MD + Baltimore County brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1700,
+      "max": 2600,
+      "typical": 2100,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Baltimore County, MD). Maryland Health Connection — Baltimore metro competitive marketplace. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0795, "type": "combined-state-plus-county",
+      "rate": 0.0795,
+      "type": "combined-state-plus-county",
       "brackets": [
-        { "min": 0, "max": 1000, "rate": 0.0520 },
-        { "min": 1000, "max": 2000, "rate": 0.0620 },
-        { "min": 2000, "max": 3000, "rate": 0.0720 },
-        { "min": 3000, "max": 100000, "rate": 0.0795 },
-        { "min": 100000, "max": 125000, "rate": 0.0820 },
-        { "min": 125000, "max": 150000, "rate": 0.0845 },
-        { "min": 150000, "max": 250000, "rate": 0.0870 },
-        { "min": 250000, "max": null, "rate": 0.0895 }
+        {
+          "min": 0,
+          "max": 1000,
+          "rate": 0.052
+        },
+        {
+          "min": 1000,
+          "max": 2000,
+          "rate": 0.062
+        },
+        {
+          "min": 2000,
+          "max": 3000,
+          "rate": 0.072
+        },
+        {
+          "min": 3000,
+          "max": 100000,
+          "rate": 0.0795
+        },
+        {
+          "min": 100000,
+          "max": 125000,
+          "rate": 0.082
+        },
+        {
+          "min": 125000,
+          "max": 150000,
+          "rate": 0.0845
+        },
+        {
+          "min": 150000,
+          "max": 250000,
+          "rate": 0.087
+        },
+        {
+          "min": 250000,
+          "max": null,
+          "rate": 0.0895
+        }
       ],
       "deduction": 5150,
       "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Combined MD state + Baltimore County piggyback (3.20%)."
     },
-    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Maryland statewide 6%; no local add-ons."
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 0,
@@ -66,18 +223,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 9,
+    "waitTimes": "low",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Outstanding healthcare density: UM St. Agnes Hospital in town (5 min), Johns Hopkins Bayview + Hopkins main campus 15-20 min, UM Medical Center (Baltimore) 15 min, GBMC 20 min. Excellent for complex retiree medical needs.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2100, "benchmarkSilverMonthlySingle": 1050,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Baltimore County",
+      "benchmarkSilverMonthly2Adult": 2100,
+      "benchmarkSilverMonthlySingle": 1050,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Baltimore County",
       "notes": "Maryland Health Connection — Baltimore County rating area (competitive metro marketplace).",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Comcast/Xfinity)",
-    "dogFriendly": 9, "expatCommunity": 4, "englishPrevalence": 10, "safetyRating": 8,
+    "dogFriendly": 9,
+    "expatCommunity": 4,
+    "englishPrevalence": 10,
+    "safetyRating": 8,
     "notes": "Walkable Frederick Road commercial district with local restaurants, breweries, and the historic Catonsville Lumber. Patapsco Valley State Park trails literally in town. UMBC (University of Maryland, Baltimore County) campus cultural events. Strong schools and mature tree-lined neighborhoods. Historic Oella mill village walkable from downtown."
   },
   "pros": [

--- a/data/locations/us-cherry-hill/location.json
+++ b/data/locations/us-cherry-hill/location.json
@@ -191,45 +191,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0637,

--- a/data/locations/us-chesapeake-va/location.json
+++ b/data/locations/us-chesapeake-va/location.json
@@ -165,45 +165,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0575,

--- a/data/locations/us-elkridge-md/location.json
+++ b/data/locations/us-elkridge-md/location.json
@@ -3,61 +3,218 @@
   "name": "Elkridge MD, USA",
   "country": "United States",
   "region": "Maryland",
-  "cities": ["Elkridge", "Jessup", "Savage"],
+  "cities": [
+    "Elkridge",
+    "Jessup",
+    "Savage"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 25, "summerHighF": 88, "rainyDaysPerYear": 114, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 25,
+    "summerHighF": 88,
+    "rainyDaysPerYear": 114,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1900, "max": 2700, "typical": 2250, "type": "2-bedroom townhome / SFH", "annualInflation": 0.035, "notes": "Howard County — affluent commuter suburb between DC and Baltimore. Cheaper than Columbia/Ellicott City but premium for MD. Newer townhome developments along US-1 corridor." },
-    "groceries": { "min": 1300, "max": 1680, "typical": 1480, "annualInflation": 0.03, "notes": "Wegmans, Giant, Whole Foods, Harris Teeter. Slightly above Baltimore but similar to Annapolis." },
-    "utilities": { "min": 265, "max": 425, "typical": 340, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + Howard County DPW water/sewer." },
-    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Howard County General Hospital (Johns Hopkins affiliate), UM Baltimore Washington Medical Center 15 min. Direct Johns Hopkins access 20 min.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 130, "max": 230, "typical": 170, "annualInflation": 0.04 },
-    "petDaycare": { "min": 310, "max": 490, "typical": 395, "annualInflation": 0.035 },
-    "petGrooming": { "min": 85, "max": 160, "typical": 120, "annualInflation": 0.03 },
-    "transportation": { "min": 290, "max": 540, "typical": 410, "annualInflation": 0.03, "notes": "MARC (Maryland Area Regional Commuter) Camden Line at Dorsey/Savage stations to DC Union Station (~45 min). Interstate 95 corridor. BWI (Baltimore-Washington International) Airport 10 min. Capital Beltway access." },
-    "entertainment": { "min": 420, "max": 615, "typical": 505, "annualInflation": 0.025, "notes": "Patapsco Valley State Park, Arundel Mills shopping, Blob's Park. Cable+1Gig typical (Comcast/Xfinity, Verizon Fios)." },
-    "clothing": { "min": 95, "max": 235, "typical": 155, "annualInflation": 0.02 },
-    "personalCare": { "min": 45, "max": 108, "typical": 70, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 115, "max": 235, "typical": 165, "annualInflation": 0.025, "notes": "HOA (homeowners association) common in townhome communities. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Howard County piggyback 3.20%." },
-    "buffer": { "min": 750, "max": 750, "typical": 750, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Excellent specialist access: Johns Hopkins (20 min), Howard County General (Hopkins affiliate), UM BWMC (University of Maryland Baltimore Washington Medical Center)." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Howard County brackets." },
-    "healthcarePreMedicare": { "min": 1750, "max": 2700, "typical": 2200, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Howard County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1900,
+      "max": 2700,
+      "typical": 2250,
+      "type": "2-bedroom townhome / SFH",
+      "annualInflation": 0.035,
+      "notes": "Howard County — affluent commuter suburb between DC and Baltimore. Cheaper than Columbia/Ellicott City but premium for MD. Newer townhome developments along US-1 corridor."
+    },
+    "groceries": {
+      "min": 1300,
+      "max": 1680,
+      "typical": 1480,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Giant, Whole Foods, Harris Teeter. Slightly above Baltimore but similar to Annapolis."
+    },
+    "utilities": {
+      "min": 265,
+      "max": 425,
+      "typical": 340,
+      "annualInflation": 0.03,
+      "notes": "BGE electric + Washington Gas + Howard County DPW water/sewer."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "notes": "Medicare baseline. Howard County General Hospital (Johns Hopkins affiliate), UM Baltimore Washington Medical Center 15 min. Direct Johns Hopkins access 20 min.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 130,
+      "max": 230,
+      "typical": 170,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 310,
+      "max": 490,
+      "typical": 395,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 85,
+      "max": 160,
+      "typical": 120,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 290,
+      "max": 540,
+      "typical": 410,
+      "annualInflation": 0.03,
+      "notes": "MARC (Maryland Area Regional Commuter) Camden Line at Dorsey/Savage stations to DC Union Station (~45 min). Interstate 95 corridor. BWI (Baltimore-Washington International) Airport 10 min. Capital Beltway access."
+    },
+    "entertainment": {
+      "min": 420,
+      "max": 615,
+      "typical": 505,
+      "annualInflation": 0.025,
+      "notes": "Patapsco Valley State Park, Arundel Mills shopping, Blob's Park. Cable+1Gig typical (Comcast/Xfinity, Verizon Fios)."
+    },
+    "clothing": {
+      "min": 95,
+      "max": 235,
+      "typical": 155,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 45,
+      "max": 108,
+      "typical": 70,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 115,
+      "max": 235,
+      "typical": 165,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) common in townhome communities. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Howard County piggyback 3.20%."
+    },
+    "buffer": {
+      "min": 750,
+      "max": 750,
+      "typical": 750,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. Excellent specialist access: Johns Hopkins (20 min), Howard County General (Hopkins affiliate), UM BWMC (University of Maryland Baltimore Washington Medical Center)."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from MD + Howard County brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1750,
+      "max": 2700,
+      "typical": 2200,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Howard County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0795, "type": "combined-state-plus-county",
+      "rate": 0.0795,
+      "type": "combined-state-plus-county",
       "brackets": [
-        { "min": 0, "max": 1000, "rate": 0.0520 },
-        { "min": 1000, "max": 2000, "rate": 0.0620 },
-        { "min": 2000, "max": 3000, "rate": 0.0720 },
-        { "min": 3000, "max": 100000, "rate": 0.0795 },
-        { "min": 100000, "max": 125000, "rate": 0.0820 },
-        { "min": 125000, "max": 150000, "rate": 0.0845 },
-        { "min": 150000, "max": 250000, "rate": 0.0870 },
-        { "min": 250000, "max": null, "rate": 0.0895 }
+        {
+          "min": 0,
+          "max": 1000,
+          "rate": 0.052
+        },
+        {
+          "min": 1000,
+          "max": 2000,
+          "rate": 0.062
+        },
+        {
+          "min": 2000,
+          "max": 3000,
+          "rate": 0.072
+        },
+        {
+          "min": 3000,
+          "max": 100000,
+          "rate": 0.0795
+        },
+        {
+          "min": 100000,
+          "max": 125000,
+          "rate": 0.082
+        },
+        {
+          "min": 125000,
+          "max": 150000,
+          "rate": 0.0845
+        },
+        {
+          "min": 150000,
+          "max": 250000,
+          "rate": 0.087
+        },
+        {
+          "min": 250000,
+          "max": null,
+          "rate": 0.0895
+        }
       ],
       "deduction": 5150,
       "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Combined MD state + Howard County piggyback (3.20% — tied for highest in MD)."
     },
-    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Maryland statewide 6%; no local add-ons."
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 0,
@@ -66,18 +223,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 9,
+    "waitTimes": "low",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Exceptional healthcare access: Howard County General (Johns Hopkins affiliate), UM Baltimore Washington Medical Center, full Johns Hopkins system 20 min. One of best healthcare-access locations in the region.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2200, "benchmarkSilverMonthlySingle": 1100,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Howard County",
+      "benchmarkSilverMonthly2Adult": 2200,
+      "benchmarkSilverMonthlySingle": 1100,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Howard County",
       "notes": "Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Howard County rating area — competitive marketplace.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Comcast/Xfinity, Verizon Fios)",
-    "dogFriendly": 8, "expatCommunity": 3, "englishPrevalence": 10, "safetyRating": 9,
+    "dogFriendly": 8,
+    "expatCommunity": 3,
+    "englishPrevalence": 10,
+    "safetyRating": 9,
     "notes": "Patapsco Valley State Park trails, Arundel Mills mega-mall, Live! Casino. Strong Howard County schools reputation. Diverse demographics. BWI (Baltimore-Washington International) Airport 10 min."
   },
   "pros": [

--- a/data/locations/us-florida/location.json
+++ b/data/locations/us-florida/location.json
@@ -186,45 +186,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0,

--- a/data/locations/us-gainesville-va/location.json
+++ b/data/locations/us-gainesville-va/location.json
@@ -161,45 +161,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0575,

--- a/data/locations/us-glen-burnie-md/location.json
+++ b/data/locations/us-glen-burnie-md/location.json
@@ -3,61 +3,219 @@
   "name": "Glen Burnie MD, USA",
   "country": "United States",
   "region": "Maryland",
-  "cities": ["Glen Burnie", "Ferndale", "Brooklyn Park", "Linthicum"],
+  "cities": [
+    "Glen Burnie",
+    "Ferndale",
+    "Brooklyn Park",
+    "Linthicum"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 26, "summerHighF": 88, "rainyDaysPerYear": 113, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 26,
+    "summerHighF": 88,
+    "rainyDaysPerYear": 113,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1600, "max": 2250, "typical": 1900, "type": "2-bedroom townhome / older SFH", "annualInflation": 0.035, "notes": "Anne Arundel County — older working-class suburb, established neighborhoods. Among cheapest viable rent in MD metro area. BWI airport + Glen Burnie Town Center shopping." },
-    "groceries": { "min": 1230, "max": 1620, "typical": 1410, "annualInflation": 0.03, "notes": "Giant, Safeway, Weis. Budget-friendly; Aldi + Lidl nearby for further savings." },
-    "utilities": { "min": 250, "max": 410, "typical": 320, "annualInflation": 0.03, "notes": "BGE electric + Washington Gas + AACO water/sewer." },
-    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. UM Baltimore Washington Medical Center in town — major regional hospital with Level II trauma, heart, cancer centers. Johns Hopkins 20 min.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 120, "max": 215, "typical": 160, "annualInflation": 0.04 },
-    "petDaycare": { "min": 295, "max": 465, "typical": 375, "annualInflation": 0.035 },
-    "petGrooming": { "min": 80, "max": 150, "typical": 115, "annualInflation": 0.03 },
-    "transportation": { "min": 270, "max": 500, "typical": 380, "annualInflation": 0.03, "notes": "Light RailLink from Glen Burnie to downtown Baltimore (~30 min). BWI (Baltimore-Washington International) Airport 5 min. Interstate 97 to Annapolis, Interstate 295 to DC. MARC (Maryland Area Regional Commuter) Penn Line at BWI (Baltimore-Washington International) Rail Station." },
-    "entertainment": { "min": 390, "max": 580, "typical": 475, "annualInflation": 0.025, "notes": "Glen Burnie Town Center, Arundel Mills (10 min), Marley Creek trails. Cable+1Gig typical (Comcast)." },
-    "clothing": { "min": 90, "max": 220, "typical": 145, "annualInflation": 0.02 },
-    "personalCare": { "min": 40, "max": 100, "typical": 65, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 100, "max": 215, "typical": 150, "annualInflation": 0.025, "notes": "HOA (homeowners association) in some developments. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Fewer HOA (homeowners association) communities than newer MD suburbs." },
-    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Excellent specialist access: UM BWMC (University of Maryland Baltimore Washington Medical Center) in town, Johns Hopkins 20 min, UM Medical Center (Baltimore) 15 min." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from MD + Anne Arundel County brackets." },
-    "healthcarePreMedicare": { "min": 1700, "max": 2650, "typical": 2150, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Anne Arundel County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1600,
+      "max": 2250,
+      "typical": 1900,
+      "type": "2-bedroom townhome / older SFH",
+      "annualInflation": 0.035,
+      "notes": "Anne Arundel County — older working-class suburb, established neighborhoods. Among cheapest viable rent in MD metro area. BWI airport + Glen Burnie Town Center shopping."
+    },
+    "groceries": {
+      "min": 1230,
+      "max": 1620,
+      "typical": 1410,
+      "annualInflation": 0.03,
+      "notes": "Giant, Safeway, Weis. Budget-friendly; Aldi + Lidl nearby for further savings."
+    },
+    "utilities": {
+      "min": 250,
+      "max": 410,
+      "typical": 320,
+      "annualInflation": 0.03,
+      "notes": "BGE electric + Washington Gas + AACO water/sewer."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "notes": "Medicare baseline. UM Baltimore Washington Medical Center in town — major regional hospital with Level II trauma, heart, cancer centers. Johns Hopkins 20 min.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 120,
+      "max": 215,
+      "typical": 160,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 295,
+      "max": 465,
+      "typical": 375,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 80,
+      "max": 150,
+      "typical": 115,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 270,
+      "max": 500,
+      "typical": 380,
+      "annualInflation": 0.03,
+      "notes": "Light RailLink from Glen Burnie to downtown Baltimore (~30 min). BWI (Baltimore-Washington International) Airport 5 min. Interstate 97 to Annapolis, Interstate 295 to DC. MARC (Maryland Area Regional Commuter) Penn Line at BWI (Baltimore-Washington International) Rail Station."
+    },
+    "entertainment": {
+      "min": 390,
+      "max": 580,
+      "typical": 475,
+      "annualInflation": 0.025,
+      "notes": "Glen Burnie Town Center, Arundel Mills (10 min), Marley Creek trails. Cable+1Gig typical (Comcast)."
+    },
+    "clothing": {
+      "min": 90,
+      "max": 220,
+      "typical": 145,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 40,
+      "max": 100,
+      "typical": 65,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 100,
+      "max": 215,
+      "typical": 150,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) in some developments. Interstate 95 + ICC (Intercounty Connector toll road) tolls. Fewer HOA (homeowners association) communities than newer MD suburbs."
+    },
+    "buffer": {
+      "min": 700,
+      "max": 700,
+      "typical": 700,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. Excellent specialist access: UM BWMC (University of Maryland Baltimore Washington Medical Center) in town, Johns Hopkins 20 min, UM Medical Center (Baltimore) 15 min."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from MD + Anne Arundel County brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1700,
+      "max": 2650,
+      "typical": 2150,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Anne Arundel County, MD). Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.078, "type": "combined-state-plus-county",
+      "rate": 0.078,
+      "type": "combined-state-plus-county",
       "brackets": [
-        { "min": 0, "max": 1000, "rate": 0.0481 },
-        { "min": 1000, "max": 2000, "rate": 0.0581 },
-        { "min": 2000, "max": 3000, "rate": 0.0681 },
-        { "min": 3000, "max": 100000, "rate": 0.0756 },
-        { "min": 100000, "max": 125000, "rate": 0.0781 },
-        { "min": 125000, "max": 150000, "rate": 0.0806 },
-        { "min": 150000, "max": 250000, "rate": 0.0831 },
-        { "min": 250000, "max": null, "rate": 0.0856 }
+        {
+          "min": 0,
+          "max": 1000,
+          "rate": 0.0481
+        },
+        {
+          "min": 1000,
+          "max": 2000,
+          "rate": 0.0581
+        },
+        {
+          "min": 2000,
+          "max": 3000,
+          "rate": 0.0681
+        },
+        {
+          "min": 3000,
+          "max": 100000,
+          "rate": 0.0756
+        },
+        {
+          "min": 100000,
+          "max": 125000,
+          "rate": 0.0781
+        },
+        {
+          "min": 125000,
+          "max": 150000,
+          "rate": 0.0806
+        },
+        {
+          "min": 150000,
+          "max": 250000,
+          "rate": 0.0831
+        },
+        {
+          "min": 250000,
+          "max": null,
+          "rate": 0.0856
+        }
       ],
       "deduction": 5150,
       "exemptions": "MD pension exclusion up to ~$39K for retirees 65+; SS fully exempt. Rates are combined state + Anne Arundel County piggyback (2.81% — lower than Baltimore/Howard/PG counties at 3.20%)."
     },
-    "salesTax": { "rate": 0.06, "notes": "Maryland statewide 6%; no local add-ons." },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Maryland statewide 6%; no local add-ons."
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Maryland has no vehicle personal property tax."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 0,
@@ -66,18 +224,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 9, "waitTimes": "low", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 9,
+    "waitTimes": "low",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Exceptional healthcare value: UM Baltimore Washington Medical Center in town (Level II trauma, 370 beds, heart/cancer/orthopedic centers), Johns Hopkins 20 min, UM Medical Center (Baltimore) 15 min. World-class care at suburban prices.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2150, "benchmarkSilverMonthlySingle": 1075,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Anne Arundel County",
+      "benchmarkSilverMonthly2Adult": 2150,
+      "benchmarkSilverMonthlySingle": 1075,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Anne Arundel County",
       "notes": "Maryland Health Connection: CareFirst, Kaiser, UnitedHealthcare. Anne Arundel rating area.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Comcast/Xfinity)",
-    "dogFriendly": 8, "expatCommunity": 4, "englishPrevalence": 10, "safetyRating": 7,
+    "dogFriendly": 8,
+    "expatCommunity": 4,
+    "englishPrevalence": 10,
+    "safetyRating": 7,
     "notes": "BWI (Baltimore-Washington International) Airport 5 min — travel convenience. Light Rail to Baltimore downtown. Older established working-class to middle-class suburb. Diverse demographics. Quiet residential pockets between commercial corridors."
   },
   "pros": [

--- a/data/locations/us-lorton-va/location.json
+++ b/data/locations/us-lorton-va/location.json
@@ -3,54 +3,196 @@
   "name": "Lorton VA, USA",
   "country": "United States",
   "region": "Virginia",
-  "cities": ["Lorton", "Fort Belvoir"],
+  "cities": [
+    "Lorton",
+    "Fort Belvoir"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 25, "summerHighF": 89, "rainyDaysPerYear": 110, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 25,
+    "summerHighF": 89,
+    "rainyDaysPerYear": 110,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1900, "max": 2650, "typical": 2200, "type": "2-bedroom newer townhome/SFH", "annualInflation": 0.035, "notes": "Newer townhome developments (Laurel Hill, Lorton Station). Southern Fairfax County." },
-    "groceries": { "min": 1300, "max": 1700, "typical": 1490, "annualInflation": 0.03, "notes": "Wegmans, Giant, Harris Teeter. Similar to Fairfax pricing." },
-    "utilities": { "min": 260, "max": 420, "typical": 330, "annualInflation": 0.03 },
-    "healthcare": { "min": 550, "max": 850, "typical": 650, "notes": "Fairfax County Medicare baseline. Inova Mt Vernon 10 min, Inova Fairfax 20 min.", "annualInflation": 0.055 },
-    "insurance": { "min": 35, "max": 55, "typical": 45, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 120, "max": 220, "typical": 170, "annualInflation": 0.04 },
-    "petDaycare": { "min": 310, "max": 490, "typical": 395, "annualInflation": 0.035 },
-    "petGrooming": { "min": 85, "max": 155, "typical": 115, "annualInflation": 0.03 },
-    "transportation": { "min": 300, "max": 550, "typical": 420, "annualInflation": 0.03, "notes": "Lorton VRE (Virginia Railway Express) station (Fredericksburg line) to DC. Interstate 95 + Fairfax County Pkwy access. Longer DC commute than Fairfax City." },
-    "entertainment": { "min": 400, "max": 590, "typical": 480, "annualInflation": 0.025, "notes": "Workhouse Arts Center (former prison), Occoquan Regional Park. Cable+1Gig." },
-    "clothing": { "min": 95, "max": 230, "typical": 150, "annualInflation": 0.02 },
-    "personalCare": { "min": 42, "max": 100, "typical": 65, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 110, "max": 230, "typical": 160, "annualInflation": 0.025, "notes": "HOA (homeowners association) common in Laurel Hill subdivisions. Interstate 95 Express Lanes tolls." },
-    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialists at Inova Fairfax + Johns Hopkins." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets." },
-    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2300, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1900,
+      "max": 2650,
+      "typical": 2200,
+      "type": "2-bedroom newer townhome/SFH",
+      "annualInflation": 0.035,
+      "notes": "Newer townhome developments (Laurel Hill, Lorton Station). Southern Fairfax County."
+    },
+    "groceries": {
+      "min": 1300,
+      "max": 1700,
+      "typical": 1490,
+      "annualInflation": 0.03,
+      "notes": "Wegmans, Giant, Harris Teeter. Similar to Fairfax pricing."
+    },
+    "utilities": {
+      "min": 260,
+      "max": 420,
+      "typical": 330,
+      "annualInflation": 0.03
+    },
+    "healthcare": {
+      "min": 550,
+      "max": 850,
+      "typical": 650,
+      "notes": "Fairfax County Medicare baseline. Inova Mt Vernon 10 min, Inova Fairfax 20 min.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 35,
+      "max": 55,
+      "typical": 45,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 120,
+      "max": 220,
+      "typical": 170,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 310,
+      "max": 490,
+      "typical": 395,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 85,
+      "max": 155,
+      "typical": 115,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 300,
+      "max": 550,
+      "typical": 420,
+      "annualInflation": 0.03,
+      "notes": "Lorton VRE (Virginia Railway Express) station (Fredericksburg line) to DC. Interstate 95 + Fairfax County Pkwy access. Longer DC commute than Fairfax City."
+    },
+    "entertainment": {
+      "min": 400,
+      "max": 590,
+      "typical": 480,
+      "annualInflation": 0.025,
+      "notes": "Workhouse Arts Center (former prison), Occoquan Regional Park. Cable+1Gig."
+    },
+    "clothing": {
+      "min": 95,
+      "max": 230,
+      "typical": 150,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 42,
+      "max": 100,
+      "typical": 65,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 110,
+      "max": 230,
+      "typical": 160,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) common in Laurel Hill subdivisions. Interstate 95 Express Lanes tolls."
+    },
+    "buffer": {
+      "min": 700,
+      "max": 700,
+      "typical": 700,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. Specialists at Inova Fairfax + Johns Hopkins."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from VA brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1800,
+      "max": 2800,
+      "typical": 2300,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Fairfax County, VA). Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0575, "type": "top-marginal",
+      "rate": 0.0575,
+      "type": "top-marginal",
       "brackets": [
-        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
-        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+        {
+          "min": 0,
+          "max": 3000,
+          "rate": 0.02
+        },
+        {
+          "min": 3000,
+          "max": 5000,
+          "rate": 0.03
+        },
+        {
+          "min": 5000,
+          "max": 17000,
+          "rate": 0.05
+        },
+        {
+          "min": 17000,
+          "max": null,
+          "rate": 0.0575
+        }
       ],
-      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+      "deduction": 24000,
+      "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
     },
-    "salesTax": { "rate": 0.06, "notes": "Fairfax County 6%" },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Fairfax County vehicle tax ~$4.57/$100." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Fairfax County 6%"
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Fairfax County vehicle tax ~$4.57/$100."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 1200,
@@ -59,18 +201,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 8, "waitTimes": "low-moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 8,
+    "waitTimes": "low-moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Inova Mount Vernon Hospital 10 min (community hospital), Inova Fairfax 20 min for specialty.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2300, "benchmarkSilverMonthlySingle": 1150,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Fairfax County",
+      "benchmarkSilverMonthly2Adult": 2300,
+      "benchmarkSilverMonthlySingle": 1150,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Fairfax County",
       "notes": "Northern Virginia (NOVA) marketplace same as Fairfax.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Verizon Fios, Cox, Xfinity)",
-    "dogFriendly": 9, "expatCommunity": 3, "englishPrevalence": 10, "safetyRating": 8,
+    "dogFriendly": 9,
+    "expatCommunity": 3,
+    "englishPrevalence": 10,
+    "safetyRating": 8,
     "notes": "Occoquan River access, Workhouse Arts Center, Laurel Hill Golf Club. Quieter than inner Northern Virginia; suburban family feel."
   },
   "pros": [

--- a/data/locations/us-manassas-va/location.json
+++ b/data/locations/us-manassas-va/location.json
@@ -3,54 +3,197 @@
   "name": "Manassas VA, USA",
   "country": "United States",
   "region": "Virginia",
-  "cities": ["Manassas", "Manassas Park"],
+  "cities": [
+    "Manassas",
+    "Manassas Park"
+  ],
   "currency": "USD",
   "exchangeRate": 1,
-  "visa": { "type": "Citizen", "incomeRequirement": null, "notes": "US citizen, no visa required." },
-  "climate": { "winterLowF": 23, "summerHighF": 89, "rainyDaysPerYear": 108, "meetsWarmWinterReq": false },
+  "visa": {
+    "type": "Citizen",
+    "incomeRequirement": null,
+    "notes": "US citizen, no visa required."
+  },
+  "climate": {
+    "winterLowF": 23,
+    "summerHighF": 89,
+    "rainyDaysPerYear": 108,
+    "meetsWarmWinterReq": false
+  },
   "monthlyCosts": {
-    "rent": { "min": 1700, "max": 2400, "typical": 1950, "type": "2-bedroom townhome/older SFH", "annualInflation": 0.035, "notes": "Independent city + Prince William County surround. Historic downtown. ~32% cheaper than Fairfax." },
-    "groceries": { "min": 1250, "max": 1650, "typical": 1430, "annualInflation": 0.03, "notes": "Giant, Wegmans, Harris Teeter. ~10% below Fairfax averages." },
-    "utilities": { "min": 240, "max": 400, "typical": 315, "annualInflation": 0.03, "notes": "NOVEC electric + Washington Gas + City of Manassas water/sewer." },
-    "healthcare": { "min": 540, "max": 830, "typical": 640, "notes": "Medicare baseline. Novant UVA Health System Prince William (Haymarket) 10 min, Sentara Northern Virginia Medical Center in Manassas.", "annualInflation": 0.055 },
-    "insurance": { "min": 30, "max": 50, "typical": 40, "type": "renter's insurance", "annualInflation": 0.03 },
-    "petCare": { "min": 110, "max": 205, "typical": 155, "annualInflation": 0.04 },
-    "petDaycare": { "min": 290, "max": 460, "typical": 370, "annualInflation": 0.035 },
-    "petGrooming": { "min": 80, "max": 145, "typical": 110, "annualInflation": 0.03 },
-    "transportation": { "min": 320, "max": 580, "typical": 450, "annualInflation": 0.03, "notes": "VRE (Virginia Railway Express) Manassas line to DC (~60 min). Interstate 66 to DC ~1hr in traffic. Higher fuel use than inner Northern Virginia (NOVA)." },
-    "entertainment": { "min": 370, "max": 560, "typical": 450, "annualInflation": 0.025, "notes": "Manassas National Battlefield Park, historic downtown. Cable+1Gig typical." },
-    "clothing": { "min": 90, "max": 215, "typical": 140, "annualInflation": 0.02 },
-    "personalCare": { "min": 40, "max": 95, "typical": 60, "annualInflation": 0.02 },
-    "subscriptions": { "min": 30, "max": 80, "typical": 55, "annualInflation": 0.03 },
-    "phoneCell": { "min": 50, "max": 80, "typical": 62, "annualInflation": 0.02 },
-    "miscellaneous": { "min": 100, "max": 215, "typical": 150, "annualInflation": 0.025, "notes": "HOA (homeowners association) in subdivisions, Interstate 66 Express Lanes tolls, Prince William County (PWC) vehicle decal." },
-    "buffer": { "min": 700, "max": 700, "typical": 700, "annualInflation": 0.025 },
-    "medicalOOP": { "min": 325, "max": 700, "typical": 475, "annualInflation": 0.055, "notes": "Same retiree profile. Specialty care may require trip to Fairfax/DC." },
-    "medicine": { "min": 73, "typical": 91, "max": 925, "annualInflation": 0.045 },
-    "taxes": { "typical": 0, "min": 0, "max": 0, "annualInflation": 0.02, "notes": "Income tax computed from VA brackets." },
-    "healthcarePreMedicare": { "min": 1800, "max": 2800, "typical": 2250, "annualInflation": 0.06, "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince William County, VA). Prince William County (PWC) marketplace — slightly cheaper than Fairfax. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number." }
+    "rent": {
+      "min": 1700,
+      "max": 2400,
+      "typical": 1950,
+      "type": "2-bedroom townhome/older SFH",
+      "annualInflation": 0.035,
+      "notes": "Independent city + Prince William County surround. Historic downtown. ~32% cheaper than Fairfax."
+    },
+    "groceries": {
+      "min": 1250,
+      "max": 1650,
+      "typical": 1430,
+      "annualInflation": 0.03,
+      "notes": "Giant, Wegmans, Harris Teeter. ~10% below Fairfax averages."
+    },
+    "utilities": {
+      "min": 240,
+      "max": 400,
+      "typical": 315,
+      "annualInflation": 0.03,
+      "notes": "NOVEC electric + Washington Gas + City of Manassas water/sewer."
+    },
+    "healthcare": {
+      "min": 540,
+      "max": 830,
+      "typical": 640,
+      "notes": "Medicare baseline. Novant UVA Health System Prince William (Haymarket) 10 min, Sentara Northern Virginia Medical Center in Manassas.",
+      "annualInflation": 0.055
+    },
+    "insurance": {
+      "min": 30,
+      "max": 50,
+      "typical": 40,
+      "type": "renter's insurance",
+      "annualInflation": 0.03
+    },
+    "petCare": {
+      "min": 110,
+      "max": 205,
+      "typical": 155,
+      "annualInflation": 0.04
+    },
+    "petDaycare": {
+      "min": 290,
+      "max": 460,
+      "typical": 370,
+      "annualInflation": 0.035
+    },
+    "petGrooming": {
+      "min": 80,
+      "max": 145,
+      "typical": 110,
+      "annualInflation": 0.03
+    },
+    "transportation": {
+      "min": 320,
+      "max": 580,
+      "typical": 450,
+      "annualInflation": 0.03,
+      "notes": "VRE (Virginia Railway Express) Manassas line to DC (~60 min). Interstate 66 to DC ~1hr in traffic. Higher fuel use than inner Northern Virginia (NOVA)."
+    },
+    "entertainment": {
+      "min": 370,
+      "max": 560,
+      "typical": 450,
+      "annualInflation": 0.025,
+      "notes": "Manassas National Battlefield Park, historic downtown. Cable+1Gig typical."
+    },
+    "clothing": {
+      "min": 90,
+      "max": 215,
+      "typical": 140,
+      "annualInflation": 0.02
+    },
+    "personalCare": {
+      "min": 40,
+      "max": 95,
+      "typical": 60,
+      "annualInflation": 0.02
+    },
+    "subscriptions": {
+      "min": 30,
+      "max": 80,
+      "typical": 55,
+      "annualInflation": 0.03
+    },
+    "phoneCell": {
+      "min": 50,
+      "max": 80,
+      "typical": 62,
+      "annualInflation": 0.02
+    },
+    "miscellaneous": {
+      "min": 100,
+      "max": 215,
+      "typical": 150,
+      "annualInflation": 0.025,
+      "notes": "HOA (homeowners association) in subdivisions, Interstate 66 Express Lanes tolls, Prince William County (PWC) vehicle decal."
+    },
+    "buffer": {
+      "min": 700,
+      "max": 700,
+      "typical": 700,
+      "annualInflation": 0.025
+    },
+    "medicalOOP": {
+      "min": 325,
+      "max": 700,
+      "typical": 475,
+      "annualInflation": 0.055,
+      "notes": "Same retiree profile. Specialty care may require trip to Fairfax/DC."
+    },
+    "medicine": {
+      "min": 73,
+      "typical": 91,
+      "max": 925,
+      "annualInflation": 0.045
+    },
+    "taxes": {
+      "typical": 0,
+      "min": 0,
+      "max": 0,
+      "annualInflation": 0.02,
+      "notes": "Income tax computed from VA brackets."
+    },
+    "healthcarePreMedicare": {
+      "min": 1800,
+      "max": 2800,
+      "typical": 2250,
+      "annualInflation": 0.06,
+      "notes": "ACA silver benchmark for 2-adult household both age ~60, before subsidies. County-level estimate (Prince William County, VA). Prince William County (PWC) marketplace — slightly cheaper than Fairfax. Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+    }
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        { "min": 0, "max": 23850, "rate": 0.10 }, { "min": 23850, "max": 96950, "rate": 0.12 },
-        { "min": 96950, "max": 206700, "rate": 0.22 }, { "min": 206700, "max": 394600, "rate": 0.24 },
-        { "min": 394600, "max": 501050, "rate": 0.32 }, { "min": 501050, "max": 751600, "rate": 0.35 },
-        { "min": 751600, "max": null, "rate": 0.37 }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
-      "rate": 0.0575, "type": "top-marginal",
+      "rate": 0.0575,
+      "type": "top-marginal",
       "brackets": [
-        { "min": 0, "max": 3000, "rate": 0.02 }, { "min": 3000, "max": 5000, "rate": 0.03 },
-        { "min": 5000, "max": 17000, "rate": 0.05 }, { "min": 17000, "max": null, "rate": 0.0575 }
+        {
+          "min": 0,
+          "max": 3000,
+          "rate": 0.02
+        },
+        {
+          "min": 3000,
+          "max": 5000,
+          "rate": 0.03
+        },
+        {
+          "min": 5000,
+          "max": 17000,
+          "rate": 0.05
+        },
+        {
+          "min": 17000,
+          "max": null,
+          "rate": 0.0575
+        }
       ],
-      "deduction": 24000, "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
+      "deduction": 24000,
+      "exemptions": "Age 65+ deduction $12K/person. SS fully exempt from VA tax."
     },
-    "salesTax": { "rate": 0.06, "notes": "Prince William County / City of Manassas 6% (4.3% state + 0.7% regional + 1% Northern Virginia (NOVA) transit)" },
-    "propertyTax": { "rate": 0, "notes": "Renters: no direct property tax. Prince William County (PWC) vehicle personal property ~$3.70/$100 assessed — slightly below Fairfax." },
+    "salesTax": {
+      "rate": 0.06,
+      "notes": "Prince William County / City of Manassas 6% (4.3% state + 0.7% regional + 1% Northern Virginia (NOVA) transit)"
+    },
+    "propertyTax": {
+      "rate": 0,
+      "notes": "Renters: no direct property tax. Prince William County (PWC) vehicle personal property ~$3.70/$100 assessed — slightly below Fairfax."
+    },
     "socialCharges": null,
     "vatRate": 0,
     "estVehicleTax": 1100,
@@ -59,18 +202,27 @@
   },
   "healthcare": {
     "system": "Medicare (at 65) + private supplement",
-    "qualityRating": 7, "waitTimes": "moderate", "dentalIncluded": false, "prescriptionCoverage": "Part D plan",
+    "qualityRating": 7,
+    "waitTimes": "moderate",
+    "dentalIncluded": false,
+    "prescriptionCoverage": "Part D plan",
     "notes": "Novant UVA Health Prince William (Haymarket) + Sentara Northern Virginia (NOVA) Medical Center. Inova Fair Oaks ~25 min for specialty.",
     "acaMarketplace": {
-      "benchmarkSilverMonthly2Adult": 2250, "benchmarkSilverMonthlySingle": 1125,
-      "premiumCapPctOfIncome": 0.085, "rateArea": "Prince William County",
+      "benchmarkSilverMonthly2Adult": 2250,
+      "benchmarkSilverMonthlySingle": 1125,
+      "premiumCapPctOfIncome": 0.085,
+      "rateArea": "Prince William County",
       "notes": "Prince William County (PWC) marketplace — similar to Fairfax with slightly more competition.",
-      "estimationLevel": "county", "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
+      "estimationLevel": "county",
+      "disclaimer": "Estimated ±15% vs healthcare.gov quote — verify for a specific ZIP before relying on the number."
     }
   },
   "lifestyle": {
     "internetSpeed": "1Gbps widely available (Verizon Fios, Comcast)",
-    "dogFriendly": 8, "expatCommunity": 4, "englishPrevalence": 9, "safetyRating": 7,
+    "dogFriendly": 8,
+    "expatCommunity": 4,
+    "englishPrevalence": 9,
+    "safetyRating": 7,
     "notes": "Manassas National Battlefield Park, historic Old Town Manassas, Bull Run Mountains. Strong Latino community. Quieter suburban/small-city feel."
   },
   "pros": [

--- a/data/locations/us-new-york-city/location.json
+++ b/data/locations/us-new-york-city/location.json
@@ -193,45 +193,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0685,

--- a/data/locations/us-philadelphia/location.json
+++ b/data/locations/us-philadelphia/location.json
@@ -187,45 +187,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0307,

--- a/data/locations/us-raleigh/location.json
+++ b/data/locations/us-raleigh/location.json
@@ -190,45 +190,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.045,

--- a/data/locations/us-richmond/location.json
+++ b/data/locations/us-richmond/location.json
@@ -187,45 +187,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0575,

--- a/data/locations/us-savannah/location.json
+++ b/data/locations/us-savannah/location.json
@@ -187,45 +187,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0549,

--- a/data/locations/us-summerville/location.json
+++ b/data/locations/us-summerville/location.json
@@ -192,45 +192,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.065,

--- a/data/locations/us-virginia/location.json
+++ b/data/locations/us-virginia/location.json
@@ -192,45 +192,7 @@
   },
   "taxes": {
     "federalIncomeTax": {
-      "applies": true,
-      "brackets": [
-        {
-          "min": 0,
-          "max": 23850,
-          "rate": 0.1
-        },
-        {
-          "min": 23850,
-          "max": 96950,
-          "rate": 0.12
-        },
-        {
-          "min": 96950,
-          "max": 206700,
-          "rate": 0.22
-        },
-        {
-          "min": 206700,
-          "max": 394600,
-          "rate": 0.24
-        },
-        {
-          "min": 394600,
-          "max": 501050,
-          "rate": 0.32
-        },
-        {
-          "min": 501050,
-          "max": 751600,
-          "rate": 0.35
-        },
-        {
-          "min": 751600,
-          "max": null,
-          "rate": 0.37
-        }
-      ],
-      "standardDeduction": 30000
+      "applies": true
     },
     "stateIncomeTax": {
       "rate": 0.0575,

--- a/docs/adr/0002-aca-regime.md
+++ b/docs/adr/0002-aca-regime.md
@@ -7,7 +7,7 @@ models both via `premiumCapPctOfIncome: 0 | 0.085`.
 
 ## Context
 The ACA marketplace has two possible subsidy regimes in the modelling window:
-- **Cliff** — pre-2021, returning for 2026: sliding 2.07–9.83% contribution
+- **Cliff** — pre-2021 rules, current for 2026 per Rev Proc 2025-25: sliding 2.10–9.96% contribution
   rate up to 400% FPL; hard cliff with no subsidy above 400%.
 - **Enhanced (ARPA/IRA)** — 2021–2025: flat 8.5% MAGI cap, no cliff.
 

--- a/src/routes/glossary.ts
+++ b/src/routes/glossary.ts
@@ -180,7 +180,7 @@ const GLOSSARY: GlossaryEntry[] = [
     plain:
       'The minimum amount the IRS makes you withdraw each year from certain retirement accounts once you reach a set age.',
     example:
-      'A 75-year-old with a $500,000 IRA must withdraw about $20,325 that year (using the 2024 table).',
+      'A 75-year-old with a $500,000 IRA must withdraw about $20,325 that year (using the current Uniform Lifetime Table, post-SECURE 2.0).',
     technical:
       'Previous year-end balance ÷ IRS uniform lifetime table divisor for current age.',
     seeAlso: ['roth_conversion'],
@@ -312,9 +312,9 @@ const GLOSSARY: GlossaryEntry[] = [
     plain:
       'A yearly income amount set by the US government, used as a benchmark for many income-based programs.',
     example:
-      'For 2024, the poverty line in the lower 48 states is about $15,060 for one person and $20,440 for two.',
+      'For 2026, the poverty line in the lower 48 states is about $15,960 for one person and $21,560 for two.',
     technical:
-      'HHS Poverty Guidelines, published annually in the Federal Register. Separate tables for the 48 contiguous states + DC, Alaska, and Hawaii. Household-size adjustment is $5,380 per additional person (2024).',
+      'HHS Poverty Guidelines, published annually in the Federal Register. Separate tables for the 48 contiguous states + DC, Alaska, and Hawaii. Household-size adjustment is $5,600 per additional person (2026).',
     seeAlso: ['magi', 'aca', 'subsidy_cliff'],
   },
   {
@@ -324,7 +324,7 @@ const GLOSSARY: GlossaryEntry[] = [
     plain:
       'An income boundary where health-insurance help stops completely. Earning one dollar more than the cutoff can mean losing thousands in help.',
     example:
-      'In 2026, a couple earning $81,761 gets no ACA help, while the same couple earning $81,759 may get thousands in premium tax credits.',
+      'In 2026, a couple earning $86,241 gets no ACA help, while the same couple earning $86,239 may get thousands in premium tax credits.',
     technical:
       'Under pre-ARPA rules, ACA premium tax credits phase out fully at 400% of FPL. The enhanced rules from the 2021 American Rescue Plan removed the cliff and capped premiums at 8.5% of MAGI; those enhanced rules expired Dec 31 2025.',
     seeAlso: ['aca', 'fpl', 'applicable_percentage'],
@@ -338,7 +338,7 @@ const GLOSSARY: GlossaryEntry[] = [
     example:
       'At 250% of the poverty line under cliff rules, your cap is about 6.5% of income. A $70,000 earner would pay about $4,550 per year; ACA help covers any premium above that.',
     technical:
-      'Under cliff (pre-ARPA) rules the sliding scale runs 2.07% (at 100% FPL) up to 9.83% (at 400% FPL). Under enhanced (ARPA/IRA 2021–2025) rules the scale is 0% (≤150% FPL) up to 8.5% flat above 400% FPL.',
+      'Under cliff rules (current for 2026 per Rev Proc 2025-25) the sliding scale runs 2.10% (at 100% FPL) up to 9.96% (at 400% FPL). Under enhanced rules (ARPA/IRA 2021–2025, expired) the scale was 0% (≤150% FPL) up to 8.5% flat above 400% FPL.',
     seeAlso: ['aca', 'subsidy_cliff', 'magi'],
   },
 ];

--- a/tools/strip-stale-federal-brackets.mjs
+++ b/tools/strip-stale-federal-brackets.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// One-off migration: strip the 2025 federal tax-bracket overrides from
+// location JSONs. Federal brackets are the same everywhere, so there's
+// no per-location reason to carry them — deleting them lets
+// `shared/taxes.js` fall through to its 2026 Rev Proc 2025-32 defaults.
+//
+// What this keeps: `applies`, `foreignTaxCredit` on `federalIncomeTax`
+// (both are genuinely per-location — non-US places may set `applies:
+// false` or `foreignTaxCredit: true`).
+//
+// What this removes: `brackets`, `standardDeduction` from
+// `federalIncomeTax`. Run once; re-running is a no-op.
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname.replace(/^\/([A-Za-z]):/, '$1:'));
+const LOC_DIR = join(ROOT, 'data', 'locations');
+
+const entries = readdirSync(LOC_DIR, { withFileTypes: true })
+  .filter(e => e.isDirectory())
+  .map(e => join(LOC_DIR, e.name, 'location.json'));
+
+let stripped = 0;
+let skipped = 0;
+
+for (const path of entries) {
+  let raw;
+  try { raw = readFileSync(path, 'utf8'); } catch { continue; }
+  const parsed = JSON.parse(raw);
+  const fit = parsed?.taxes?.federalIncomeTax;
+  if (!fit || typeof fit !== 'object') { skipped++; continue; }
+  const hadBrackets = Object.prototype.hasOwnProperty.call(fit, 'brackets');
+  const hadStdDed = Object.prototype.hasOwnProperty.call(fit, 'standardDeduction');
+  if (!hadBrackets && !hadStdDed) { skipped++; continue; }
+  delete fit.brackets;
+  delete fit.standardDeduction;
+  // Preserve the existing formatting shape — the seed files are
+  // pretty-printed with 2-space indents + trailing newline. Use
+  // JSON.stringify with indent=2, then add the trailing newline.
+  const serialized = JSON.stringify(parsed, null, 2) + '\n';
+  writeFileSync(path, serialized, 'utf8');
+  stripped++;
+  console.log(`  ${path.replace(ROOT, '').replace(/^[\\/]/, '').replace(/\\/g, '/')}`);
+}
+
+console.log(`\nStripped federal-bracket overrides from ${stripped} files; ${skipped} unaffected.`);


### PR DESCRIPTION
## Summary
Every US location (and several international locations modeling expat US-federal tax) carried a hard-coded copy of the 2025 MFJ federal tax brackets + \$30,000 standard deduction as location-level overrides. Those overrides won over the 2026 defaults that just landed in [#24](https://github.com/justice8096/retirement-api/pull/24) — users on 31 of 158 locations would silently get 2025 tax math.

Federal brackets are the same everywhere. No per-location reason to carry them. Stripping lets \`shared/taxes.js\` fall through to its 2026 Rev Proc 2025-32 defaults.

## Changes
- Removed \`taxes.federalIncomeTax.brackets\` and \`.standardDeduction\` from 31 location JSONs (22 US + 9 international).
- Kept \`.applies\` and \`.foreignTaxCredit\` (both genuinely per-location).
- Added \`tools/strip-stale-federal-brackets.mjs\` — idempotent migration script for future annual rollovers.

## Test plan
- [x] \`npm run test:shared\` — 147/147 passing
- [x] \`grep -l '23850\|96950\|394600' data/locations/*/location.json\` — empty
- [x] Baseline \`npm test\` unchanged (15 pre-existing failures fixed by [#25](https://github.com/justice8096/retirement-api/pull/25))

## Outcome
Closes the one remaining 2026-value gap flagged in the post-#24 audit. Every location now uses the 2026 federal defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)