### PR TITLE
docs: location-data contribution guide + on-demand scaffold tool

### DIFF
--- a/docs/CONTRIBUTING-LOCATION-DATA.md
+++ b/docs/CONTRIBUTING-LOCATION-DATA.md
@@ -1,0 +1,198 @@
+# Contributing Location Data
+
+**137 of 158 locations** currently ship with only the core `location.json` and
+no supplemental data (neighborhoods, livability, local-info). This doc exists
+so a contributor can pick any location and fill in the gaps without having to
+reverse-engineer the schema from an existing file.
+
+## Quick start
+
+Scaffold empty-but-valid supplement files for one location:
+
+```bash
+node tools/scaffold-location-supplements.mjs <location-id>
+```
+
+Example: `node tools/scaffold-location-supplements.mjs us-austin`
+
+The scaffolder refuses to overwrite existing files, so it's safe to run on a
+location that already has some supplements — it creates only the missing ones.
+
+Then edit the four files described below, commit them, and open a PR.
+
+## The four supplement files
+
+Each location lives at `data/locations/<location-id>/` and may carry up to
+four supplement JSONs alongside the required `location.json`:
+
+| File | Purpose | Dashboard screen |
+|---|---|---|
+| `neighborhoods.json` | Per-area housing / walk scores / character | Community → Neighborhoods |
+| `services.json` | Nearby hospitals, pharmacies, groceries, banks, etc. | Community → Local Services |
+| `inclusion.json` | Racial / LGBTQ / religious / ability inclusion scores | Community → Livability Index |
+| `local-info.json` | Webcams, bloggers, official sites, YouTube channels | Community → Local Info |
+
+The reference exemplar for all four is `data/locations/portugal-lisbon/` —
+when in doubt, read how that location expresses a field and follow the
+same shape.
+
+## Data-quality conventions
+
+- **Every claim needs a source.** Add a `sources[]` array with `{title,
+  url, type?}` next to any factual claim (rent, walk score, legal
+  protection, inclusion rating). Sources should be official, research, or
+  reputable journalism — not user-generated content alone.
+- **Prefer conservative estimates.** This project advises retirement
+  decisions with six-figure consequences. Round down for "typical rent",
+  pick the lower end of walk-score ranges, flag ambiguity in
+  `character_notes`.
+- **Date-stamp the authorship.** Every file should carry a `"lastUpdated":
+  "YYYY-MM-DD"` at the top level — it's how downstream review knows when
+  to re-verify prices.
+- **Don't over-fit to your visit.** A trip to Cascais in August isn't a
+  four-season sample. Reflect that in the summary.
+
+## `neighborhoods.json`
+
+```json
+{
+  "city": "City Name",
+  "neighborhoods": [
+    {
+      "id": "unique-slug",
+      "name": "Neighborhood Name",
+      "description": "One sentence describing the area geographically.",
+      "character": "Historic, quiet, student-heavy — comma-separated adjectives.",
+      "housing": {
+        "avgRentOneBedroomEUR": 900,
+        "avgRentTwoBedroomEUR": 1300,
+        "buyPricePerSqmEUR": 5500,
+        "predominantType": "Renovated apartments in historic buildings"
+      },
+      "walkabilityScore": 80,
+      "transitScore": 72,
+      "safetyRating": "moderate-high",
+      "expats": { "communitySize": "moderate", "englishPrevalence": "high" },
+      "character_notes": "Tram 28 runs through. Street markets on Saturdays.",
+      "sources": [
+        { "title": "Numbeo Cost of Living Lisbon", "url": "https://www.numbeo.com/cost-of-living/in/Lisbon" }
+      ]
+    }
+  ]
+}
+```
+
+- Currency suffix in field names (`avgRentOneBedroomEUR`) — use the
+  three-letter code matching the location's `currency` in `location.json`.
+  For USD locations, suffix with `USD`.
+- `walkabilityScore` / `transitScore`: 0–100 ints. Prefer WalkScore / TransitScore
+  data where available, otherwise provide your best estimate with a source note.
+- `safetyRating`: one of `low | moderate-low | moderate | moderate-high | high`.
+- `expats.communitySize`: one of `very-small | small | moderate | large | very-large`.
+- `expats.englishPrevalence`: one of `low | moderate | high`.
+- **Minimum useful entry count:** 3–4 neighborhoods. Less than 3 offers
+  almost no signal for compare-and-pick workflows.
+
+## `services.json`
+
+```json
+{
+  "distanceUnit": "km",
+  "currency": "EUR",
+  "services": [
+    {
+      "categoryId": "hospital",
+      "name": "Hospital de Santa Maria (CHULN)",
+      "address": "Avenida Professor Egas Moniz, 1649-035 Lisboa",
+      "distanceKm": 4,
+      "notes": "Largest hospital in Portugal, university teaching hospital, 24/7 emergency",
+      "sources": [
+        { "title": "CHULN", "url": "https://www.chln.min-saude.pt/" }
+      ]
+    }
+  ]
+}
+```
+
+Valid `categoryId` values:
+
+| Category | What belongs here |
+|---|---|
+| `hospital` | General hospitals, emergency rooms, specialty hospitals |
+| `pharmacy` | Pharmacies, chemists, dispensaries |
+| `grocery` | Supermarkets, farmers markets with reliable weekly hours |
+| `bank` | Banks, credit unions, currency-exchange offices |
+| `hardware` | Hardware stores, garden centers |
+| `vet` | Veterinary clinics |
+| `gym` | Gyms, community pools with open-swim hours |
+| `shopping` | Shopping malls, department stores |
+| `transit` | Train stations, long-distance bus terminals, airports |
+
+Aim for **2–4 entries per category** that are actually near the primary
+residential areas — not necessarily the city center.
+
+## `inclusion.json`
+
+Most complex of the four; requires research into the legal environment
++ lived experience across several protected characteristics. See the
+Portugal exemplar for the full shape.
+
+Required keys: `country`, `region`, `overallInclusionScore`,
+`lastUpdated`, and `categories` containing at minimum `racial`,
+`religious`, `lgbtq`, `ability`, and `ageism` subsections.
+
+Each subsection needs:
+
+- `score`: 1–10 integer
+- `summary`: 2–3 paragraph plain-language summary of the local reality
+- `legalProtections`: the key law names / commissions / protections
+- `positiveFactors`: 4–6 bullets
+- `riskFactors`: 4–6 bullets (be honest — users will make life-altering
+  decisions from this data)
+- `sources[]`: official / research / news sources backing the above
+
+## `local-info.json`
+
+Simplest of the four — four arrays of curated external links:
+
+```json
+{
+  "climate": {
+    "type": "Temperate oceanic",
+    "avgTemp": { "low": 50, "high": 78 }
+  },
+  "webcams":        [ { "name": "...", "url": "..." } ],
+  "bloggers":       [ { "name": "...", "url": "..." } ],
+  "officialSites":  [ { "name": "...", "url": "...", "type": "government" | "tourism" | "expat" } ],
+  "youtubeChannels":[ { "name": "...", "url": "..." } ]
+}
+```
+
+Climate is optional — when omitted, the dashboard falls back to
+`location.json.climate` (which is always populated). Include it in
+`local-info.json` only when you want to add a prose description (`type`)
+that `location.json` doesn't carry.
+
+## PR checklist
+
+- [ ] JSON files validate (`node -e 'JSON.parse(require("fs").readFileSync("path", "utf8"))'`)
+- [ ] Every factual claim has at least one entry in `sources[]`
+- [ ] `lastUpdated` is set on `inclusion.json` (and any other file where you
+      add `lastUpdated`)
+- [ ] Committed under one location at a time — a bulk 50-location PR is
+      hard to review; prefer separate PRs or separate commits per location
+- [ ] No `_meta.status: "stub"` left in — the scaffolder emits this on
+      every new file; real PRs remove it when real data lands
+
+## Current gaps
+
+See `audits/location-data-gaps-<date>.md` for the authoritative list. At
+the time of this doc's writing:
+
+- **137 of 158 locations** missing `neighborhoods.json`
+- **137 of 158** missing `inclusion.json`
+- **137 of 158** missing `local-info.json`
+- **21 of 158** missing `services.json`
+
+Re-run `node tools/audit-location-data-completeness.mjs` any time to
+regenerate the report.

