### PR TITLE
feat(data): fill subregion on remaining 117 locations (FU-001 follow-up)

### DIFF
--- a/data/locations/colombia-bogota/location.json
+++ b/data/locations/colombia-bogota/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income if under 183 days/year.",
     "vatRate": 0.19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Distrito Capital"
 }

--- a/data/locations/colombia-cartagena/location.json
+++ b/data/locations/colombia-cartagena/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income if under 183 days/year.",
     "vatRate": 0.19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Bolívar"
 }

--- a/data/locations/colombia-medellin/location.json
+++ b/data/locations/colombia-medellin/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income if not a tax resident (under 183 days). If tax resident, worldwide income is taxed at progressive rates up to 39%.",
     "vatRate": 0.19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Antioquia"
 }

--- a/data/locations/colombia-pereira/location.json
+++ b/data/locations/colombia-pereira/location.json
@@ -170,5 +170,6 @@
     "notes": "No tax on foreign-source income if under 183 days/year.",
     "vatRate": 0.19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Risaralda"
 }

--- a/data/locations/colombia-santa-marta/location.json
+++ b/data/locations/colombia-santa-marta/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income if under 183 days/year.",
     "vatRate": 0.19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Magdalena"
 }

--- a/data/locations/costa-rica-arenal/location.json
+++ b/data/locations/costa-rica-arenal/location.json
@@ -170,5 +170,6 @@
     "notes": "Territorial tax system: foreign income not taxed.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Alajuela"
 }

--- a/data/locations/costa-rica-atenas/location.json
+++ b/data/locations/costa-rica-atenas/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax system: foreign income not taxed.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Alajuela"
 }

--- a/data/locations/costa-rica-central-valley/location.json
+++ b/data/locations/costa-rica-central-valley/location.json
@@ -170,5 +170,6 @@
     "notes": "Territorial tax system: only Costa Rica-sourced income is taxed. Foreign pensions and Social Security not taxed. CAJA mandatory contribution ~11% of declared income.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Central Valley"
 }

--- a/data/locations/costa-rica-grecia/location.json
+++ b/data/locations/costa-rica-grecia/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax system: foreign income not taxed.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Alajuela"
 }

--- a/data/locations/costa-rica-guanacaste/location.json
+++ b/data/locations/costa-rica-guanacaste/location.json
@@ -170,5 +170,6 @@
     "notes": "Territorial tax system: foreign income not taxed.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Guanacaste"
 }

--- a/data/locations/costa-rica-puerto-viejo/location.json
+++ b/data/locations/costa-rica-puerto-viejo/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax system: foreign income not taxed.",
     "vatRate": 0.13,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Limón"
 }

--- a/data/locations/croatia-dubrovnik/location.json
+++ b/data/locations/croatia-dubrovnik/location.json
@@ -175,5 +175,6 @@
     "notes": "Croatian progressive income tax 20% (up to €50,400) and 30% above. Surtax may apply (0-18% depending on municipality). No US-Croatia tax treaty.",
     "vatRate": 25,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Dubrovnik-Neretva"
 }

--- a/data/locations/croatia-istria/location.json
+++ b/data/locations/croatia-istria/location.json
@@ -175,5 +175,6 @@
     "notes": "Croatian progressive income tax 20%/30%. Municipal surtax may apply. No US-Croatia tax treaty.",
     "vatRate": 25,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Istria"
 }

--- a/data/locations/croatia-split/location.json
+++ b/data/locations/croatia-split/location.json
@@ -175,5 +175,6 @@
     "notes": "Croatian progressive income tax 20%/30%. Municipal surtax may apply. No US-Croatia tax treaty.",
     "vatRate": 25,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Split-Dalmatia"
 }

--- a/data/locations/croatia-zagreb/location.json
+++ b/data/locations/croatia-zagreb/location.json
@@ -175,5 +175,6 @@
     "notes": "Croatian progressive income tax 20%/30%. Zagreb has 18% municipal surtax. No US-Croatia tax treaty.",
     "vatRate": 25,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Zagreb"
 }

--- a/data/locations/cyprus-larnaca/location.json
+++ b/data/locations/cyprus-larnaca/location.json
@@ -175,5 +175,6 @@
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Very favorable for retirees.",
     "vatRate": 19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Larnaca District"
 }

--- a/data/locations/cyprus-limassol/location.json
+++ b/data/locations/cyprus-limassol/location.json
@@ -175,5 +175,6 @@
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Very favorable for retirees.",
     "vatRate": 19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Limassol District"
 }

