### PR TITLE
feat(shared): country-keyed tax sources

### DIFF
--- a/shared/country-tax-sources.d.ts
+++ b/shared/country-tax-sources.d.ts
@@ -1,0 +1,7 @@
+import type { Source } from './taxes';
+
+/** Per-country structured tax-source citations keyed by full country name. */
+export const COUNTRY_TAX_SOURCES: Record<string, Source[]>;
+
+/** Lookup helper — returns `undefined` for unknown countries. */
+export function taxSourcesFor(country: string | null | undefined): Source[] | undefined;

--- a/shared/country-tax-sources.js
+++ b/shared/country-tax-sources.js
@@ -1,0 +1,221 @@
+/**
+ * Per-country structured citations for VAT, social charges, and income-tax
+ * bracket tables shown on the retirement dashboard's Taxes screen.
+ *
+ * Keyed by the `loc.country` string that retirement-api emits (full
+ * English name, not ISO code). Each entry lists 1–3 authoritative
+ * sources. Prefer the national tax authority's official page when
+ * available; fall back to the PwC / KPMG Worldwide Tax Summary (which
+ * the tax-advisory industry treats as the go-to English-language
+ * reference for cross-border retirees).
+ *
+ * Keep in sync with the dashboard-side rendering (see Todos #11).
+ */
+
+/** @typedef {{title: string, url: string, accessed?: string}} Source */
+
+/** @type {Record<string, Source[]>} */
+export var COUNTRY_TAX_SOURCES = {
+  'United States': [
+    {
+      title: 'IRS Rev. Proc. 2025-32 (2026 inflation adjustments)',
+      url: 'https://www.irs.gov/pub/irs-drop/rp-25-32.pdf',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'IRC § 1 — Tax imposed',
+      url: 'https://www.law.cornell.edu/uscode/text/26/1',
+      accessed: '2026-04-22',
+    },
+  ],
+  'France': [
+    {
+      title: 'DGFiP — Barème de l\'impôt sur le revenu 2026',
+      url: 'https://www.impots.gouv.fr/particulier/les-bareme-impots',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'Service-Public.fr — Prélèvements sociaux (CSG, CRDS)',
+      url: 'https://www.service-public.fr/particuliers/vosdroits/F2971',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — France',
+      url: 'https://taxsummaries.pwc.com/france',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Portugal': [
+    {
+      title: 'Autoridade Tributária — IRS (income tax)',
+      url: 'https://info.portaldasfinancas.gov.pt/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Portugal',
+      url: 'https://taxsummaries.pwc.com/portugal',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Spain': [
+    {
+      title: 'Agencia Tributaria — IRPF brackets',
+      url: 'https://sede.agenciatributaria.gob.es/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Spain',
+      url: 'https://taxsummaries.pwc.com/spain',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Italy': [
+    {
+      title: 'Agenzia delle Entrate — IRPEF brackets',
+      url: 'https://www.agenziaentrate.gov.it/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Italy',
+      url: 'https://taxsummaries.pwc.com/italy',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Ireland': [
+    {
+      title: 'Revenue.ie — Income tax rates and credits',
+      url: 'https://www.revenue.ie/en/jobs-and-pensions/calculating-your-income-tax/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Ireland',
+      url: 'https://taxsummaries.pwc.com/ireland',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Greece': [
+    {
+      title: 'AADE (Independent Authority for Public Revenue)',
+      url: 'https://www.aade.gr/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Greece',
+      url: 'https://taxsummaries.pwc.com/greece',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Croatia': [
+    {
+      title: 'Porezna uprava (Croatian Tax Administration)',
+      url: 'https://www.porezna-uprava.hr/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Croatia',
+      url: 'https://taxsummaries.pwc.com/croatia',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Cyprus': [
+    {
+      title: 'Cyprus Tax Department',
+      url: 'https://www.mof.gov.cy/mof/tax/taxdep.nsf',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Cyprus',
+      url: 'https://taxsummaries.pwc.com/cyprus',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Malta': [
+    {
+      title: 'Commissioner for Revenue (CfR) — Malta',
+      url: 'https://cfr.gov.mt/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Malta',
+      url: 'https://taxsummaries.pwc.com/malta',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Mexico': [
+    {
+      title: 'SAT (Servicio de Administración Tributaria)',
+      url: 'https://www.sat.gob.mx/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Mexico',
+      url: 'https://taxsummaries.pwc.com/mexico',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Panama': [
+    {
+      title: 'DGI Panamá (Dirección General de Ingresos)',
+      url: 'https://dgi.mef.gob.pa/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Panama',
+      url: 'https://taxsummaries.pwc.com/panama',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Costa Rica': [
+    {
+      title: 'Ministerio de Hacienda — Costa Rica',
+      url: 'https://www.hacienda.go.cr/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Costa Rica',
+      url: 'https://taxsummaries.pwc.com/costa-rica',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Colombia': [
+    {
+      title: 'DIAN (Dirección de Impuestos y Aduanas Nacionales)',
+      url: 'https://www.dian.gov.co/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Colombia',
+      url: 'https://taxsummaries.pwc.com/colombia',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Ecuador': [
+    {
+      title: 'SRI (Servicio de Rentas Internas)',
+      url: 'https://www.sri.gob.ec/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Ecuador',
+      url: 'https://taxsummaries.pwc.com/ecuador',
+      accessed: '2026-04-22',
+    },
+  ],
+  'Uruguay': [
+    {
+      title: 'DGI Uruguay (Dirección General Impositiva)',
+      url: 'https://www.dgi.gub.uy/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'PwC Worldwide Tax Summaries — Uruguay',
+      url: 'https://taxsummaries.pwc.com/uruguay',
+      accessed: '2026-04-22',
+    },
+  ],
+};
+
+/** Lookup helper — returns `undefined` for unknown countries. */
+export function taxSourcesFor(country) {
+  return COUNTRY_TAX_SOURCES[country];
+}

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1,5 +1,6 @@
 export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes';
 export type { TaxBracket, TaxConfig, TaxResult, TaxDetail, SocialCharges, LocationWithTaxes, Source } from './taxes';
+export { COUNTRY_TAX_SOURCES, taxSourcesFor } from './country-tax-sources';
 
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity';
 

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,5 +1,6 @@
 // @retirement/shared — pure calculation libraries shared between dashboard and API
 export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes.js';
+export { COUNTRY_TAX_SOURCES, taxSourcesFor } from './country-tax-sources.js';
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity.js';
 export { getRMDStartAge, getDistributionPeriod, calcRMD, calcCoupleRMD, RMD_PENALTY_RATE, RMD_PENALTY_RATE_CORRECTED } from './rmd.js';
 export { getFxMultiplier, getInflationMultiplier, getInflationFxMultiplier, getAvgInflationMultiplier, getTypicalMonthly, getProjectedMonthly, projectCosts } from './inflation.js';

--- a/src/routes/locations.ts
+++ b/src/routes/locations.ts
@@ -147,7 +147,7 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
       // them regardless of whether locationData carries them.
       const data = q.fields === 'full'
         ? locations.map((loc: Record<string, unknown>) => {
-            const merged = {
+            const merged: Record<string, unknown> = {
               ...(loc.locationData as Record<string, unknown>),
               id: loc.id,
               name: loc.name,

--- a/src/routes/locations.ts
+++ b/src/routes/locations.ts
@@ -15,6 +15,7 @@ import type { FastifyInstance } from 'fastify';
 import prisma from '../db/prisma.js';
 import { cached } from '../lib/cache.js';
 import { toValidationErrorPayload } from '../lib/validation.js';
+import { taxSourcesFor } from '../../shared/country-tax-sources.js';
 
 interface LocationData {
   name: string;
@@ -145,18 +146,32 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
       // (id, monthlyCostTotal, updatedAt, etc.) must be overlaid so clients get
       // them regardless of whether locationData carries them.
       const data = q.fields === 'full'
-        ? locations.map((loc: Record<string, unknown>) => ({
-            ...(loc.locationData as object),
-            id: loc.id,
-            name: loc.name,
-            country: loc.country,
-            region: loc.region,
-            subregion: loc.subregion,
-            currency: loc.currency,
-            monthlyCostTotal: loc.monthlyCostTotal,
-            updatedAt: loc.updatedAt,
-            _version: loc.version,
-          }))
+        ? locations.map((loc: Record<string, unknown>) => {
+            const merged = {
+              ...(loc.locationData as Record<string, unknown>),
+              id: loc.id,
+              name: loc.name,
+              country: loc.country,
+              region: loc.region,
+              subregion: loc.subregion,
+              currency: loc.currency,
+              monthlyCostTotal: loc.monthlyCostTotal,
+              updatedAt: loc.updatedAt,
+              _version: loc.version,
+            };
+            // Todos #11 — inject country-level tax citations so the Taxes
+            // screen tooltip can render on every card without a per-:id
+            // round-trip. Mirrors the injection in the /:id handler.
+            const sources = taxSourcesFor(loc.country as string);
+            if (sources) {
+              const taxes = (merged.taxes as Record<string, unknown> | undefined) ?? {};
+              if (!Array.isArray(taxes.sources) || taxes.sources.length === 0) {
+                taxes.sources = sources;
+              }
+              merged.taxes = taxes;
+            }
+            return merged;
+          })
         : locations;
 
       return {
@@ -262,6 +277,20 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
       // don't have to infer from field absence.
       if (healthcare && loc.country !== 'United States' && !aca) {
         healthcare.acaApplicable = false;
+      }
+
+      // Todos #11 — inject country-level tax citations onto the taxes
+      // payload. Sources aren't stored per-location seed; they're derived
+      // from `loc.country` at read time via shared/country-tax-sources.
+      const sources = taxSourcesFor(loc.country);
+      if (sources) {
+        const taxes = (data.taxes as Record<string, unknown> | undefined) ?? {};
+        // Preserve anything the seed already carried (e.g. if a location
+        // later ships per-location sources that override the country set).
+        if (!Array.isArray(taxes.sources) || taxes.sources.length === 0) {
+          taxes.sources = sources;
+        }
+        data.taxes = taxes;
       }
 
       // WCAG best-practice — natural-language summary that downstream


### PR DESCRIPTION
## Summary
Closes the foreign-taxation citation gap from [Todos #11](../../../../SecondBrainData/Retirement/Todos.md). The retirement-dashboard-angular Taxes screen now renders source tooltips on every location card — US + 15 foreign countries — instead of only US-bracket rows.

## Changes
- New `shared/country-tax-sources.{js,d.ts}` — `COUNTRY_TAX_SOURCES` map keyed by full country name. 16 countries; each entry cites the national tax authority (DGFiP, AT, Agencia Tributaria, SAT, DIAN, etc.) plus PwC Worldwide Tax Summaries as a secondary English-language reference.
- `shared/index.{js,d.ts}` re-exports `COUNTRY_TAX_SOURCES` + `taxSourcesFor()`.
- `src/routes/locations.ts` injects `taxes.sources` on both `GET /:id` and `GET /` (when `fields=full`). Injection is additive — per-location seed sources (if any) are preserved.

## Countries covered
United States, France, Portugal, Spain, Italy, Ireland, Greece, Croatia, Cyprus, Malta, Mexico, Panama, Costa Rica, Colombia, Ecuador, Uruguay.

## Test plan
- [x] 20 test files / 35,391 tests pass (`npx vitest run`).
- [x] Manually verified: `GET /api/locations/us-chicago-il` → 2 sources; `GET /api/locations/france-lyon` → 3 sources.
- [x] List endpoint (`GET /api/locations?fields=full&limit=5`) also injects sources (dashboard uses this to hydrate its cache).

## Pairs with
- [retirement-dashboard-angular#44](https://github.com/justice8096/retirement-dashboard-angular/pull/44) — consumer side (adds `TaxInfo.sources` + renders the tooltip on each card's country label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)