### PR TITLE
fix(services): restore local-cuisine search for San Juan + Raleigh

### DIFF
--- a/data/locations/us-raleigh/services.json
+++ b/data/locations/us-raleigh/services.json
@@ -325,13 +325,13 @@
     },
     {
       "categoryId": "restaurant_local",
-      "name": "Torero's Mexican Restaurant",
+      "name": "Top-rated Southern / Carolina BBQ (search)",
       "distanceMi": 30,
-      "notes": "Top-rated local restaurant within 30 mi. Sourced from OpenStreetMap.",
+      "notes": "Highest-rated authentic Southern / Eastern-Carolina BBQ restaurants within ~30 mi. OSM's first hit was already covered by another cuisine category, so we fall back to a search.",
       "sources": [
         {
-          "title": "OpenStreetMap — Torero's Mexican Restaurant",
-          "url": "https://www.openstreetmap.org/node/299507889",
+          "title": "Google Maps — top rated southern BBQ restaurants near Raleigh, NC",
+          "url": "https://www.google.com/maps/search/top%20rated%20southern%20bbq%20restaurants%20near%20Raleigh%2C%20NC",
           "accessed": "2026-04-23"
         }
       ]

--- a/data/locations/us-san-juan-pr/services.json
+++ b/data/locations/us-san-juan-pr/services.json
@@ -303,13 +303,13 @@
     },
     {
       "categoryId": "restaurant_local",
-      "name": "Chili's",
+      "name": "Top-rated Puerto Rican cuisine (search)",
       "distanceMi": 30,
-      "notes": "Top-rated local restaurant within 30 mi. Sourced from OpenStreetMap.",
+      "notes": "Highest-rated authentic Puerto Rican restaurants (mofongo, lechón, arroz con gandules) within ~30 mi. OSM's first hit was a chain already covered by another category, so we fall back to a search.",
       "sources": [
         {
-          "title": "OpenStreetMap — Chili's",
-          "url": "https://www.openstreetmap.org/node/660739551",
+          "title": "Google Maps — top rated Puerto Rican restaurants near San Juan, PR",
+          "url": "https://www.google.com/maps/search/top%20rated%20puerto%20rican%20restaurants%20near%20San%20Juan%2C%20PR",
           "accessed": "2026-04-23"
         }
       ]


### PR DESCRIPTION
## Summary

Per [codex-bot review on PR 58](https://github.com/justice8096/retirement-api/pull/58), the OSM enrichment picked the first restaurant hit within range, which collapsed two distinct categories into the same venue in two locations:

| Location | restaurant_local was | Same name also used for |
|---|---|---|
| us-san-juan-pr | Chili's | restaurant_mexican |
| us-raleigh | Torero's Mexican Restaurant | restaurant_mexican |

Both stripped the local-cuisine guidance the category is supposed to provide.

## Fix

Restore a cuisine-specific Google-Maps search placeholder for each:
- San Juan → "Top-rated Puerto Rican cuisine" (mofongo, lechon, arroz con gandules)
- Raleigh → "Top-rated Southern / Carolina BBQ"

Users now see an actionable pointer to authentic local food while we source better data.

## Test plan

- [ ] Dashboard Services screen for San Juan shows `restaurant_local` as Puerto Rican search link
- [ ] Dashboard Services screen for Raleigh shows `restaurant_local` as BBQ search link
- [ ] No other location has the same collision (verified via script — only these two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)