--- a/data/locations/cyprus-paphos/location.json
+++ b/data/locations/cyprus-paphos/location.json
@@ -175,5 +175,6 @@
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Or opt for standard progressive rates 20%-35%. Very favorable for retirees. US-Cyprus tax treaty.",
     "vatRate": 19,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Paphos District"
 }

--- a/data/locations/ecuador-cotacachi/location.json
+++ b/data/locations/ecuador-cotacachi/location.json
@@ -168,5 +168,6 @@
     "notes": "Ecuador uses USD. Jubilado discounts apply.",
     "vatRate": 0.15,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Imbabura"
 }

--- a/data/locations/ecuador-cuenca/location.json
+++ b/data/locations/ecuador-cuenca/location.json
@@ -168,5 +168,6 @@
     "notes": "Ecuador uses USD. Income tax on worldwide income if fiscal resident, but retiree visa holders may qualify for exemptions. Progressive rates 0-37%. Jubilado discount benefits offset many costs.",
     "vatRate": 0.15,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Azuay"
 }

--- a/data/locations/ecuador-quito/location.json
+++ b/data/locations/ecuador-quito/location.json
@@ -168,5 +168,6 @@
     "notes": "Ecuador uses USD. Progressive income tax 0-37% on worldwide income for residents.",
     "vatRate": 0.15,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Pichincha"
 }

--- a/data/locations/ecuador-salinas/location.json
+++ b/data/locations/ecuador-salinas/location.json
@@ -168,5 +168,6 @@
     "notes": "Ecuador uses USD. Jubilado discounts apply.",
     "vatRate": 0.15,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Santa Elena"
 }

--- a/data/locations/ecuador-vilcabamba/location.json
+++ b/data/locations/ecuador-vilcabamba/location.json
@@ -168,5 +168,6 @@
     "notes": "Ecuador uses USD. Jubilado discounts apply.",
     "vatRate": 0.15,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Loja"
 }

--- a/data/locations/france-dordogne/location.json
+++ b/data/locations/france-dordogne/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Nouvelle-Aquitaine"
 }

--- a/data/locations/france-gascony/location.json
+++ b/data/locations/france-gascony/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Nouvelle-Aquitaine"
 }

--- a/data/locations/france-languedoc/location.json
+++ b/data/locations/france-languedoc/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income (CSG/CRDS). US-France tax treaty.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Occitanie"
 }

--- a/data/locations/france-nice/location.json
+++ b/data/locations/france-nice/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Provence-Alpes-Côte d'Azur"
 }

--- a/data/locations/france-paris/location.json
+++ b/data/locations/france-paris/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Île-de-France"
 }

--- a/data/locations/france-toulon/location.json
+++ b/data/locations/france-toulon/location.json
@@ -175,5 +175,6 @@
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",
     "vatRate": 20,
     "socialChargesRate": 9.1
-  }
+  },
+  "subregion": "Provence-Alpes-Côte d'Azur"
 }

--- a/data/locations/greece-athens/location.json
+++ b/data/locations/greece-athens/location.json
@@ -175,5 +175,6 @@
     "notes": "Greek progressive income tax 9%-44%. Special 7% flat tax for foreign retirees transferring tax residency (10-year program). US-Greece tax treaty.",
     "vatRate": 24,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Attica"
 }

--- a/data/locations/greece-corfu/location.json
+++ b/data/locations/greece-corfu/location.json
@@ -175,5 +175,6 @@
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",
     "vatRate": 24,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Ionian Islands"
 }

--- a/data/locations/greece-crete/location.json
+++ b/data/locations/greece-crete/location.json
@@ -175,5 +175,6 @@
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",
     "vatRate": 24,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Crete"
 }

--- a/data/locations/greece-peloponnese/location.json
+++ b/data/locations/greece-peloponnese/location.json
@@ -175,5 +175,6 @@
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",
     "vatRate": 24,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Peloponnese"
 }

--- a/data/locations/greece-rhodes/location.json
+++ b/data/locations/greece-rhodes/location.json
@@ -175,5 +175,6 @@
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",
     "vatRate": 24,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "South Aegean"
 }

--- a/data/locations/ireland-cork/location.json
+++ b/data/locations/ireland-cork/location.json
@@ -175,5 +175,6 @@
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",
     "vatRate": 23,
     "socialChargesRate": 4
-  }
+  },
+  "subregion": "Munster"
 }

--- a/data/locations/ireland-galway/location.json
+++ b/data/locations/ireland-galway/location.json
@@ -175,5 +175,6 @@
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",
     "vatRate": 23,
     "socialChargesRate": 4
