### PR TITLE
feat(shared/taxes): structured Source[] citations for 2026 constants

### DIFF
--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1,5 +1,5 @@
-export { calcBracketTax, calcTaxesForLocation } from './taxes';
-export type { TaxBracket, TaxConfig, TaxResult, TaxDetail, SocialCharges, LocationWithTaxes } from './taxes';
+export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes';
+export type { TaxBracket, TaxConfig, TaxResult, TaxDetail, SocialCharges, LocationWithTaxes, Source } from './taxes';
 
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity';
 

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,5 +1,5 @@
 // @retirement/shared — pure calculation libraries shared between dashboard and API
-export { calcBracketTax, calcTaxesForLocation } from './taxes.js';
+export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes.js';
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity.js';
 export { getRMDStartAge, getDistributionPeriod, calcRMD, calcCoupleRMD, RMD_PENALTY_RATE, RMD_PENALTY_RATE_CORRECTED } from './rmd.js';
 export { getFxMultiplier, getInflationMultiplier, getInflationFxMultiplier, getAvgInflationMultiplier, getTypicalMonthly, getProjectedMonthly, projectCosts } from './inflation.js';

--- a/shared/taxes.d.ts
+++ b/shared/taxes.d.ts
@@ -1,3 +1,9 @@
+export interface Source {
+  title: string;
+  url: string;
+  accessed?: string;
+}
+
 export interface TaxBracket {
   min: number;
   max: number | null;
@@ -59,6 +65,10 @@ export interface LocationWithTaxes {
   taxes: TaxConfig;
   [key: string]: unknown;
 }
+
+export const FED_BRACKETS_2026_SOURCES: Source[];
+export const FED_STD_DEDUCTION_2026_SOURCES: Source[];
+export const OBBBA_SENIOR_SOURCES: Source[];
 
 export function calcBracketTax(income: number, brackets: TaxBracket[]): number;
 

--- a/shared/taxes.js
+++ b/shared/taxes.js
@@ -11,7 +11,10 @@ export function calcBracketTax(income, brackets) {
 
 // ─── 2026 tax constants (US) ────────────────────────────────────────────
 //
-// Sources:
+// Sources: see structured arrays (FED_BRACKETS_2026_SOURCES,
+// FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES) below — these
+// are what the dashboard surfaces through <app-source-tooltip>. The
+// free-text summary:
 //   - Federal income tax brackets + standard deduction:
 //     IRS Rev Proc 2025-32 (2026 inflation adjustments).
 //   - OBBBA senior bonus deduction:
@@ -22,6 +25,43 @@ export function calcBracketTax(income, brackets) {
 // Filing-status-specific brackets. The location seed data may override
 // these via `taxes.federalIncomeTax.brackets`, so callers that want
 // strict 2026 behaviour should NOT pass a `brackets` override.
+
+/** Citations for the 2026 federal bracket tables (MFJ + Single). */
+export var FED_BRACKETS_2026_SOURCES = [
+  {
+    title: 'IRS Rev. Proc. 2025-32 (2026 inflation adjustments)',
+    url: 'https://www.irs.gov/pub/irs-drop/rp-25-32.pdf',
+    accessed: '2026-04-20',
+  },
+  {
+    title: 'IRC § 1 — Tax imposed (statutory bracket structure)',
+    url: 'https://www.law.cornell.edu/uscode/text/26/1',
+    accessed: '2026-04-20',
+  },
+];
+
+/** Citations for the 2026 standard deduction (MFJ / Single / HoH). */
+export var FED_STD_DEDUCTION_2026_SOURCES = [
+  {
+    title: 'IRS Rev. Proc. 2025-32 § 3.17 (2026 standard deduction)',
+    url: 'https://www.irs.gov/pub/irs-drop/rp-25-32.pdf',
+    accessed: '2026-04-20',
+  },
+];
+
+/** Citations for the OBBBA senior bonus deduction ($6,000, age 65+, 2025–2028). */
+export var OBBBA_SENIOR_SOURCES = [
+  {
+    title: 'One Big Beautiful Bill Act § 13301 — Senior bonus deduction',
+    url: 'https://www.congress.gov/bill/119th-congress/house-bill/1/text',
+    accessed: '2026-04-20',
+  },
+  {
+    title: 'IRS summary: Additional senior deduction (IRC § 151(d)(5))',
+    url: 'https://www.irs.gov/newsroom/additional-deduction-for-taxpayers-aged-65-and-older',
+    accessed: '2026-04-20',
+  },
+];
 export var FED_STD_DEDUCTION_2026 = {
   mfj: 32200,
   single: 16100,


### PR DESCRIPTION
## Summary
- Adds `Source` interface to `shared/taxes.d.ts` (matches the dashboard's `Source` shape — independent declaration to keep `shared/` buildable without a frontend dep).
- Three structured citation arrays exported from `shared/taxes.js`:
  - `FED_BRACKETS_2026_SOURCES` — IRS Rev. Proc. 2025-32 + IRC § 1
  - `FED_STD_DEDUCTION_2026_SOURCES` — IRS Rev. Proc. 2025-32 § 3.17
  - `OBBBA_SENIOR_SOURCES` — OBBBA § 13301 + IRS guidance
- Re-exported from `shared/index.js` + `shared/index.d.ts` so the dashboard can `import { FED_BRACKETS_2026_SOURCES } from '@retirement/shared'` and feed it to `<app-source-tooltip>`.

The 2026 values themselves (`FED_BRACKETS_2026_MFJ/SINGLE`, `FED_STD_DEDUCTION_2026`, OBBBA senior bonus) were already landed and correct per Rev. Proc. 2025-32. This PR only adds structured source metadata — no behavior change.

Closes the #10 law-conformance citations: the 5 findings from the 2026-04-20 algorithm review are all closed; this surfaces the sources structurally so each value carries a clickable citation in the UI.

## Test plan
- [x] `npx vitest run shared/__tests__/taxes.test.js` — 37 passed
- [x] `node -e \"import('./shared/index.js').then(...)\"` — all three source arrays load and have populated entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)