### PR TITLE
fix(seed): switch prisma/seed.ts to Prisma 7 driver-adapter

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,11 +6,15 @@
  *   tsx prisma/seed.ts                         # seed from default path
  *   DATA_DIR=./data tsx prisma/seed.ts         # seed from custom path
  */
+import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
 import fs from 'fs';
 import path from 'path';
 
-const prisma = new PrismaClient();
+// Prisma 7 requires the driver adapter pattern (see src/db/prisma.ts).
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
 
 // Default: read from the original project's data directory
 const DATA_DIR = process.env.DATA_DIR || path.resolve('../../data');


### PR DESCRIPTION
## Summary
`src/db/prisma.ts` already uses the `PrismaPg` driver adapter (required by Prisma 7 — `PrismaClient` without an adapter throws at construction). `prisma/seed.ts` was still instantiating `new PrismaClient()` directly, so `tsx prisma/seed.ts` broke after the Prisma 7 upgrade.

- Import `dotenv/config` so `DATABASE_URL` resolves when invoked outside the Fastify bootstrap.
- Pass `PrismaPg` into `PrismaClient`, matching the pattern in `src/db/prisma.ts`.

No behaviour change in the seeding logic itself — same upsert loop, same `supplementTypes` list.

## Test plan
- [ ] `tsx prisma/seed.ts` completes without the adapter error
- [x] Type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)