-  }
+  },
+  "subregion": "Connacht"
 }

--- a/data/locations/ireland-limerick/location.json
+++ b/data/locations/ireland-limerick/location.json
@@ -175,5 +175,6 @@
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",
     "vatRate": 23,
     "socialChargesRate": 4
-  }
+  },
+  "subregion": "Munster"
 }

--- a/data/locations/ireland-wexford/location.json
+++ b/data/locations/ireland-wexford/location.json
@@ -175,5 +175,6 @@
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",
     "vatRate": 23,
     "socialChargesRate": 4
-  }
+  },
+  "subregion": "Leinster"
 }

--- a/data/locations/italy-abruzzo/location.json
+++ b/data/locations/italy-abruzzo/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. Italy offers 7% flat tax for retirees moving to southern regions (towns under 20K population). US-Italy tax treaty.",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Abruzzo"
 }

--- a/data/locations/italy-lake-region/location.json
+++ b/data/locations/italy-lake-region/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax not available (northern Italy, larger towns).",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Lombardy"
 }

--- a/data/locations/italy-puglia/location.json
+++ b/data/locations/italy-puglia/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax for retirees in southern towns under 20K population.",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Apulia"
 }

--- a/data/locations/italy-sardinia/location.json
+++ b/data/locations/italy-sardinia/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax may apply in qualifying small towns.",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Sardinia"
 }

--- a/data/locations/italy-sicily/location.json
+++ b/data/locations/italy-sicily/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax for retirees in southern towns under 20K population.",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Sicily"
 }

--- a/data/locations/italy-tuscany/location.json
+++ b/data/locations/italy-tuscany/location.json
@@ -175,5 +175,6 @@
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax not available in most Tuscan towns (population over 20K).",
     "vatRate": 22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Tuscany"
 }

--- a/data/locations/malta-gozo/location.json
+++ b/data/locations/malta-gozo/location.json
@@ -175,5 +175,6 @@
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year. Gozo has reduced property requirements.",
     "vatRate": 18,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Gozo"
 }

--- a/data/locations/malta-sliema/location.json
+++ b/data/locations/malta-sliema/location.json
@@ -175,5 +175,6 @@
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year.",
     "vatRate": 18,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Central Region"
 }

--- a/data/locations/malta-valletta/location.json
+++ b/data/locations/malta-valletta/location.json
@@ -175,5 +175,6 @@
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year. Standard rates 0%-35% otherwise. US-Malta tax treaty.",
     "vatRate": 18,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "South Eastern Region"
 }

--- a/data/locations/mexico-lake-chapala/location.json
+++ b/data/locations/mexico-lake-chapala/location.json
@@ -170,5 +170,6 @@
     "notes": "Territorial tax for temporary residents: only Mexican-source income taxed. US pensions and Social Security not taxed by Mexico for temporary residents.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Jalisco"
 }

--- a/data/locations/mexico-mazatlan/location.json
+++ b/data/locations/mexico-mazatlan/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Sinaloa"
 }

--- a/data/locations/mexico-merida/location.json
+++ b/data/locations/mexico-merida/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Yucatán"
 }

--- a/data/locations/mexico-oaxaca/location.json
+++ b/data/locations/mexico-oaxaca/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Oaxaca"
 }

--- a/data/locations/mexico-playa-del-carmen/location.json
+++ b/data/locations/mexico-playa-del-carmen/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Quintana Roo"
 }

--- a/data/locations/mexico-puerto-vallarta/location.json
+++ b/data/locations/mexico-puerto-vallarta/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Jalisco"
 }

--- a/data/locations/mexico-queretaro/location.json
+++ b/data/locations/mexico-queretaro/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Querétaro"
 }

--- a/data/locations/mexico-san-miguel-de-allende/location.json
+++ b/data/locations/mexico-san-miguel-de-allende/location.json
@@ -168,5 +168,6 @@
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",
     "vatRate": 0.16,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Guanajuato"
 }

--- a/data/locations/panama-bocas-del-toro/location.json
+++ b/data/locations/panama-bocas-del-toro/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Bocas del Toro"
 }

--- a/data/locations/panama-chitre/location.json
+++ b/data/locations/panama-chitre/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Herrera"
 }

--- a/data/locations/panama-city-bella-vista/location.json
+++ b/data/locations/panama-city-bella-vista/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income. Panama City has higher living costs but extensive urban amenities.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panama Province"
 }

--- a/data/locations/panama-city-casco-viejo/location.json
+++ b/data/locations/panama-city-casco-viejo/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panama Province"
 }

