### PR TITLE
feat(db): surface subregion through AdminLocation + API

### DIFF
--- a/prisma/migrations/20260420194904_add_subregion_to_admin_location/migration.sql
+++ b/prisma/migrations/20260420194904_add_subregion_to_admin_location/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "admin_locations" ADD COLUMN     "subregion" TEXT;
+
+-- Backfill subregion from locationData JSONB. Paired with the region-
+-- taxonomy migration that added `subregion` to every location.json.
+-- Idempotent: running on rows that already have a subregion is a no-op.
+UPDATE "admin_locations"
+SET "subregion" = location_data->>'subregion'
+WHERE location_data ? 'subregion';
+
+-- CreateIndex
+CREATE INDEX "admin_locations_subregion_idx" ON "admin_locations"("subregion");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -321,6 +321,7 @@ model AdminLocation {
   name         String   @default("") // Extracted from locationData.name
   country      String   @default("") // Extracted from locationData.country
   region       String   @default("") // Extracted from locationData.region
+  subregion    String?  // Extracted from locationData.subregion (state/province/department)
   currency     String   @default("USD")
   monthlyCostTotal Int  @default(0) @map("monthly_cost_total") // Sum of all typical costs (USD)
 
@@ -329,6 +330,7 @@ model AdminLocation {
 
   @@index([country])
   @@index([region])
+  @@index([subregion])
   @@index([currency])
   @@index([monthlyCostTotal])
   @@index([name])

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -59,6 +59,7 @@ function extractSearchFields(locationData: Record<string, unknown>) {
   const name = typeof locationData.name === 'string' ? locationData.name : '';
   const country = typeof locationData.country === 'string' ? locationData.country : '';
   const region = typeof locationData.region === 'string' ? locationData.region : '';
+  const subregion = typeof locationData.subregion === 'string' ? locationData.subregion : null;
   const currency = typeof locationData.currency === 'string' ? locationData.currency : 'USD';
 
   // Sum all monthlyCosts.*.typical values for cost-range filtering
@@ -73,7 +74,7 @@ function extractSearchFields(locationData: Record<string, unknown>) {
     }
   }
 
-  return { name, country, region, currency, monthlyCostTotal: Math.round(monthlyCostTotal) };
+  return { name, country, region, subregion, currency, monthlyCostTotal: Math.round(monthlyCostTotal) };
 }
 
 export default async function adminRoutes(app: FastifyInstance): Promise<void> {

--- a/src/routes/locations.ts
+++ b/src/routes/locations.ts
@@ -110,6 +110,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
           name: true,
           country: true,
           region: true,
+          subregion: true,
           currency: true,
           monthlyCostTotal: true,
           updatedAt: true,
@@ -121,6 +122,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
           name: true,
           country: true,
           region: true,
+          subregion: true,
           currency: true,
           monthlyCostTotal: true,
           updatedAt: true,
@@ -149,6 +151,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
             name: loc.name,
             country: loc.country,
             region: loc.region,
+            subregion: loc.subregion,
             currency: loc.currency,
             monthlyCostTotal: loc.monthlyCostTotal,
             updatedAt: loc.updatedAt,
@@ -178,7 +181,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
     try {
       return await cached('locations:all', () =>
         prisma.adminLocation.findMany({
-          select: { id: true, name: true, country: true, region: true, currency: true, monthlyCostTotal: true },
+          select: { id: true, name: true, country: true, region: true, subregion: true, currency: true, monthlyCostTotal: true },
           orderBy: { name: 'asc' },
         }),
       );
@@ -277,6 +280,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
         name: loc.name,
         country: loc.country,
         region: loc.region,
+        subregion: loc.subregion,
         currency: loc.currency,
         monthlyCostTotal: loc.monthlyCostTotal,
         updatedAt: loc.updatedAt,

--- a/tools/backfill-subregion-from-files.mjs
+++ b/tools/backfill-subregion-from-files.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// One-off backfill: read subregion from each data/locations/<id>/location.json
+// and update the admin_locations.subregion column + the location_data JSONB.
+//
+// Ran after FU-001 region normalization + the 117-location subregion
+// fill-in. Safe to re-run — idempotent.
+//
+// Usage: node tools/backfill-subregion-from-files.mjs
+import 'dotenv/config';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname.replace(/^\/([A-Za-z]):/, '$1:'));
+const LOC_DIR = join(ROOT, 'data', 'locations');
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+const ids = readdirSync(LOC_DIR, { withFileTypes: true })
+  .filter(e => e.isDirectory())
+  .map(e => e.name)
+  .sort();
+
+let updated = 0;
+let skipped = 0;
+let missing = 0;
+
+for (const id of ids) {
+  const data = JSON.parse(readFileSync(join(LOC_DIR, id, 'location.json'), 'utf8'));
+  const subregion = data.subregion ?? null;
+
+  const row = await prisma.adminLocation.findUnique({ where: { id } });
+  if (!row) {
+    missing++;
+    console.log(`  MISSING ${id} (in data/ but not in DB)`);
+    continue;
+  }
+
+  // Update the denormalized column AND merge subregion into location_data so
+  // future reads of the JSONB carry it too. Prevents drift between the
+  // column and the JSONB payload.
+  const mergedLocationData = { ...(row.locationData ?? {}), subregion };
+  await prisma.adminLocation.update({
+    where: { id },
+    data: { subregion, locationData: mergedLocationData },
+  });
+  if (!row.subregion || row.subregion !== subregion) {
+    updated++;
+    console.log(`  ${id.padEnd(32)} subregion="${subregion ?? '(null)'}"`);
+  } else {
+    skipped++;
+  }
+}
+
+console.log('');
+console.log(`Updated: ${updated}`);
+console.log(`Skipped: ${skipped} (already in sync)`);
+console.log(`Missing: ${missing} (on disk but not in DB)`);
+
+await prisma.$disconnect();


### PR DESCRIPTION
## Summary
After FU-001 landed \`subregion\` on every \`location.json\`, the dashboard's region filter was still showing US macros — because \`/api/locations\` returns a **denormalized** row shape that didn't include \`subregion\`. (Dashboard#38 wired the UI helper but never received any values.)

### Schema
- New \`subregion String?\` column on \`AdminLocation\`, indexed for filter queries.
- Migration \`20260420194904_add_subregion_to_admin_location\` adds the column + backfills from the JSONB:
  \`\`\`sql
  UPDATE "admin_locations"
  SET "subregion" = location_data->>'subregion'
  WHERE location_data ? 'subregion';
  \`\`\`

### Sync
- \`extractSearchFields()\` in [\`admin.ts\`](src/routes/admin.ts) now emits \`subregion\` alongside region/country/etc., so future \`/api/admin/locations\` create + update flows keep the column in sync.

### Routes
- \`/api/locations\` (paginated) · \`/api/locations/all\` · \`/api/locations/:id\` all \`select\` and return \`subregion\`.

### Backfill
- [\`tools/backfill-subregion-from-files.mjs\`](tools/backfill-subregion-from-files.mjs) reconciles existing DB rows from the on-disk \`location.json\` files (the DB-side JSONB backfill alone isn't enough because the existing \`location_data\` was seeded before subregion existed). Idempotent.

## Test plan
- [x] \`prisma migrate deploy\` applied cleanly
- [x] \`node tools/backfill-subregion-from-files.mjs\` updated all 158 rows; rerun shows 0 updates
- [x] \`curl /api/locations?search=denver\` now returns \`"subregion": "Colorado"\`
- [x] \`curl /api/locations/all\` includes subregion on every row
- [x] \`npm run typecheck\` clean

Paired with already-merged [dashboard#38](https://github.com/justice8096/retirement-dashboard-angular/pull/38) — once this ships, dropdown flips from "US Mountain West" to "Colorado" etc. on hot reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)