### PR TITLE
feat(shared): per-category cost-data sources + consolidated injector

### DIFF
--- a/shared/category-cost-sources.d.ts
+++ b/shared/category-cost-sources.d.ts
@@ -1,0 +1,7 @@
+import type { Source } from './taxes';
+
+/** Per-cost-category structured citations keyed by MonthlyCosts key. */
+export const CATEGORY_COST_SOURCES: Record<string, Source[]>;
+
+/** Lookup helper — returns `undefined` for unknown categories. */
+export function costSourcesFor(category: string | null | undefined): Source[] | undefined;

--- a/shared/category-cost-sources.js
+++ b/shared/category-cost-sources.js
@@ -1,0 +1,170 @@
+/**
+ * Per-category structured citations for the cost-range values
+ * (`monthlyCosts.<category>.typical` etc.) returned from the
+ * locations endpoints. Each category maps to 1–3 authoritative
+ * sources. Seed data doesn't carry these per-location; retirement-api
+ * injects them at response time based on the category key.
+ *
+ * Keys match `MonthlyCosts` properties on the dashboard model.
+ *
+ * See Todos #11.
+ */
+
+/** @typedef {{title: string, url: string, accessed?: string}} Source */
+
+/** @type {Record<string, Source[]>} */
+export var CATEGORY_COST_SOURCES = {
+  rent: [
+    {
+      title: 'Numbeo — Cost of Living (rent by city)',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'Expatistan — rent comparisons',
+      url: 'https://www.expatistan.com/cost-of-living',
+      accessed: '2026-04-22',
+    },
+  ],
+  groceries: [
+    {
+      title: 'Numbeo — Grocery basket prices',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  utilities: [
+    {
+      title: 'Numbeo — Utilities (electricity, water, heating, internet)',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  healthcare: [
+    {
+      title: 'OECD Health Statistics',
+      url: 'https://www.oecd.org/health/health-data.htm',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'World Health Organization — Country health profiles',
+      url: 'https://www.who.int/data/gho/data/countries',
+      accessed: '2026-04-22',
+    },
+  ],
+  insurance: [
+    {
+      title: 'International Insurance (Cigna Global, IMG, GeoBlue) rate quotes',
+      url: 'https://www.cignaglobal.com/',
+      accessed: '2026-04-22',
+    },
+  ],
+  medicine: [
+    {
+      title: 'GoodRx — Prescription price database (US)',
+      url: 'https://www.goodrx.com/',
+      accessed: '2026-04-22',
+    },
+    {
+      title: 'OECD — Pharmaceutical market / drug prices',
+      url: 'https://www.oecd.org/health/pharmaceutical-market.htm',
+      accessed: '2026-04-22',
+    },
+  ],
+  medicalOOP: [
+    {
+      title: 'KFF — Out-of-pocket health spending by country',
+      url: 'https://www.kff.org/',
+      accessed: '2026-04-22',
+    },
+  ],
+  petCare: [
+    {
+      title: 'Rover — Pet care costs by region',
+      url: 'https://www.rover.com/blog/pet-care-costs/',
+      accessed: '2026-04-22',
+    },
+  ],
+  petDaycare: [
+    {
+      title: 'Rover — Pet daycare rates',
+      url: 'https://www.rover.com/',
+      accessed: '2026-04-22',
+    },
+  ],
+  petGrooming: [
+    {
+      title: 'Rover — Pet grooming cost guide',
+      url: 'https://www.rover.com/blog/dog-grooming-cost/',
+      accessed: '2026-04-22',
+    },
+  ],
+  transportation: [
+    {
+      title: 'Numbeo — Transportation (fares, fuel, monthly pass)',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  entertainment: [
+    {
+      title: 'Numbeo — Restaurants & leisure',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  clothing: [
+    {
+      title: 'Numbeo — Clothing & shoes',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  personalCare: [
+    {
+      title: 'Numbeo — Personal care / haircut / hygiene',
+      url: 'https://www.numbeo.com/cost-of-living/',
+      accessed: '2026-04-22',
+    },
+  ],
+  subscriptions: [
+    {
+      title: 'Published list prices (Netflix, Spotify, ChatGPT, etc.)',
+      url: 'https://www.netflix.com/signup/planform',
+      accessed: '2026-04-22',
+    },
+  ],
+  phoneCell: [
+    {
+      title: 'Per-location detailed-costs seed (see supplements)',
+      url: 'https://github.com/justice8096/retirement-api/tree/master/data/locations',
+      accessed: '2026-04-22',
+    },
+  ],
+  taxes: [
+    {
+      title: 'See country tax-sources tooltip on the Taxes screen',
+      url: 'https://github.com/justice8096/retirement-api/blob/master/shared/country-tax-sources.js',
+      accessed: '2026-04-22',
+    },
+  ],
+  buffer: [
+    {
+      title: 'Internal assumption (10% contingency buffer over sum of categories)',
+      url: 'https://github.com/justice8096/retirement-dashboard-angular',
+      accessed: '2026-04-22',
+    },
+  ],
+  miscellaneous: [
+    {
+      title: 'Internal assumption (residual catch-all)',
+      url: 'https://github.com/justice8096/retirement-dashboard-angular',
+      accessed: '2026-04-22',
+    },
+  ],
+};
+
+/** Lookup helper — returns `undefined` for unknown categories. */
+export function costSourcesFor(category) {
+  return CATEGORY_COST_SOURCES[category];
+}

--- a/shared/index.d.ts
+++ b/shared/index.d.ts
@@ -1,6 +1,7 @@
 export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes';
 export type { TaxBracket, TaxConfig, TaxResult, TaxDetail, SocialCharges, LocationWithTaxes, Source } from './taxes';
 export { COUNTRY_TAX_SOURCES, taxSourcesFor } from './country-tax-sources';
+export { CATEGORY_COST_SOURCES, costSourcesFor } from './category-cost-sources';
 
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity';
 

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,6 +1,7 @@
 // @retirement/shared — pure calculation libraries shared between dashboard and API
 export { calcBracketTax, calcTaxesForLocation, FED_BRACKETS_2026_SOURCES, FED_STD_DEDUCTION_2026_SOURCES, OBBBA_SENIOR_SOURCES } from './taxes.js';
 export { COUNTRY_TAX_SOURCES, taxSourcesFor } from './country-tax-sources.js';
+export { CATEGORY_COST_SOURCES, costSourcesFor } from './category-cost-sources.js';
 export { calcSSBenefit, calcSpousalBenefit } from './socialSecurity.js';
 export { getRMDStartAge, getDistributionPeriod, calcRMD, calcCoupleRMD, RMD_PENALTY_RATE, RMD_PENALTY_RATE_CORRECTED } from './rmd.js';
 export { getFxMultiplier, getInflationMultiplier, getInflationFxMultiplier, getAvgInflationMultiplier, getTypicalMonthly, getProjectedMonthly, projectCosts } from './inflation.js';

--- a/src/routes/locations.ts
+++ b/src/routes/locations.ts
@@ -16,6 +16,35 @@ import prisma from '../db/prisma.js';
 import { cached } from '../lib/cache.js';
 import { toValidationErrorPayload } from '../lib/validation.js';
 import { taxSourcesFor } from '../../shared/country-tax-sources.js';
+import { costSourcesFor } from '../../shared/category-cost-sources.js';
+
+/** Shape a location data object in place with both country-level tax
+ *  citations and per-category cost citations. See Todos #11.
+ *  The injection is additive: if seed data already provided sources
+ *  at a given point, those are preserved. */
+function injectSources(data: Record<string, unknown>, country: string | null | undefined): void {
+  // Tax sources (country-keyed).
+  const taxSources = taxSourcesFor(country ?? '');
+  if (taxSources) {
+    const taxes = (data.taxes as Record<string, unknown> | undefined) ?? {};
+    if (!Array.isArray(taxes.sources) || taxes.sources.length === 0) {
+      taxes.sources = taxSources;
+    }
+    data.taxes = taxes;
+  }
+  // Per-category cost sources.
+  const monthlyCosts = data.monthlyCosts as Record<string, Record<string, unknown>> | undefined;
+  if (monthlyCosts) {
+    for (const key of Object.keys(monthlyCosts)) {
+      const range = monthlyCosts[key];
+      if (!range || typeof range !== 'object') continue;
+      const catSources = costSourcesFor(key);
+      if (catSources && (!Array.isArray(range.sources) || range.sources.length === 0)) {
+        range.sources = catSources;
+      }
+    }
+  }
+}
 
 interface LocationData {
   name: string;
@@ -159,17 +188,10 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
               updatedAt: loc.updatedAt,
               _version: loc.version,
             };
-            // Todos #11 — inject country-level tax citations so the Taxes
-            // screen tooltip can render on every card without a per-:id
-            // round-trip. Mirrors the injection in the /:id handler.
-            const sources = taxSourcesFor(loc.country as string);
-            if (sources) {
-              const taxes = (merged.taxes as Record<string, unknown> | undefined) ?? {};
-              if (!Array.isArray(taxes.sources) || taxes.sources.length === 0) {
-                taxes.sources = sources;
-              }
-              merged.taxes = taxes;
-            }
+            // Todos #11 — inject country-level tax + per-category cost
+            // citations so dashboard tooltips render without a per-:id
+            // round-trip. Additive: seed sources are preserved.
+            injectSources(merged, loc.country as string);
             return merged;
           })
         : locations;
@@ -279,19 +301,9 @@ export default async function locationRoutes(app: FastifyInstance): Promise<void
         healthcare.acaApplicable = false;
       }
 
-      // Todos #11 — inject country-level tax citations onto the taxes
-      // payload. Sources aren't stored per-location seed; they're derived
-      // from `loc.country` at read time via shared/country-tax-sources.
-      const sources = taxSourcesFor(loc.country);
-      if (sources) {
-        const taxes = (data.taxes as Record<string, unknown> | undefined) ?? {};
-        // Preserve anything the seed already carried (e.g. if a location
-        // later ships per-location sources that override the country set).
-        if (!Array.isArray(taxes.sources) || taxes.sources.length === 0) {
-          taxes.sources = sources;
-        }
-        data.taxes = taxes;
-      }
+      // Todos #11 — inject country-level tax + per-category cost citations.
+      // Additive: seed sources are preserved.
+      injectSources(data, loc.country);
 
       // WCAG best-practice — natural-language summary that downstream
       // screen-reader UIs can announce without re-synthesizing from fields.


### PR DESCRIPTION
## Summary
Follow-up to [#47](https://github.com/justice8096/retirement-api/pull/47) — closes the remaining cost-data citations gap from Todos #11. Every `monthlyCosts.<category>` entry returned from `/api/locations` and `/api/locations/:id` now carries a `sources: Source[]` array.

## Changes
- New `shared/category-cost-sources.{js,d.ts}` — 18 categories mapped to authoritative source URLs (Numbeo, Expatistan, GoodRx, OECD Health Statistics, WHO country profiles, Rover, KFF).
- `shared/index` re-exports `CATEGORY_COST_SOURCES` + `costSourcesFor`.
- `src/routes/locations.ts` — new `injectSources()` helper consolidates country-tax and per-category cost injection. Applied on both `GET /:id` and `GET /` (fields=full). Additive — seed sources are preserved.

## Verified
`GET /api/locations/us-chicago-il` returns sources on `rent` (2), `groceries` (1), `medicine` (2), `transportation` (1), `taxes` (1).

## Pairs with
- [retirement-dashboard-angular](https://github.com/justice8096/retirement-dashboard-angular) (upcoming PR) — adds `CostRange.sources?: Source[]` to the model and wires the tooltip into cost-detail headers (Housing / Groceries / Medicine / etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)