--- a/data/locations/panama-city-costa-del-este/location.json
+++ b/data/locations/panama-city-costa-del-este/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panama Province"
 }

--- a/data/locations/panama-city-el-cangrejo/location.json
+++ b/data/locations/panama-city-el-cangrejo/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panama Province"
 }

--- a/data/locations/panama-city-punta-pacifica/location.json
+++ b/data/locations/panama-city-punta-pacifica/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panama Province"
 }

--- a/data/locations/panama-coronado/location.json
+++ b/data/locations/panama-coronado/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Panamá Oeste"
 }

--- a/data/locations/panama-david/location.json
+++ b/data/locations/panama-david/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Chiriquí"
 }

--- a/data/locations/panama-el-valle/location.json
+++ b/data/locations/panama-el-valle/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Coclé"
 }

--- a/data/locations/panama-pedasi/location.json
+++ b/data/locations/panama-pedasi/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Los Santos"
 }

--- a/data/locations/panama-puerto-armuelles/location.json
+++ b/data/locations/panama-puerto-armuelles/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Chiriquí"
 }

--- a/data/locations/panama-volcan/location.json
+++ b/data/locations/panama-volcan/location.json
@@ -168,5 +168,6 @@
     "notes": "No tax on foreign-source income.",
     "vatRate": 0.07,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Chiriquí"
 }

--- a/data/locations/portugal-algarve/location.json
+++ b/data/locations/portugal-algarve/location.json
@@ -175,5 +175,6 @@
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%. US-Portugal tax treaty helps avoid double taxation.",
     "vatRate": 23,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Algarve"
 }

--- a/data/locations/portugal-cascais/location.json
+++ b/data/locations/portugal-cascais/location.json
@@ -175,5 +175,6 @@
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
     "vatRate": 23,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Lisboa"
 }

--- a/data/locations/portugal-porto/location.json
+++ b/data/locations/portugal-porto/location.json
@@ -175,5 +175,6 @@
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
     "vatRate": 23,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Norte"
 }

--- a/data/locations/portugal-silver-coast/location.json
+++ b/data/locations/portugal-silver-coast/location.json
@@ -175,5 +175,6 @@
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
     "vatRate": 23,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Centro"
 }

--- a/data/locations/spain-barcelona/location.json
+++ b/data/locations/spain-barcelona/location.json
@@ -175,5 +175,6 @@
     "notes": "Spanish progressive income tax 19%-47%. Catalonia has slightly higher regional surcharges.",
     "vatRate": 21,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Catalonia"
 }

--- a/data/locations/spain-canary-islands/location.json
+++ b/data/locations/spain-canary-islands/location.json
@@ -175,5 +175,6 @@
     "notes": "Spanish progressive income tax 19%-47%. Canary Islands use IGIC (7%) instead of mainland IVA/VAT (21%).",
     "vatRate": 7,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Canary Islands"
 }

--- a/data/locations/spain-costa-del-sol/location.json
+++ b/data/locations/spain-costa-del-sol/location.json
@@ -175,5 +175,6 @@
     "notes": "Spanish progressive income tax 19%-47%. Beckham Law may apply for new residents (flat 24% up to €600K). US-Spain tax treaty.",
     "vatRate": 21,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Andalusia"
 }

--- a/data/locations/spain-valencia/location.json
+++ b/data/locations/spain-valencia/location.json
@@ -175,5 +175,6 @@
     "notes": "Spanish progressive income tax 19%-47%. Valencia region may have slightly different regional rates.",
     "vatRate": 21,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Valencia"
 }

--- a/data/locations/uruguay-colonia/location.json
+++ b/data/locations/uruguay-colonia/location.json
@@ -168,5 +168,6 @@
     "notes": "Foreign income tax-exempt year 1, then 12% flat rate on foreign income.",
     "vatRate": 0.22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Colonia"
 }

--- a/data/locations/uruguay-montevideo/location.json
+++ b/data/locations/uruguay-montevideo/location.json
@@ -168,5 +168,6 @@
     "notes": "Foreign income tax-exempt in year 1. After that, foreign income taxed at flat 12% (reduced from standard rates). Uruguay has 22% IVA (VAT).",
     "vatRate": 0.22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Montevideo"
 }

--- a/data/locations/uruguay-punta-del-este/location.json
+++ b/data/locations/uruguay-punta-del-este/location.json
@@ -168,5 +168,6 @@
     "notes": "Foreign income tax-exempt year 1, then 12% flat rate on foreign income.",
     "vatRate": 0.22,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Maldonado"
 }