--- a/tools/scaffold-location-supplements.mjs
+++ b/tools/scaffold-location-supplements.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Scaffold empty-but-valid supplement JSON files for a location.
+//
+// Usage:   node tools/scaffold-location-supplements.mjs <location-id> [--force]
+// Example: node tools/scaffold-location-supplements.mjs us-austin
+//
+// Creates whichever of these files don't yet exist:
+//   neighborhoods.json, services.json, inclusion.json, local-info.json
+//
+// Every new file carries `_meta.status = "stub"` so reviewers can tell at
+// a glance which locations are placeholders awaiting contribution. Real
+// PRs should remove the _meta block when real data lands.
+//
+// See docs/CONTRIBUTING-LOCATION-DATA.md for field-by-field guidance.
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname.replace(/^\/([A-Za-z]):/, '$1:'));
+const LOC_DIR = join(ROOT, 'data', 'locations');
+const TODAY = new Date().toISOString().slice(0, 10);
+
+const args = process.argv.slice(2);
+const force = args.includes('--force');
+const locationId = args.find(a => !a.startsWith('--'));
+
+if (!locationId) {
+  console.error('Usage: node tools/scaffold-location-supplements.mjs <location-id> [--force]');
+  console.error('');
+  console.error('Available locations:');
+  const ids = readdirSync(LOC_DIR, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name)
+    .sort();
+  // Print in a compact grid.
+  const width = Math.max(...ids.map(id => id.length)) + 2;
+  const cols = Math.max(1, Math.floor(100 / width));
+  for (let i = 0; i < ids.length; i += cols) {
+    console.error('  ' + ids.slice(i, i + cols).map(id => id.padEnd(width)).join(''));
+  }
+  process.exit(1);
+}
+
+const locDir = join(LOC_DIR, locationId);
+if (!existsSync(locDir)) {
+  console.error(`No such location: ${locationId}`);
+  console.error(`Expected directory: ${locDir}`);
+  process.exit(1);
+}
+
+const baseJson = JSON.parse(readFileSync(join(locDir, 'location.json'), 'utf8'));
+const locName = baseJson.name ?? locationId;
+const primaryCity = Array.isArray(baseJson.cities) ? baseJson.cities[0] : locName;
+const currency = baseJson.currency ?? 'USD';
+
+// ─── Templates ────────────────────────────────────────────────────────────
+// Each template is a function so we can weave in data we already know
+// (currency code, primary city, climate) to save contributors time.
+
+const TEMPLATES = {
+  'neighborhoods.json': () => ({
+    _meta: {
+      status: 'stub',
+      generated: TODAY,
+      instructions:
+        'Replace this stub. Add 3–4 neighborhood entries with housing, ' +
+        'walk/transit scores, safety, expat community signals, and sources. ' +
+        'See docs/CONTRIBUTING-LOCATION-DATA.md.',
+    },
+    city: primaryCity,
+    neighborhoods: [],
+  }),
+
+  'services.json': () => ({
+    _meta: {
+      status: 'stub',
+      generated: TODAY,
+      instructions:
+        'Replace this stub. Add 2–4 entries per category (hospital, pharmacy, ' +
+        'grocery, bank, hardware, vet, gym, shopping, transit) with address, ' +
+        'distance, and sources. See docs/CONTRIBUTING-LOCATION-DATA.md.',
+    },
+    distanceUnit: 'km',
+    currency,
+    services: [],
+  }),
+
+  'inclusion.json': () => ({
+    _meta: {
+      status: 'stub',
+      generated: TODAY,
+      instructions:
+        'Replace this stub. Research racial / religious / LGBTQ / ability / ' +
+        'ageism inclusion for this location. Every subsection needs score, ' +
+        'summary, legal protections, positive factors, risk factors, and ' +
+        'sources. See docs/CONTRIBUTING-LOCATION-DATA.md for the required ' +
+        'shape — Portugal is the reference exemplar.',
+    },
+    country: baseJson.country ?? '',
+    region: baseJson.region ?? '',
+    overallInclusionScore: null,
+    lastUpdated: TODAY,
+    categories: {},
+  }),
+
+  'local-info.json': () => ({
+    _meta: {
+      status: 'stub',
+      generated: TODAY,
+      instructions:
+        'Replace this stub. Add webcams, bloggers, official sites, and YouTube ' +
+        'channels for the location. Climate is optional here — if omitted, the ' +
+        'dashboard falls back to location.json.climate.',
+    },
+    webcams: [],
+    bloggers: [],
+    officialSites: [],
+    youtubeChannels: [],
+  }),
+};
+
+let createdCount = 0;
+let skippedCount = 0;
+
+for (const [filename, builder] of Object.entries(TEMPLATES)) {
+  const target = join(locDir, filename);
+  if (existsSync(target) && !force) {
+    console.log(`  skip    ${filename} (already exists; pass --force to overwrite)`);
+    skippedCount++;
+    continue;
+  }
+  const payload = builder();
+  writeFileSync(target, JSON.stringify(payload, null, 2) + '\n');
+  console.log(`  created ${filename}`);
+  createdCount++;
+}
+
+console.log('');
+console.log(`${locationId}: ${createdCount} created, ${skippedCount} skipped`);
+if (createdCount > 0) {
+  console.log('Next steps:');
+  console.log(`  1. Edit data/locations/${locationId}/*.json`);
+  console.log('  2. Remove the _meta.status block when real data lands');
+  console.log('  3. Open a PR — see docs/CONTRIBUTING-LOCATION-DATA.md');
+}


### PR DESCRIPTION
## Summary
Unblocks the 137-location supplement-data gap by turning a blank-page problem into a template-fill problem.

**New:**
- [\`docs/CONTRIBUTING-LOCATION-DATA.md\`](docs/CONTRIBUTING-LOCATION-DATA.md) — schemas, conventions, field-by-field guidance for the four supplement JSONs (neighborhoods, services, inclusion, local-info). Reference exemplar: \`data/locations/portugal-lisbon/\`.
- [\`tools/scaffold-location-supplements.mjs\`](tools/scaffold-location-supplements.mjs) — generates empty-but-valid skeletons for a single location ID. Refuses to overwrite, carries explicit \`_meta.status: "stub"\` markers.

**Deliberately does NOT** commit pre-generated stubs across 137 locations — they'd be noise. The tool is on-demand per contributor per location.

**Follow-up (separate issue):** list every location with missing supplements so contributors can claim one.

## Test plan
- [x] Scaffolder ran on \`us-gainesville-va\` → created 4 valid files with correct shape
- [x] Scaffolder refused to overwrite when run on \`us-austin\` (already complete)
- [x] \`node tools/audit-location-data-completeness.mjs\` still reports expected gap counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)