### PR TITLE
fix(cors): restore PUT/PATCH/DELETE in preflight after fastify-cors v11 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -928,6 +928,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -949,6 +950,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
       "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1371,6 +1373,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
       "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.0",
         "@opentelemetry/resources": "2.7.0",
@@ -1388,6 +1391,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2243,6 +2247,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2813,6 +2818,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -3406,6 +3412,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3537,6 +3544,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -4041,6 +4049,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4061,6 +4070,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4081,6 +4091,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -63,6 +63,12 @@ if (corsOrigins.includes('*')) {
 await app.register(cors, {
   origin: corsOrigins.length === 1 ? corsOrigins[0] : corsOrigins,
   credentials: true,
+  // @fastify/cors v11 shrank the default allowed methods to `GET,HEAD,POST`,
+  // breaking mutation endpoints (`PUT /me/household`, `PATCH /me/preferences`,
+  // `DELETE /me/scenarios/:id`). Restore the full set explicitly so the
+  // preflight advertises every verb the API actually exposes.
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'Accept-Version', 'Accept-Language'],
 });
 await app.register(helmet, {
   contentSecurityPolicy: process.env.NODE_ENV === 'production' ? undefined : false,


### PR DESCRIPTION
## Summary
\`@fastify/cors\` v10 → v11 (merged in api#19 this cycle) shrank the default \`Access-Control-Allow-Methods\` to \`GET,HEAD,POST\` only — silently breaking every mutation endpoint.

Reproduction: any browser PUT/PATCH/DELETE now fails with:

\`\`\`
Access to fetch at 'http://localhost:3000/api/me/household'
from origin 'http://localhost:4200' has been blocked by CORS
policy: Method PUT is not allowed by Access-Control-Allow-Methods
in preflight response.
\`\`\`

Fix: explicitly list the full methods set + the custom headers the API uses (\`Accept-Version\`, \`Accept-Language\`).

## Paired dashboard change
[dashboard#29](https://github.com/justice8096/retirement-dashboard-angular/pulls) — coerces Prisma Decimal strings → numbers so the PUT passes Zod once the preflight allows it.

## Test plan
- [x] \`curl -X OPTIONS -H "Access-Control-Request-Method: PUT"\` now returns \`access-control-allow-methods: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS\`
- [x] Manual: PUT /me/household round-trips 200 from the dashboard
- [ ] Reviewer: consider adding a regression test in \`src/__tests__/\` that asserts the preflight methods set

🤖 Generated with [Claude Code](https://claude.com/claude-code)