--- a/data/locations/us-albuquerque-nm/location.json
+++ b/data/locations/us-albuquerque-nm/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + NM state income tax (1.7-5.9%); SS benefits exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "New Mexico"
 }

--- a/data/locations/us-armstrong-county-pa/location.json
+++ b/data/locations/us-armstrong-county-pa/location.json
@@ -181,5 +181,6 @@
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Pennsylvania"
 }

--- a/data/locations/us-asheville-nc/location.json
+++ b/data/locations/us-asheville-nc/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + NC state income tax (flat 4.5%)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "North Carolina"
 }

--- a/data/locations/us-birmingham-al/location.json
+++ b/data/locations/us-birmingham-al/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + AL state income tax (2-5%); SS benefits exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Alabama"
 }

--- a/data/locations/us-chesapeake-va/location.json
+++ b/data/locations/us-chesapeake-va/location.json
@@ -252,5 +252,6 @@
     "Humid summers with high heat index",
     "Limited walkability in most neighborhoods",
     "Vehicle personal property tax adds ~$1,000/year"
-  ]
+  ],
+  "subregion": "Virginia"
 }

--- a/data/locations/us-chicago-il/location.json
+++ b/data/locations/us-chicago-il/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + IL flat state income tax (4.95%)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Illinois"
 }

--- a/data/locations/us-cleveland-oh/location.json
+++ b/data/locations/us-cleveland-oh/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + OH state income tax (0-3.75%) + city income tax (~2%)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Ohio"
 }

--- a/data/locations/us-dallas-tx/location.json
+++ b/data/locations/us-dallas-tx/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no TX state income tax (high property taxes)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Texas"
 }

--- a/data/locations/us-denver-co/location.json
+++ b/data/locations/us-denver-co/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + CO flat state income tax (4.4%)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Colorado"
 }

--- a/data/locations/us-fort-lauderdale-fl/location.json
+++ b/data/locations/us-fort-lauderdale-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-fort-wayne-in/location.json
+++ b/data/locations/us-fort-wayne-in/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + IN flat state income tax (3.05%) + county income tax; SS exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Indiana"
 }

--- a/data/locations/us-fort-worth-tx/location.json
+++ b/data/locations/us-fort-worth-tx/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no TX state income tax (high property taxes)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Texas"
 }

--- a/data/locations/us-grand-forks-nd/location.json
+++ b/data/locations/us-grand-forks-nd/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + ND state income tax (0-2.5%); very low rates",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "North Dakota"
 }

--- a/data/locations/us-killeen-tx/location.json
+++ b/data/locations/us-killeen-tx/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no TX state income tax (high property taxes)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Texas"
 }

--- a/data/locations/us-lapeer-mi/location.json
+++ b/data/locations/us-lapeer-mi/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + MI flat state income tax (4.25%); SS partially exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Michigan"
 }

--- a/data/locations/us-little-rock-ar/location.json
+++ b/data/locations/us-little-rock-ar/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + AR state income tax (2-4.4%); SS exempt up to $6,000",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Arkansas"
 }

--- a/data/locations/us-lorain-oh/location.json
+++ b/data/locations/us-lorain-oh/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + OH state income tax (0-3.75%) + city income tax (~2.5%)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Ohio"
 }

--- a/data/locations/us-lynchburg-va/location.json
+++ b/data/locations/us-lynchburg-va/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Virginia"
 }

--- a/data/locations/us-miami-fl/location.json
+++ b/data/locations/us-miami-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-milwaukee-wi/location.json
+++ b/data/locations/us-milwaukee-wi/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + WI state income tax (3.54-7.65%); SS benefits exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Wisconsin"
 }

--- a/data/locations/us-minneapolis-mn/location.json
+++ b/data/locations/us-minneapolis-mn/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + MN state income tax (5.35-9.85%); SS partially taxed",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Minnesota"
 }

--- a/data/locations/us-nashville-tn/location.json
+++ b/data/locations/us-nashville-tn/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no TN state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Tennessee"
 }

--- a/data/locations/us-norfolk-va/location.json
+++ b/data/locations/us-norfolk-va/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Virginia"
 }

--- a/data/locations/us-oakland-county-mi/location.json
+++ b/data/locations/us-oakland-county-mi/location.json
@@ -183,5 +183,6 @@
     "notes": "Federal + MI flat state income tax (4.25%); some cities add local tax; SS partially exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Michigan"
 }

