### PR TITLE
chore(ci): split dev-tooling major bumps into per-package PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,11 @@ updates:
       sentry:
         patterns:
           - "@sentry/*"
+      # Dev tooling groups patch + minor bumps only. Major bumps (e.g.
+      # typescript 5 → 6, vitest 3 → 4) arrive as individual per-package
+      # PRs so each can be evaluated on its own — previous bundled PRs
+      # (closed #23) were blocked when one package's major introduced
+      # breaking changes the others didn't share.
       dev-tooling:
         dependency-type: development
         patterns:
@@ -40,6 +45,9 @@ updates:
           - "tsx"
           - "vitest"
           - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions — pin SHAs, update tags weekly.
   - package-ecosystem: github-actions


### PR DESCRIPTION
Follow-up to closing PR #23. Restricts the `dev-tooling` group to `[minor, patch]` so major bumps (typescript 5 → 6, vitest 3 → 4, etc.) arrive as individual per-package PRs where each can be reviewed on its own merits.