### PR TITLE
fix(security): Helmet CORP same-origin → same-site for split-origin SPA

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,11 @@ await app.register(cors, {
 });
 await app.register(helmet, {
   contentSecurityPolicy: process.env.NODE_ENV === 'production' ? undefined : false,
+  // Default `same-origin` blocks the SPA at a different origin (e.g. localhost:4200)
+  // from reading JSON responses even when CORS permits them. `same-site` keeps CORP
+  // strict enough to prevent cross-site resource inclusion while allowing the
+  // paired dashboard and marketing-site origins to consume the API.
+  crossOriginResourcePolicy: { policy: 'same-site' },
 });
 // Build Redis store for distributed rate limiting (falls back to in-memory)
 let redisClient: { quit: () => Promise<void> } | undefined;


### PR DESCRIPTION
## Summary
- Helmet's default `Cross-Origin-Resource-Policy: same-origin` was blocking the paired Angular dashboard at `localhost:4200` from reading JSON responses from this API at `localhost:3000`, even though CORS explicitly permitted the request.
- CORP is browser-enforced (curl was unaffected), which masked the issue during API-side testing.
- Switching to `same-site` preserves protection against cross-site resource inclusion while allowing same-registrable-domain frontends (dev + eventual `app.example.com` ↔ `api.example.com`).

## Test plan
- [x] `curl -s -o /dev/null -w "%header{cross-origin-resource-policy}" -H "Origin: http://localhost:4200" http://localhost:3000/api/locations/all` → `same-site`.
- [x] Browser fetch from localhost:4200 no longer fails with net::ERR / HTTP 0.
- [ ] Regression check: no existing integration test relied on strict `same-origin` CORP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)