--- a/data/locations/us-palm-bay-fl/location.json
+++ b/data/locations/us-palm-bay-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-pittsburgh-pa/location.json
+++ b/data/locations/us-pittsburgh-pa/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Pennsylvania"
 }

--- a/data/locations/us-port-huron-mi/location.json
+++ b/data/locations/us-port-huron-mi/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + MI flat state income tax (4.25%); SS partially exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Michigan"
 }

--- a/data/locations/us-portsmouth-va/location.json
+++ b/data/locations/us-portsmouth-va/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Virginia"
 }

--- a/data/locations/us-quincy-fl/location.json
+++ b/data/locations/us-quincy-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-saint-paul-mn/location.json
+++ b/data/locations/us-saint-paul-mn/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + MN state income tax (5.35-9.85%); SS partially taxed",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Minnesota"
 }

--- a/data/locations/us-san-marcos-tx/location.json
+++ b/data/locations/us-san-marcos-tx/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no TX state income tax (high property taxes)",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Texas"
 }

--- a/data/locations/us-skowhegan-me/location.json
+++ b/data/locations/us-skowhegan-me/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + ME state income tax (5.8-7.15%); SS exempt",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Maine"
 }

--- a/data/locations/us-st-augustine-fl/location.json
+++ b/data/locations/us-st-augustine-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-st-petersburg-fl/location.json
+++ b/data/locations/us-st-petersburg-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-tampa-fl/location.json
+++ b/data/locations/us-tampa-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/data/locations/us-virginia-beach-va/location.json
+++ b/data/locations/us-virginia-beach-va/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Virginia"
 }

--- a/data/locations/us-williamsport-pa/location.json
+++ b/data/locations/us-williamsport-pa/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Pennsylvania"
 }

--- a/data/locations/us-yulee-fl/location.json
+++ b/data/locations/us-yulee-fl/location.json
@@ -180,5 +180,6 @@
     "notes": "Federal only â€” no FL state income tax",
     "vatRate": 0,
     "socialChargesRate": 0
-  }
+  },
+  "subregion": "Florida"
 }

--- a/tools/normalize-region-taxonomy.mjs
+++ b/tools/normalize-region-taxonomy.mjs
@@ -80,12 +80,168 @@ const VALID_MACRO = new Set([
   'Africa', 'Oceania',
 ]);
 
+/** Per-location subregion assignments for locations whose `region` is
+ *  already a clean macro. Only adds `subregion` — never touches `region`.
+ *  Geography-derived; run once, idempotent. Order doesn't matter. */
+const ID_SUBREGION = {
+  // US state extraction (id suffix → state name)
+  'us-albuquerque-nm':         'New Mexico',
+  'us-armstrong-county-pa':    'Pennsylvania',
+  'us-asheville-nc':           'North Carolina',
+  'us-birmingham-al':          'Alabama',
+  'us-chesapeake-va':          'Virginia',
+  'us-chicago-il':             'Illinois',
+  'us-cleveland-oh':           'Ohio',
+  'us-dallas-tx':              'Texas',
+  'us-denver-co':              'Colorado',
+  'us-fort-lauderdale-fl':     'Florida',
+  'us-fort-wayne-in':          'Indiana',
+  'us-fort-worth-tx':          'Texas',
+  'us-grand-forks-nd':         'North Dakota',
+  'us-killeen-tx':             'Texas',
+  'us-lapeer-mi':              'Michigan',
+  'us-little-rock-ar':         'Arkansas',
+  'us-lorain-oh':              'Ohio',
+  'us-lynchburg-va':           'Virginia',
+  'us-miami-fl':               'Florida',
+  'us-milwaukee-wi':           'Wisconsin',
+  'us-minneapolis-mn':         'Minnesota',
+  'us-nashville-tn':           'Tennessee',
+  'us-norfolk-va':             'Virginia',
+  'us-oakland-county-mi':      'Michigan',
+  'us-palm-bay-fl':            'Florida',
+  'us-pittsburgh-pa':          'Pennsylvania',
+  'us-port-huron-mi':          'Michigan',
+  'us-portsmouth-va':          'Virginia',
+  'us-quincy-fl':              'Florida',
+  'us-saint-paul-mn':          'Minnesota',
+  'us-san-marcos-tx':          'Texas',
+  'us-skowhegan-me':           'Maine',
+  'us-st-augustine-fl':        'Florida',
+  'us-st-petersburg-fl':       'Florida',
+  'us-tampa-fl':               'Florida',
+  'us-virginia-beach-va':      'Virginia',
+  'us-williamsport-pa':        'Pennsylvania',
+  'us-yulee-fl':               'Florida',
+
+  // Colombia (departments)
+  'colombia-bogota':           'Distrito Capital',
+  'colombia-cartagena':        'Bolívar',
+  'colombia-medellin':         'Antioquia',
+  'colombia-pereira':          'Risaralda',
+  'colombia-santa-marta':      'Magdalena',
+
+  // Costa Rica (provincias)
+  'costa-rica-arenal':         'Alajuela',
+  'costa-rica-atenas':         'Alajuela',
+  'costa-rica-central-valley': 'Central Valley',
+  'costa-rica-grecia':         'Alajuela',
+  'costa-rica-guanacaste':     'Guanacaste',
+  'costa-rica-puerto-viejo':   'Limón',
+
+  // Croatia (županije)
+  'croatia-dubrovnik':         'Dubrovnik-Neretva',
+  'croatia-istria':            'Istria',
+  'croatia-split':             'Split-Dalmatia',
+  'croatia-zagreb':            'Zagreb',
+
+  // Cyprus (districts)
+  'cyprus-larnaca':            'Larnaca District',
+  'cyprus-limassol':           'Limassol District',
+  'cyprus-paphos':             'Paphos District',
+
+  // Ecuador (provincias)
+  'ecuador-cotacachi':         'Imbabura',
+  'ecuador-cuenca':            'Azuay',
+  'ecuador-quito':             'Pichincha',
+  'ecuador-salinas':           'Santa Elena',
+  'ecuador-vilcabamba':        'Loja',
+
+  // France (régions — 2016 reform names)
+  'france-dordogne':           'Nouvelle-Aquitaine',
+  'france-gascony':            'Nouvelle-Aquitaine',
+  'france-languedoc':          'Occitanie',
+  'france-nice':               "Provence-Alpes-Côte d'Azur",
+  'france-paris':              'Île-de-France',
+  'france-toulon':             "Provence-Alpes-Côte d'Azur",
+
+  // Greece (peripheries)
+  'greece-athens':             'Attica',
+  'greece-corfu':              'Ionian Islands',
+  'greece-crete':              'Crete',
+  'greece-peloponnese':        'Peloponnese',
+  'greece-rhodes':             'South Aegean',
+
+  // Ireland (provinces)
+  'ireland-cork':              'Munster',
+  'ireland-galway':            'Connacht',
+  'ireland-limerick':          'Munster',
+  'ireland-wexford':           'Leinster',
+
+  // Italy (regioni)
+  'italy-abruzzo':             'Abruzzo',
+  'italy-lake-region':         'Lombardy',
+  'italy-puglia':              'Apulia',
+  'italy-sardinia':            'Sardinia',
+  'italy-sicily':              'Sicily',
+  'italy-tuscany':             'Tuscany',
+
+  // Malta (regions)
+  'malta-gozo':                'Gozo',
+  'malta-sliema':              'Central Region',
+  'malta-valletta':            'South Eastern Region',
+
+  // Mexico (estados)
+  'mexico-lake-chapala':       'Jalisco',
+  'mexico-mazatlan':           'Sinaloa',
+  'mexico-merida':             'Yucatán',
+  'mexico-oaxaca':             'Oaxaca',
+  'mexico-playa-del-carmen':   'Quintana Roo',
+  'mexico-puerto-vallarta':    'Jalisco',
+  'mexico-queretaro':          'Querétaro',
+  'mexico-san-miguel-de-allende': 'Guanajuato',
+
+  // Panama (provincias) — panama-city-* are neighborhoods within Panama
+  // City proper, so all roll up to "Panama Province"
+  'panama-bocas-del-toro':     'Bocas del Toro',
+  'panama-chitre':             'Herrera',
+  'panama-city-bella-vista':   'Panama Province',
+  'panama-city-casco-viejo':   'Panama Province',
+  'panama-city-costa-del-este':'Panama Province',
+  'panama-city-el-cangrejo':   'Panama Province',
+  'panama-city-punta-pacifica':'Panama Province',
+  'panama-coronado':           'Panamá Oeste',
+  'panama-david':              'Chiriquí',
+  'panama-el-valle':           'Coclé',
+  'panama-pedasi':             'Los Santos',
+  'panama-puerto-armuelles':   'Chiriquí',
+  'panama-volcan':             'Chiriquí',
+
+  // Portugal (NUTS II regions)
+  'portugal-algarve':          'Algarve',
+  'portugal-cascais':          'Lisboa',
+  'portugal-porto':            'Norte',
+  'portugal-silver-coast':     'Centro',
+
+  // Spain (comunidades autónomas)
+  'spain-barcelona':           'Catalonia',
+  'spain-canary-islands':      'Canary Islands',
+  'spain-costa-del-sol':       'Andalusia',
+  'spain-valencia':            'Valencia',
+
+  // Uruguay (departamentos)
+  'uruguay-colonia':           'Colonia',
+  'uruguay-montevideo':        'Montevideo',
+  'uruguay-punta-del-este':    'Maldonado',
+};
+
 const ids = readdirSync(LOC_DIR, { withFileTypes: true })
   .filter(e => e.isDirectory())
   .map(e => e.name)
   .sort();
 
 let changed = 0;
+let subregionAdded = 0;
 let alreadyMacro = 0;
 let unmapped = 0;
 const unmappedList = [];
@@ -98,16 +254,28 @@ for (const id of ids) {
 
   if (REMAP[current]) {
     const { region, subregion } = REMAP[current];
-    if (data.region === region && data.subregion === subregion) continue; // idempotent
+    // Per-id override wins when present (e.g. us-virginia-va stays on
+    // "Virginia" rather than getting the REMAP-level subregion).
+    const finalSubregion = ID_SUBREGION[id] ?? subregion;
+    if (data.region === region && data.subregion === finalSubregion) continue;
     data.region = region;
-    data.subregion = subregion;
+    data.subregion = finalSubregion;
     changed++;
-    console.log(`  ${id.padEnd(28)} "${current}" → region="${region}" subregion="${subregion}"`);
+    console.log(`  ${id.padEnd(30)} "${current}" → region="${region}" subregion="${finalSubregion}"`);
     if (!dryRun) writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
     continue;
   }
 
   if (VALID_MACRO.has(current)) {
+    // Already on a macro — check if we have a subregion override to add.
+    const sub = ID_SUBREGION[id];
+    if (sub && data.subregion !== sub) {
+      data.subregion = sub;
+      subregionAdded++;
+      console.log(`  ${id.padEnd(30)} region="${current}" + subregion="${sub}"`);
+      if (!dryRun) writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+      continue;
+    }
     alreadyMacro++;
     continue;
   }
@@ -117,9 +285,10 @@ for (const id of ids) {
 }
 
 console.log('');
-console.log(`Remapped:      ${changed}`);
-console.log(`Already macro: ${alreadyMacro}`);
-console.log(`Unmapped:      ${unmapped}`);
+console.log(`Remapped (region → subregion):        ${changed}`);
+console.log(`Subregion added (already on macro):   ${subregionAdded}`);
+console.log(`Already macro, no subregion mapping:  ${alreadyMacro}`);
+console.log(`Unmapped:                              ${unmapped}`);
 if (unmappedList.length) {
   console.log('\nUnmapped regions (left untouched — add to REMAP or VALID_MACRO):');
   for (const u of unmappedList) {


### PR DESCRIPTION
## Summary
Extends \`tools/normalize-region-taxonomy.mjs\` with an \`ID_SUBREGION\` table that assigns a state / province / department / county to every location whose \`region\` was already on a macro and therefore got no \`subregion\` from the first pass.

**Coverage now: 158 / 158** locations carry both \`region\` and \`subregion\`.

## Taxonomy sources
| Country / region | Taxonomy used |
|---|---|
| US | state extracted from id suffix (-nc, -fl, -tx, …) |
| Colombia | departamentos |
| Costa Rica | provincias + "Central Valley" for the conurbation |
| Croatia | županije (Dubrovnik-Neretva, Split-Dalmatia, Istria, Zagreb) |
| Cyprus, Ecuador, Greece | first-level administrative divisions |
| France | post-2016 régions (Nouvelle-Aquitaine, Occitanie, Île-de-France, …) |
| Ireland | historical provinces (Munster, Leinster, Connacht) |
| Italy | regioni (Abruzzo, Apulia, Sicily, Tuscany, …) |
| Malta | statistical regions |
| Mexico | estados |
| Panama | provincias; all \`panama-city-*\` → Panama Province |
| Portugal | NUTS II regions (Norte, Centro, Algarve, Lisboa) |
| Spain | comunidades autónomas |
| Uruguay | departamentos |

Tool remains idempotent — re-running on the normalized tree is a no-op (verified).

## Test plan
- [x] Dry-run showed 117 new subregion assignments, 41 already populated from the prior pass, 0 unmapped
- [x] Ran the migration — re-running immediately is a no-op
- [x] \`npm run db:generate\` still clean (schema unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)