### PR TITLE
feat(local-info): discovery-link placeholders for 137 locations

### DIFF
--- a/data/locations/colombia-bogota/local-info.json
+++ b/data/locations/colombia-bogota/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Bogotá webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Bogot%C3%A1%20webcam",
+      "description": "Live webcams near Bogotá — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Bogotá on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Bogot%C3%A1%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Bogotá. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Bogotá expat blogs (search)",
+      "url": "https://www.google.com/search?q=Bogot%C3%A1%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Bogotá. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/colombia-cartagena/local-info.json
+++ b/data/locations/colombia-cartagena/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cartagena webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cartagena%20webcam",
+      "description": "Live webcams near Cartagena — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cartagena on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cartagena%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cartagena. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cartagena expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cartagena%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cartagena. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/colombia-medellin/local-info.json
+++ b/data/locations/colombia-medellin/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Medellín webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Medell%C3%ADn%20webcam",
+      "description": "Live webcams near Medellín — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Medellín on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Medell%C3%ADn%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Medellín. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Medellín expat blogs (search)",
+      "url": "https://www.google.com/search?q=Medell%C3%ADn%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Medellín. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/colombia-pereira/local-info.json
+++ b/data/locations/colombia-pereira/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Pereira / Coffee Axis webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Pereira%20%2F%20Coffee%20Axis%20webcam",
+      "description": "Live webcams near Pereira / Coffee Axis — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Pereira / Coffee Axis on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Pereira%20%2F%20Coffee%20Axis%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Pereira / Coffee Axis. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Pereira / Coffee Axis expat blogs (search)",
+      "url": "https://www.google.com/search?q=Pereira%20%2F%20Coffee%20Axis%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Pereira / Coffee Axis. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/colombia-santa-marta/local-info.json
+++ b/data/locations/colombia-santa-marta/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Santa Marta webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Santa%20Marta%20webcam",
+      "description": "Live webcams near Santa Marta — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Santa Marta on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Santa%20Marta%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Santa Marta. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Santa Marta expat blogs (search)",
+      "url": "https://www.google.com/search?q=Santa%20Marta%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Santa Marta. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-arenal/local-info.json
+++ b/data/locations/costa-rica-arenal/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Arenal / Lake Arenal webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Arenal%20%2F%20Lake%20Arenal%20webcam",
+      "description": "Live webcams near Arenal / Lake Arenal — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Arenal / Lake Arenal on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Arenal%20%2F%20Lake%20Arenal%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Arenal / Lake Arenal. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Arenal / Lake Arenal expat blogs (search)",
+      "url": "https://www.google.com/search?q=Arenal%20%2F%20Lake%20Arenal%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Arenal / Lake Arenal. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-atenas/local-info.json
+++ b/data/locations/costa-rica-atenas/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Atenas webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Atenas%20webcam",
+      "description": "Live webcams near Atenas — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Atenas on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Atenas%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Atenas. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Atenas expat blogs (search)",
+      "url": "https://www.google.com/search?q=Atenas%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Atenas. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-central-valley/local-info.json
+++ b/data/locations/costa-rica-central-valley/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Central Valley webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Central%20Valley%20webcam",
+      "description": "Live webcams near Central Valley — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Central Valley on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Central%20Valley%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Central Valley. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Central Valley expat blogs (search)",
+      "url": "https://www.google.com/search?q=Central%20Valley%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Central Valley. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-grecia/local-info.json
+++ b/data/locations/costa-rica-grecia/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Grecia webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Grecia%20webcam",
+      "description": "Live webcams near Grecia — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Grecia on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Grecia%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Grecia. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Grecia expat blogs (search)",
+      "url": "https://www.google.com/search?q=Grecia%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Grecia. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-guanacaste/local-info.json
+++ b/data/locations/costa-rica-guanacaste/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Guanacaste webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Guanacaste%20webcam",
+      "description": "Live webcams near Guanacaste — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Guanacaste on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Guanacaste%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Guanacaste. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Guanacaste expat blogs (search)",
+      "url": "https://www.google.com/search?q=Guanacaste%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Guanacaste. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/costa-rica-puerto-viejo/local-info.json
+++ b/data/locations/costa-rica-puerto-viejo/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Puerto Viejo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Puerto%20Viejo%20webcam",
+      "description": "Live webcams near Puerto Viejo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Puerto Viejo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Puerto%20Viejo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Puerto Viejo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Puerto Viejo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Puerto%20Viejo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Puerto Viejo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/croatia-dubrovnik/local-info.json
+++ b/data/locations/croatia-dubrovnik/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Dubrovnik webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Dubrovnik%20webcam",
+      "description": "Live webcams near Dubrovnik — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Dubrovnik on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Dubrovnik%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Dubrovnik. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Dubrovnik expat blogs (search)",
+      "url": "https://www.google.com/search?q=Dubrovnik%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Dubrovnik. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/croatia-istria/local-info.json
+++ b/data/locations/croatia-istria/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.istra-istria.hr/hr/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Istria webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Istria%20webcam",
+      "description": "Live webcams near Istria — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Istria on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Istria%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Istria. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Istria expat blogs (search)",
+      "url": "https://www.google.com/search?q=Istria%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Istria. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/croatia-split/local-info.json
+++ b/data/locations/croatia-split/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://split.hr/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Split webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Split%20webcam",
+      "description": "Live webcams near Split — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Split on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Split%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Split. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Split expat blogs (search)",
+      "url": "https://www.google.com/search?q=Split%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Split. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/croatia-zagreb/local-info.json
+++ b/data/locations/croatia-zagreb/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Zagreb webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Zagreb%20webcam",
+      "description": "Live webcams near Zagreb — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Zagreb on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Zagreb%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Zagreb. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Zagreb expat blogs (search)",
+      "url": "https://www.google.com/search?q=Zagreb%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Zagreb. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/cyprus-larnaca/local-info.json
+++ b/data/locations/cyprus-larnaca/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Larnaca webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Larnaca%20webcam",
+      "description": "Live webcams near Larnaca — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Larnaca on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Larnaca%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Larnaca. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Larnaca expat blogs (search)",
+      "url": "https://www.google.com/search?q=Larnaca%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Larnaca. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/cyprus-limassol/local-info.json
+++ b/data/locations/cyprus-limassol/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Limassol webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Limassol%20webcam",
+      "description": "Live webcams near Limassol — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Limassol on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Limassol%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Limassol. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Limassol expat blogs (search)",
+      "url": "https://www.google.com/search?q=Limassol%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Limassol. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/cyprus-paphos/local-info.json
+++ b/data/locations/cyprus-paphos/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 202,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Paphos webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Paphos%20webcam",
+      "description": "Live webcams near Paphos — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Paphos on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Paphos%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Paphos. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Paphos expat blogs (search)",
+      "url": "https://www.google.com/search?q=Paphos%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Paphos. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ecuador-cotacachi/local-info.json
+++ b/data/locations/ecuador-cotacachi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cotacachi webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cotacachi%20webcam",
+      "description": "Live webcams near Cotacachi — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cotacachi on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cotacachi%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cotacachi. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cotacachi expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cotacachi%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cotacachi. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ecuador-cuenca/local-info.json
+++ b/data/locations/ecuador-cuenca/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cuenca webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cuenca%20webcam",
+      "description": "Live webcams near Cuenca — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cuenca on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cuenca%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cuenca. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cuenca expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cuenca%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cuenca. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ecuador-quito/local-info.json
+++ b/data/locations/ecuador-quito/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Quito webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Quito%20webcam",
+      "description": "Live webcams near Quito — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Quito on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Quito%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Quito. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Quito expat blogs (search)",
+      "url": "https://www.google.com/search?q=Quito%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Quito. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ecuador-salinas/local-info.json
+++ b/data/locations/ecuador-salinas/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Salinas webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Salinas%20webcam",
+      "description": "Live webcams near Salinas — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Salinas on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Salinas%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Salinas. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Salinas expat blogs (search)",
+      "url": "https://www.google.com/search?q=Salinas%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Salinas. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ecuador-vilcabamba/local-info.json
+++ b/data/locations/ecuador-vilcabamba/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Vilcabamba webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Vilcabamba%20webcam",
+      "description": "Live webcams near Vilcabamba — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Vilcabamba on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Vilcabamba%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Vilcabamba. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Vilcabamba expat blogs (search)",
+      "url": "https://www.google.com/search?q=Vilcabamba%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Vilcabamba. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-dordogne/local-info.json
+++ b/data/locations/france-dordogne/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Dordogne webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Dordogne%20webcam",
+      "description": "Live webcams near Dordogne — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Dordogne on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Dordogne%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Dordogne. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Dordogne expat blogs (search)",
+      "url": "https://www.google.com/search?q=Dordogne%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Dordogne. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-gascony/local-info.json
+++ b/data/locations/france-gascony/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Gascony webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Gascony%20webcam",
+      "description": "Live webcams near Gascony — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Gascony on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Gascony%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Gascony. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Gascony expat blogs (search)",
+      "url": "https://www.google.com/search?q=Gascony%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Gascony. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-languedoc/local-info.json
+++ b/data/locations/france-languedoc/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Languedoc webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Languedoc%20webcam",
+      "description": "Live webcams near Languedoc — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Languedoc on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Languedoc%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Languedoc. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Languedoc expat blogs (search)",
+      "url": "https://www.google.com/search?q=Languedoc%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Languedoc. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-nice/local-info.json
+++ b/data/locations/france-nice/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Nice / Côte d'Azur webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Nice%20%2F%20C%C3%B4te%20d'Azur%20webcam",
+      "description": "Live webcams near Nice / Côte d'Azur — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Nice / Côte d'Azur on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Nice%20%2F%20C%C3%B4te%20d'Azur%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Nice / Côte d'Azur. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Nice / Côte d'Azur expat blogs (search)",
+      "url": "https://www.google.com/search?q=Nice%20%2F%20C%C3%B4te%20d'Azur%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Nice / Côte d'Azur. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-paris/local-info.json
+++ b/data/locations/france-paris/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Paris webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Paris%20webcam",
+      "description": "Live webcams near Paris — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Paris on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Paris%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Paris. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Paris expat blogs (search)",
+      "url": "https://www.google.com/search?q=Paris%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Paris. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/france-toulon/local-info.json
+++ b/data/locations/france-toulon/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://toulon.fr/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Toulon webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Toulon%20webcam",
+      "description": "Live webcams near Toulon — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Toulon on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Toulon%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Toulon. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Toulon expat blogs (search)",
+      "url": "https://www.google.com/search?q=Toulon%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Toulon. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/greece-athens/local-info.json
+++ b/data/locations/greece-athens/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 403,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Athens webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Athens%20webcam",
+      "description": "Live webcams near Athens — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Athens on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Athens%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Athens. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Athens expat blogs (search)",
+      "url": "https://www.google.com/search?q=Athens%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Athens. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/greece-corfu/local-info.json
+++ b/data/locations/greece-corfu/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://corfu.gr/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Corfu webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Corfu%20webcam",
+      "description": "Live webcams near Corfu — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Corfu on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Corfu%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Corfu. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Corfu expat blogs (search)",
+      "url": "https://www.google.com/search?q=Corfu%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Corfu. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/greece-crete/local-info.json
+++ b/data/locations/greece-crete/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Crete webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Crete%20webcam",
+      "description": "Live webcams near Crete — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Crete on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Crete%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Crete. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Crete expat blogs (search)",
+      "url": "https://www.google.com/search?q=Crete%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Crete. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/greece-peloponnese/local-info.json
+++ b/data/locations/greece-peloponnese/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Peloponnese webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Peloponnese%20webcam",
+      "description": "Live webcams near Peloponnese — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Peloponnese on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Peloponnese%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Peloponnese. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Peloponnese expat blogs (search)",
+      "url": "https://www.google.com/search?q=Peloponnese%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Peloponnese. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/greece-rhodes/local-info.json
+++ b/data/locations/greece-rhodes/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 404,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Rhodes webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Rhodes%20webcam",
+      "description": "Live webcams near Rhodes — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Rhodes on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Rhodes%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Rhodes. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Rhodes expat blogs (search)",
+      "url": "https://www.google.com/search?q=Rhodes%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Rhodes. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ireland-cork/local-info.json
+++ b/data/locations/ireland-cork/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.corkcity.ie/en/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cork webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cork%20webcam",
+      "description": "Live webcams near Cork — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cork on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cork%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cork. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cork expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cork%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cork. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ireland-galway/local-info.json
+++ b/data/locations/ireland-galway/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Galway webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Galway%20webcam",
+      "description": "Live webcams near Galway — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Galway on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Galway%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Galway. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Galway expat blogs (search)",
+      "url": "https://www.google.com/search?q=Galway%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Galway. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ireland-limerick/local-info.json
+++ b/data/locations/ireland-limerick/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Limerick webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Limerick%20webcam",
+      "description": "Live webcams near Limerick — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Limerick on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Limerick%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Limerick. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Limerick expat blogs (search)",
+      "url": "https://www.google.com/search?q=Limerick%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Limerick. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/ireland-wexford/local-info.json
+++ b/data/locations/ireland-wexford/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Wexford webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Wexford%20webcam",
+      "description": "Live webcams near Wexford — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Wexford on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Wexford%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Wexford. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Wexford expat blogs (search)",
+      "url": "https://www.google.com/search?q=Wexford%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Wexford. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-abruzzo/local-info.json
+++ b/data/locations/italy-abruzzo/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Abruzzo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Abruzzo%20webcam",
+      "description": "Live webcams near Abruzzo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Abruzzo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Abruzzo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Abruzzo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Abruzzo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Abruzzo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Abruzzo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-lake-region/local-info.json
+++ b/data/locations/italy-lake-region/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Italian Lake Region webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Italian%20Lake%20Region%20webcam",
+      "description": "Live webcams near Italian Lake Region — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Italian Lake Region on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Italian%20Lake%20Region%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Italian Lake Region. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Italian Lake Region expat blogs (search)",
+      "url": "https://www.google.com/search?q=Italian%20Lake%20Region%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Italian Lake Region. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-puglia/local-info.json
+++ b/data/locations/italy-puglia/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Puglia webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Puglia%20webcam",
+      "description": "Live webcams near Puglia — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Puglia on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Puglia%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Puglia. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Puglia expat blogs (search)",
+      "url": "https://www.google.com/search?q=Puglia%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Puglia. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-sardinia/local-info.json
+++ b/data/locations/italy-sardinia/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Sardinia webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Sardinia%20webcam",
+      "description": "Live webcams near Sardinia — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Sardinia on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Sardinia%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Sardinia. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Sardinia expat blogs (search)",
+      "url": "https://www.google.com/search?q=Sardinia%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Sardinia. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-sicily/local-info.json
+++ b/data/locations/italy-sicily/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Sicily webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Sicily%20webcam",
+      "description": "Live webcams near Sicily — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Sicily on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Sicily%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Sicily. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Sicily expat blogs (search)",
+      "url": "https://www.google.com/search?q=Sicily%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Sicily. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/italy-tuscany/local-info.json
+++ b/data/locations/italy-tuscany/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Tuscany webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Tuscany%20webcam",
+      "description": "Live webcams near Tuscany — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Tuscany on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Tuscany%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Tuscany. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Tuscany expat blogs (search)",
+      "url": "https://www.google.com/search?q=Tuscany%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Tuscany. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/malta-gozo/local-info.json
+++ b/data/locations/malta-gozo/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://gozo.gov.mt/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Gozo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Gozo%20webcam",
+      "description": "Live webcams near Gozo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Gozo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Gozo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Gozo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Gozo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Gozo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Gozo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/malta-sliema/local-info.json
+++ b/data/locations/malta-sliema/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Sliema webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Sliema%20webcam",
+      "description": "Live webcams near Sliema — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Sliema on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Sliema%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Sliema. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Sliema expat blogs (search)",
+      "url": "https://www.google.com/search?q=Sliema%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Sliema. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/malta-valletta/local-info.json
+++ b/data/locations/malta-valletta/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Valletta webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Valletta%20webcam",
+      "description": "Live webcams near Valletta — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Valletta on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Valletta%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Valletta. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Valletta expat blogs (search)",
+      "url": "https://www.google.com/search?q=Valletta%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Valletta. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-lake-chapala/local-info.json
+++ b/data/locations/mexico-lake-chapala/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Lake Chapala / Ajijic webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Lake%20Chapala%20%2F%20Ajijic%20webcam",
+      "description": "Live webcams near Lake Chapala / Ajijic — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Lake Chapala / Ajijic on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Lake%20Chapala%20%2F%20Ajijic%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Lake Chapala / Ajijic. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Lake Chapala / Ajijic expat blogs (search)",
+      "url": "https://www.google.com/search?q=Lake%20Chapala%20%2F%20Ajijic%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Lake Chapala / Ajijic. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-mazatlan/local-info.json
+++ b/data/locations/mexico-mazatlan/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 403,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Mazatlán webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Mazatl%C3%A1n%20webcam",
+      "description": "Live webcams near Mazatlán — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Mazatlán on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Mazatl%C3%A1n%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Mazatlán. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Mazatlán expat blogs (search)",
+      "url": "https://www.google.com/search?q=Mazatl%C3%A1n%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Mazatlán. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-merida/local-info.json
+++ b/data/locations/mexico-merida/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://validate.perfdrive.com/?ssa=da94819e-2c1f-489a-8cfc-0047da2c6e12&ssb=63252213301&ssc=https%3A%2F%2Fwww.merida.gob.mx%2F&ssi=6c397185-cirv-4369-a55a-666cd58c862d&ssk=botmanager_support@radware.com&ssm=31328425703574036104536488322657&ssn=98682c8cac59a87c91aeec063ed9ca9492aa042c65ba-9015-46da-9861a8&sso=bfbf5f9c-528051d31ecd8694644e974e2cafae0e1a16e3a08a1e4f43&ssp=22835034681776903620177697921366536&ssq=12934773566317974759435663746096163729049&ssr=OTYuMjQxLjEzMS4xMjA=&sst=retirement-api-link-probe/1.0&ssu=&ssv=&ssw=&ssx=eyJfX3V6bWYiOiI3ZjkwMDAwNDJjNjViYS05MDE1LTQ2ZGEtOWY5Yy01MjgwNTFkMzFlY2QxLTE3NzY5MzU2NjM2MjQwLTAwMzUzNGRiNjU0NTc5NDczMTcxMCIsInJkIjoibWVyaWRhLmdvYi5teCIsInV6bXgiOiI3ZjkwMDAzMjMxYjJkYi1jZTRjLTRjNjEtYWNmMC00OGI0OWY2YzU2YWMxLTE3NzY5MzU2NjM2MjQwLWYxYTMwN2I2ZjRhOGZkOTAxMCJ9"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Mérida webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?M%C3%A9rida%20webcam",
+      "description": "Live webcams near Mérida — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Mérida on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=M%C3%A9rida%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Mérida. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Mérida expat blogs (search)",
+      "url": "https://www.google.com/search?q=M%C3%A9rida%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Mérida. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-oaxaca/local-info.json
+++ b/data/locations/mexico-oaxaca/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Oaxaca City webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Oaxaca%20City%20webcam",
+      "description": "Live webcams near Oaxaca City — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Oaxaca City on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Oaxaca%20City%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Oaxaca City. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Oaxaca City expat blogs (search)",
+      "url": "https://www.google.com/search?q=Oaxaca%20City%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Oaxaca City. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-playa-del-carmen/local-info.json
+++ b/data/locations/mexico-playa-del-carmen/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Playa del Carmen webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Playa%20del%20Carmen%20webcam",
+      "description": "Live webcams near Playa del Carmen — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Playa del Carmen on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Playa%20del%20Carmen%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Playa del Carmen. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Playa del Carmen expat blogs (search)",
+      "url": "https://www.google.com/search?q=Playa%20del%20Carmen%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Playa del Carmen. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-puerto-vallarta/local-info.json
+++ b/data/locations/mexico-puerto-vallarta/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Puerto Vallarta webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Puerto%20Vallarta%20webcam",
+      "description": "Live webcams near Puerto Vallarta — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Puerto Vallarta on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Puerto%20Vallarta%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Puerto Vallarta. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Puerto Vallarta expat blogs (search)",
+      "url": "https://www.google.com/search?q=Puerto%20Vallarta%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Puerto Vallarta. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-queretaro/local-info.json
+++ b/data/locations/mexico-queretaro/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Querétaro webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Quer%C3%A9taro%20webcam",
+      "description": "Live webcams near Querétaro — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Querétaro on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Quer%C3%A9taro%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Querétaro. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Querétaro expat blogs (search)",
+      "url": "https://www.google.com/search?q=Quer%C3%A9taro%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Querétaro. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/mexico-san-miguel-de-allende/local-info.json
+++ b/data/locations/mexico-san-miguel-de-allende/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.sanmigueldeallende.gob.mx/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "San Miguel de Allende webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?San%20Miguel%20de%20Allende%20webcam",
+      "description": "Live webcams near San Miguel de Allende — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "San Miguel de Allende on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=San%20Miguel%20de%20Allende%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in San Miguel de Allende. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "San Miguel de Allende expat blogs (search)",
+      "url": "https://www.google.com/search?q=San%20Miguel%20de%20Allende%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about San Miguel de Allende. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-bocas-del-toro/local-info.json
+++ b/data/locations/panama-bocas-del-toro/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Bocas del Toro webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Bocas%20del%20Toro%20webcam",
+      "description": "Live webcams near Bocas del Toro — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Bocas del Toro on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Bocas%20del%20Toro%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Bocas del Toro. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Bocas del Toro expat blogs (search)",
+      "url": "https://www.google.com/search?q=Bocas%20del%20Toro%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Bocas del Toro. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-chitre/local-info.json
+++ b/data/locations/panama-chitre/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Chitré webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Chitr%C3%A9%20webcam",
+      "description": "Live webcams near Chitré — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Chitré on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Chitr%C3%A9%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Chitré. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Chitré expat blogs (search)",
+      "url": "https://www.google.com/search?q=Chitr%C3%A9%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Chitré. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-city-bella-vista/local-info.json
+++ b/data/locations/panama-city-bella-vista/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://mupa.gob.pa/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Panama City — Bella Vista webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Panama%20City%20%E2%80%94%20Bella%20Vista%20webcam",
+      "description": "Live webcams near Panama City — Bella Vista — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Panama City — Bella Vista on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Panama%20City%20%E2%80%94%20Bella%20Vista%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Panama City — Bella Vista. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Panama City — Bella Vista expat blogs (search)",
+      "url": "https://www.google.com/search?q=Panama%20City%20%E2%80%94%20Bella%20Vista%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Panama City — Bella Vista. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-city-casco-viejo/local-info.json
+++ b/data/locations/panama-city-casco-viejo/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://mupa.gob.pa/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Panama City — Casco Viejo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Panama%20City%20%E2%80%94%20Casco%20Viejo%20webcam",
+      "description": "Live webcams near Panama City — Casco Viejo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Panama City — Casco Viejo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Panama%20City%20%E2%80%94%20Casco%20Viejo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Panama City — Casco Viejo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Panama City — Casco Viejo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Panama%20City%20%E2%80%94%20Casco%20Viejo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Panama City — Casco Viejo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-city-costa-del-este/local-info.json
+++ b/data/locations/panama-city-costa-del-este/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://mupa.gob.pa/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Panama City — Costa del Este webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Panama%20City%20%E2%80%94%20Costa%20del%20Este%20webcam",
+      "description": "Live webcams near Panama City — Costa del Este — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Panama City — Costa del Este on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Panama%20City%20%E2%80%94%20Costa%20del%20Este%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Panama City — Costa del Este. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Panama City — Costa del Este expat blogs (search)",
+      "url": "https://www.google.com/search?q=Panama%20City%20%E2%80%94%20Costa%20del%20Este%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Panama City — Costa del Este. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-city-el-cangrejo/local-info.json
+++ b/data/locations/panama-city-el-cangrejo/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://mupa.gob.pa/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Panama City — El Cangrejo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Panama%20City%20%E2%80%94%20El%20Cangrejo%20webcam",
+      "description": "Live webcams near Panama City — El Cangrejo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Panama City — El Cangrejo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Panama%20City%20%E2%80%94%20El%20Cangrejo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Panama City — El Cangrejo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Panama City — El Cangrejo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Panama%20City%20%E2%80%94%20El%20Cangrejo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Panama City — El Cangrejo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-city-punta-pacifica/local-info.json
+++ b/data/locations/panama-city-punta-pacifica/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://mupa.gob.pa/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Panama City — Punta Pacifica webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Panama%20City%20%E2%80%94%20Punta%20Pacifica%20webcam",
+      "description": "Live webcams near Panama City — Punta Pacifica — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Panama City — Punta Pacifica on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Panama%20City%20%E2%80%94%20Punta%20Pacifica%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Panama City — Punta Pacifica. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Panama City — Punta Pacifica expat blogs (search)",
+      "url": "https://www.google.com/search?q=Panama%20City%20%E2%80%94%20Punta%20Pacifica%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Panama City — Punta Pacifica. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-coronado/local-info.json
+++ b/data/locations/panama-coronado/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Coronado webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Coronado%20webcam",
+      "description": "Live webcams near Coronado — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Coronado on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Coronado%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Coronado. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Coronado expat blogs (search)",
+      "url": "https://www.google.com/search?q=Coronado%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Coronado. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-david/local-info.json
+++ b/data/locations/panama-david/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "David webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?David%20webcam",
+      "description": "Live webcams near David — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "David on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=David%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in David. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "David expat blogs (search)",
+      "url": "https://www.google.com/search?q=David%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about David. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-el-valle/local-info.json
+++ b/data/locations/panama-el-valle/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "El Valle de Antón webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?El%20Valle%20de%20Ant%C3%B3n%20webcam",
+      "description": "Live webcams near El Valle de Antón — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "El Valle de Antón on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=El%20Valle%20de%20Ant%C3%B3n%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in El Valle de Antón. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "El Valle de Antón expat blogs (search)",
+      "url": "https://www.google.com/search?q=El%20Valle%20de%20Ant%C3%B3n%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about El Valle de Antón. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-pedasi/local-info.json
+++ b/data/locations/panama-pedasi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Pedasí webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Pedas%C3%AD%20webcam",
+      "description": "Live webcams near Pedasí — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Pedasí on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Pedas%C3%AD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Pedasí. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Pedasí expat blogs (search)",
+      "url": "https://www.google.com/search?q=Pedas%C3%AD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Pedasí. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-puerto-armuelles/local-info.json
+++ b/data/locations/panama-puerto-armuelles/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Puerto Armuelles webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Puerto%20Armuelles%20webcam",
+      "description": "Live webcams near Puerto Armuelles — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Puerto Armuelles on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Puerto%20Armuelles%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Puerto Armuelles. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Puerto Armuelles expat blogs (search)",
+      "url": "https://www.google.com/search?q=Puerto%20Armuelles%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Puerto Armuelles. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/panama-volcan/local-info.json
+++ b/data/locations/panama-volcan/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Volcán webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Volc%C3%A1n%20webcam",
+      "description": "Live webcams near Volcán — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Volcán on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Volc%C3%A1n%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Volcán. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Volcán expat blogs (search)",
+      "url": "https://www.google.com/search?q=Volc%C3%A1n%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Volcán. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/portugal-algarve/local-info.json
+++ b/data/locations/portugal-algarve/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.ccdr-alg.pt/site/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Algarve webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Algarve%20webcam",
+      "description": "Live webcams near Algarve — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Algarve on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Algarve%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Algarve. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Algarve expat blogs (search)",
+      "url": "https://www.google.com/search?q=Algarve%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Algarve. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/portugal-cascais/local-info.json
+++ b/data/locations/portugal-cascais/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cascais webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cascais%20webcam",
+      "description": "Live webcams near Cascais — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cascais on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cascais%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cascais. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cascais expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cascais%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cascais. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/portugal-porto/local-info.json
+++ b/data/locations/portugal-porto/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Porto webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Porto%20webcam",
+      "description": "Live webcams near Porto — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Porto on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Porto%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Porto. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Porto expat blogs (search)",
+      "url": "https://www.google.com/search?q=Porto%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Porto. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/portugal-silver-coast/local-info.json
+++ b/data/locations/portugal-silver-coast/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Silver Coast webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Silver%20Coast%20webcam",
+      "description": "Live webcams near Silver Coast — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Silver Coast on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Silver%20Coast%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Silver Coast. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Silver Coast expat blogs (search)",
+      "url": "https://www.google.com/search?q=Silver%20Coast%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Silver Coast. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/spain-barcelona/local-info.json
+++ b/data/locations/spain-barcelona/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.barcelona.cat/ca"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Barcelona webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Barcelona%20webcam",
+      "description": "Live webcams near Barcelona — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Barcelona on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Barcelona%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Barcelona. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Barcelona expat blogs (search)",
+      "url": "https://www.google.com/search?q=Barcelona%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Barcelona. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/spain-canary-islands/local-info.json
+++ b/data/locations/spain-canary-islands/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.gobiernodecanarias.org/principal/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Canary Islands webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Canary%20Islands%20webcam",
+      "description": "Live webcams near Canary Islands — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Canary Islands on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Canary%20Islands%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Canary Islands. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Canary Islands expat blogs (search)",
+      "url": "https://www.google.com/search?q=Canary%20Islands%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Canary Islands. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/spain-costa-del-sol/local-info.json
+++ b/data/locations/spain-costa-del-sol/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Costa del Sol webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Costa%20del%20Sol%20webcam",
+      "description": "Live webcams near Costa del Sol — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Costa del Sol on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Costa%20del%20Sol%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Costa del Sol. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Costa del Sol expat blogs (search)",
+      "url": "https://www.google.com/search?q=Costa%20del%20Sol%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Costa del Sol. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/spain-valencia/local-info.json
+++ b/data/locations/spain-valencia/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.valencia.es/cas/inicio"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Valencia webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Valencia%20webcam",
+      "description": "Live webcams near Valencia — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Valencia on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Valencia%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Valencia. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Valencia expat blogs (search)",
+      "url": "https://www.google.com/search?q=Valencia%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Valencia. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/uruguay-colonia/local-info.json
+++ b/data/locations/uruguay-colonia/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Colonia del Sacramento webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Colonia%20del%20Sacramento%20webcam",
+      "description": "Live webcams near Colonia del Sacramento — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Colonia del Sacramento on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Colonia%20del%20Sacramento%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Colonia del Sacramento. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Colonia del Sacramento expat blogs (search)",
+      "url": "https://www.google.com/search?q=Colonia%20del%20Sacramento%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Colonia del Sacramento. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/uruguay-montevideo/local-info.json
+++ b/data/locations/uruguay-montevideo/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Montevideo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Montevideo%20webcam",
+      "description": "Live webcams near Montevideo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Montevideo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Montevideo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Montevideo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Montevideo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Montevideo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Montevideo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/uruguay-punta-del-este/local-info.json
+++ b/data/locations/uruguay-punta-del-este/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Punta del Este webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Punta%20del%20Este%20webcam",
+      "description": "Live webcams near Punta del Este — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Punta del Este on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Punta%20del%20Este%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Punta del Este. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Punta del Este expat blogs (search)",
+      "url": "https://www.google.com/search?q=Punta%20del%20Este%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Punta del Este. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-albuquerque-nm/local-info.json
+++ b/data/locations/us-albuquerque-nm/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Albuquerque webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Albuquerque%20webcam",
+      "description": "Live webcams near Albuquerque — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Albuquerque on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Albuquerque%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Albuquerque. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Albuquerque expat blogs (search)",
+      "url": "https://www.google.com/search?q=Albuquerque%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Albuquerque. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-annandale-va/local-info.json
+++ b/data/locations/us-annandale-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Annandale VA webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Annandale%20VA%20webcam",
+      "description": "Live webcams near Annandale VA — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Annandale VA on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Annandale%20VA%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Annandale VA. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Annandale VA expat blogs (search)",
+      "url": "https://www.google.com/search?q=Annandale%20VA%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Annandale VA. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-annapolis-md/local-info.json
+++ b/data/locations/us-annapolis-md/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Annapolis MD webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Annapolis%20MD%20webcam",
+      "description": "Live webcams near Annapolis MD — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Annapolis MD on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Annapolis%20MD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Annapolis MD. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Annapolis MD expat blogs (search)",
+      "url": "https://www.google.com/search?q=Annapolis%20MD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Annapolis MD. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-armstrong-county-pa/local-info.json
+++ b/data/locations/us-armstrong-county-pa/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Armstrong County webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Armstrong%20County%20webcam",
+      "description": "Live webcams near Armstrong County — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Armstrong County on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Armstrong%20County%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Armstrong County. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Armstrong County expat blogs (search)",
+      "url": "https://www.google.com/search?q=Armstrong%20County%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Armstrong County. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-asheville-nc/local-info.json
+++ b/data/locations/us-asheville-nc/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Asheville webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Asheville%20webcam",
+      "description": "Live webcams near Asheville — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Asheville on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Asheville%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Asheville. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Asheville expat blogs (search)",
+      "url": "https://www.google.com/search?q=Asheville%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Asheville. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-baltimore-md/local-info.json
+++ b/data/locations/us-baltimore-md/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.baltimorecity.gov/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Baltimore webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Baltimore%20webcam",
+      "description": "Live webcams near Baltimore — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Baltimore on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Baltimore%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Baltimore. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Baltimore expat blogs (search)",
+      "url": "https://www.google.com/search?q=Baltimore%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Baltimore. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-birmingham-al/local-info.json
+++ b/data/locations/us-birmingham-al/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Birmingham webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Birmingham%20webcam",
+      "description": "Live webcams near Birmingham — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Birmingham on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Birmingham%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Birmingham. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Birmingham expat blogs (search)",
+      "url": "https://www.google.com/search?q=Birmingham%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Birmingham. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-bowie-md/local-info.json
+++ b/data/locations/us-bowie-md/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Bowie MD webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Bowie%20MD%20webcam",
+      "description": "Live webcams near Bowie MD — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Bowie MD on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Bowie%20MD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Bowie MD. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Bowie MD expat blogs (search)",
+      "url": "https://www.google.com/search?q=Bowie%20MD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Bowie MD. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-camden-nj/local-info.json
+++ b/data/locations/us-camden-nj/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.camdennj.gov/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Camden webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Camden%20webcam",
+      "description": "Live webcams near Camden — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Camden on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Camden%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Camden. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Camden expat blogs (search)",
+      "url": "https://www.google.com/search?q=Camden%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Camden. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-catonsville-md/local-info.json
+++ b/data/locations/us-catonsville-md/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 403,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Catonsville MD webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Catonsville%20MD%20webcam",
+      "description": "Live webcams near Catonsville MD — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Catonsville MD on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Catonsville%20MD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Catonsville MD. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Catonsville MD expat blogs (search)",
+      "url": "https://www.google.com/search?q=Catonsville%20MD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Catonsville MD. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-charlotte-amalie-vi/local-info.json
+++ b/data/locations/us-charlotte-amalie-vi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Charlotte Amalie webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Charlotte%20Amalie%20webcam",
+      "description": "Live webcams near Charlotte Amalie — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Charlotte Amalie on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Charlotte%20Amalie%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Charlotte Amalie. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Charlotte Amalie expat blogs (search)",
+      "url": "https://www.google.com/search?q=Charlotte%20Amalie%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Charlotte Amalie. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-chicago-il/local-info.json
+++ b/data/locations/us-chicago-il/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.chicago.gov/city/en.html"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Chicago webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Chicago%20webcam",
+      "description": "Live webcams near Chicago — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Chicago on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Chicago%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Chicago. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Chicago expat blogs (search)",
+      "url": "https://www.google.com/search?q=Chicago%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Chicago. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-christiansted-vi/local-info.json
+++ b/data/locations/us-christiansted-vi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Christiansted webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Christiansted%20webcam",
+      "description": "Live webcams near Christiansted — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Christiansted on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Christiansted%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Christiansted. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Christiansted expat blogs (search)",
+      "url": "https://www.google.com/search?q=Christiansted%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Christiansted. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-cleveland-oh/local-info.json
+++ b/data/locations/us-cleveland-oh/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Cleveland webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Cleveland%20webcam",
+      "description": "Live webcams near Cleveland — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Cleveland on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Cleveland%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Cleveland. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Cleveland expat blogs (search)",
+      "url": "https://www.google.com/search?q=Cleveland%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Cleveland. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-dallas-tx/local-info.json
+++ b/data/locations/us-dallas-tx/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://dallascityhall.com/Pages/default.aspx"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Dallas webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Dallas%20webcam",
+      "description": "Live webcams near Dallas — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Dallas on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Dallas%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Dallas. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Dallas expat blogs (search)",
+      "url": "https://www.google.com/search?q=Dallas%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Dallas. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-dededo-gu/local-info.json
+++ b/data/locations/us-dededo-gu/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Dededo webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Dededo%20webcam",
+      "description": "Live webcams near Dededo — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Dededo on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Dededo%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Dededo. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Dededo expat blogs (search)",
+      "url": "https://www.google.com/search?q=Dededo%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Dededo. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-denver-co/local-info.json
+++ b/data/locations/us-denver-co/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.denvergov.org/Home"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Denver webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Denver%20webcam",
+      "description": "Live webcams near Denver — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Denver on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Denver%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Denver. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Denver expat blogs (search)",
+      "url": "https://www.google.com/search?q=Denver%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Denver. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-elkridge-md/local-info.json
+++ b/data/locations/us-elkridge-md/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Elkridge MD webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Elkridge%20MD%20webcam",
+      "description": "Live webcams near Elkridge MD — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Elkridge MD on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Elkridge%20MD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Elkridge MD. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Elkridge MD expat blogs (search)",
+      "url": "https://www.google.com/search?q=Elkridge%20MD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Elkridge MD. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-fort-lauderdale-fl/local-info.json
+++ b/data/locations/us-fort-lauderdale-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Fort Lauderdale webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Fort%20Lauderdale%20webcam",
+      "description": "Live webcams near Fort Lauderdale — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Fort Lauderdale on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Fort%20Lauderdale%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Fort Lauderdale. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Fort Lauderdale expat blogs (search)",
+      "url": "https://www.google.com/search?q=Fort%20Lauderdale%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Fort Lauderdale. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-fort-wayne-in/local-info.json
+++ b/data/locations/us-fort-wayne-in/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.cityoffortwayne.in.gov/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Fort Wayne webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Fort%20Wayne%20webcam",
+      "description": "Live webcams near Fort Wayne — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Fort Wayne on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Fort%20Wayne%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Fort Wayne. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Fort Wayne expat blogs (search)",
+      "url": "https://www.google.com/search?q=Fort%20Wayne%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Fort Wayne. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-fort-worth-tx/local-info.json
+++ b/data/locations/us-fort-worth-tx/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.fortworthtexas.gov/Home"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Fort Worth webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Fort%20Worth%20webcam",
+      "description": "Live webcams near Fort Worth — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Fort Worth on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Fort%20Worth%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Fort Worth. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Fort Worth expat blogs (search)",
+      "url": "https://www.google.com/search?q=Fort%20Worth%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Fort Worth. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-gainesville-va/local-info.json
+++ b/data/locations/us-gainesville-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Gainesville VA webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Gainesville%20VA%20webcam",
+      "description": "Live webcams near Gainesville VA — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Gainesville VA on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Gainesville%20VA%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Gainesville VA. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Gainesville VA expat blogs (search)",
+      "url": "https://www.google.com/search?q=Gainesville%20VA%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Gainesville VA. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-glen-burnie-md/local-info.json
+++ b/data/locations/us-glen-burnie-md/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Glen Burnie MD webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Glen%20Burnie%20MD%20webcam",
+      "description": "Live webcams near Glen Burnie MD — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Glen Burnie MD on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Glen%20Burnie%20MD%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Glen Burnie MD. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Glen Burnie MD expat blogs (search)",
+      "url": "https://www.google.com/search?q=Glen%20Burnie%20MD%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Glen Burnie MD. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-grand-forks-nd/local-info.json
+++ b/data/locations/us-grand-forks-nd/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Grand Forks webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Grand%20Forks%20webcam",
+      "description": "Live webcams near Grand Forks — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Grand Forks on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Grand%20Forks%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Grand Forks. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Grand Forks expat blogs (search)",
+      "url": "https://www.google.com/search?q=Grand%20Forks%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Grand Forks. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-hagatna-gu/local-info.json
+++ b/data/locations/us-hagatna-gu/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Hagåtña webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Hag%C3%A5t%C3%B1a%20webcam",
+      "description": "Live webcams near Hagåtña — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Hagåtña on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Hag%C3%A5t%C3%B1a%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Hagåtña. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Hagåtña expat blogs (search)",
+      "url": "https://www.google.com/search?q=Hag%C3%A5t%C3%B1a%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Hagåtña. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-killeen-tx/local-info.json
+++ b/data/locations/us-killeen-tx/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Killeen webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Killeen%20webcam",
+      "description": "Live webcams near Killeen — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Killeen on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Killeen%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Killeen. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Killeen expat blogs (search)",
+      "url": "https://www.google.com/search?q=Killeen%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Killeen. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-lapeer-mi/local-info.json
+++ b/data/locations/us-lapeer-mi/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://lapeercountyweb.org/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Lapeer webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Lapeer%20webcam",
+      "description": "Live webcams near Lapeer — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Lapeer on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Lapeer%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Lapeer. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Lapeer expat blogs (search)",
+      "url": "https://www.google.com/search?q=Lapeer%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Lapeer. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-little-rock-ar/local-info.json
+++ b/data/locations/us-little-rock-ar/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://littlerock.gov/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Little Rock webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Little%20Rock%20webcam",
+      "description": "Live webcams near Little Rock — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Little Rock on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Little%20Rock%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Little Rock. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Little Rock expat blogs (search)",
+      "url": "https://www.google.com/search?q=Little%20Rock%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Little Rock. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-lorain-oh/local-info.json
+++ b/data/locations/us-lorain-oh/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Lorain webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Lorain%20webcam",
+      "description": "Live webcams near Lorain — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Lorain on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Lorain%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Lorain. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Lorain expat blogs (search)",
+      "url": "https://www.google.com/search?q=Lorain%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Lorain. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-lorton-va/local-info.json
+++ b/data/locations/us-lorton-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Lorton VA webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Lorton%20VA%20webcam",
+      "description": "Live webcams near Lorton VA — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Lorton VA on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Lorton%20VA%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Lorton VA. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Lorton VA expat blogs (search)",
+      "url": "https://www.google.com/search?q=Lorton%20VA%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Lorton VA. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-lynchburg-va/local-info.json
+++ b/data/locations/us-lynchburg-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Lynchburg webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Lynchburg%20webcam",
+      "description": "Live webcams near Lynchburg — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Lynchburg on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Lynchburg%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Lynchburg. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Lynchburg expat blogs (search)",
+      "url": "https://www.google.com/search?q=Lynchburg%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Lynchburg. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-manassas-va/local-info.json
+++ b/data/locations/us-manassas-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Manassas VA webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Manassas%20VA%20webcam",
+      "description": "Live webcams near Manassas VA — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Manassas VA on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Manassas%20VA%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Manassas VA. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Manassas VA expat blogs (search)",
+      "url": "https://www.google.com/search?q=Manassas%20VA%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Manassas VA. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-miami-fl/local-info.json
+++ b/data/locations/us-miami-fl/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.miami.gov/Home"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Miami webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Miami%20webcam",
+      "description": "Live webcams near Miami — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Miami on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Miami%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Miami. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Miami expat blogs (search)",
+      "url": "https://www.google.com/search?q=Miami%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Miami. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-milwaukee-wi/local-info.json
+++ b/data/locations/us-milwaukee-wi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Milwaukee webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Milwaukee%20webcam",
+      "description": "Live webcams near Milwaukee — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Milwaukee on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Milwaukee%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Milwaukee. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Milwaukee expat blogs (search)",
+      "url": "https://www.google.com/search?q=Milwaukee%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Milwaukee. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-minneapolis-mn/local-info.json
+++ b/data/locations/us-minneapolis-mn/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Minneapolis webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Minneapolis%20webcam",
+      "description": "Live webcams near Minneapolis — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Minneapolis on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Minneapolis%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Minneapolis. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Minneapolis expat blogs (search)",
+      "url": "https://www.google.com/search?q=Minneapolis%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Minneapolis. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-nashville-tn/local-info.json
+++ b/data/locations/us-nashville-tn/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Nashville webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Nashville%20webcam",
+      "description": "Live webcams near Nashville — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Nashville on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Nashville%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Nashville. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Nashville expat blogs (search)",
+      "url": "https://www.google.com/search?q=Nashville%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Nashville. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-new-york-city/local-info.json
+++ b/data/locations/us-new-york-city/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.nyc.gov/main"
     }
+  ],
+  "webcams": [
+    {
+      "name": "New York City webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?New%20York%20City%20webcam",
+      "description": "Live webcams near New York City — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "New York City on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=New%20York%20City%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in New York City. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "New York City expat blogs (search)",
+      "url": "https://www.google.com/search?q=New%20York%20City%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about New York City. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-oakland-county-mi/local-info.json
+++ b/data/locations/us-oakland-county-mi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Oakland County webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Oakland%20County%20webcam",
+      "description": "Live webcams near Oakland County — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Oakland County on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Oakland%20County%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Oakland County. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Oakland County expat blogs (search)",
+      "url": "https://www.google.com/search?q=Oakland%20County%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Oakland County. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-pago-pago-as/local-info.json
+++ b/data/locations/us-pago-pago-as/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Pago Pago webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Pago%20Pago%20webcam",
+      "description": "Live webcams near Pago Pago — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Pago Pago on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Pago%20Pago%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Pago Pago. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Pago Pago expat blogs (search)",
+      "url": "https://www.google.com/search?q=Pago%20Pago%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Pago Pago. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-palm-bay-fl/local-info.json
+++ b/data/locations/us-palm-bay-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 404,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Palm Bay webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Palm%20Bay%20webcam",
+      "description": "Live webcams near Palm Bay — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Palm Bay on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Palm%20Bay%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Palm Bay. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Palm Bay expat blogs (search)",
+      "url": "https://www.google.com/search?q=Palm%20Bay%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Palm Bay. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-pittsburgh-pa/local-info.json
+++ b/data/locations/us-pittsburgh-pa/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://www.pittsburghpa.gov/Home"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Pittsburgh webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Pittsburgh%20webcam",
+      "description": "Live webcams near Pittsburgh — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Pittsburgh on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Pittsburgh%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Pittsburgh. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Pittsburgh expat blogs (search)",
+      "url": "https://www.google.com/search?q=Pittsburgh%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Pittsburgh. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-ponce-pr/local-info.json
+++ b/data/locations/us-ponce-pr/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Ponce webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Ponce%20webcam",
+      "description": "Live webcams near Ponce — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Ponce on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Ponce%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Ponce. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Ponce expat blogs (search)",
+      "url": "https://www.google.com/search?q=Ponce%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Ponce. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-port-huron-mi/local-info.json
+++ b/data/locations/us-port-huron-mi/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Port Huron webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Port%20Huron%20webcam",
+      "description": "Live webcams near Port Huron — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Port Huron on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Port%20Huron%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Port Huron. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Port Huron expat blogs (search)",
+      "url": "https://www.google.com/search?q=Port%20Huron%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Port Huron. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-portsmouth-va/local-info.json
+++ b/data/locations/us-portsmouth-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Portsmouth webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Portsmouth%20webcam",
+      "description": "Live webcams near Portsmouth — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Portsmouth on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Portsmouth%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Portsmouth. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Portsmouth expat blogs (search)",
+      "url": "https://www.google.com/search?q=Portsmouth%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Portsmouth. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-quincy-fl/local-info.json
+++ b/data/locations/us-quincy-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Quincy webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Quincy%20webcam",
+      "description": "Live webcams near Quincy — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Quincy on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Quincy%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Quincy. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Quincy expat blogs (search)",
+      "url": "https://www.google.com/search?q=Quincy%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Quincy. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-saint-paul-mn/local-info.json
+++ b/data/locations/us-saint-paul-mn/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Saint Paul webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Saint%20Paul%20webcam",
+      "description": "Live webcams near Saint Paul — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Saint Paul on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Saint%20Paul%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Saint Paul. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Saint Paul expat blogs (search)",
+      "url": "https://www.google.com/search?q=Saint%20Paul%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Saint Paul. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-saipan-mp/local-info.json
+++ b/data/locations/us-saipan-mp/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Saipan webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Saipan%20webcam",
+      "description": "Live webcams near Saipan — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Saipan on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Saipan%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Saipan. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Saipan expat blogs (search)",
+      "url": "https://www.google.com/search?q=Saipan%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Saipan. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-san-juan-pr/local-info.json
+++ b/data/locations/us-san-juan-pr/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "San Juan webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?San%20Juan%20webcam",
+      "description": "Live webcams near San Juan — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "San Juan on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=San%20Juan%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in San Juan. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "San Juan expat blogs (search)",
+      "url": "https://www.google.com/search?q=San%20Juan%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about San Juan. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-san-marcos-tx/local-info.json
+++ b/data/locations/us-san-marcos-tx/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "San Marcos webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?San%20Marcos%20webcam",
+      "description": "Live webcams near San Marcos — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "San Marcos on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=San%20Marcos%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in San Marcos. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "San Marcos expat blogs (search)",
+      "url": "https://www.google.com/search?q=San%20Marcos%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about San Marcos. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-skowhegan-me/local-info.json
+++ b/data/locations/us-skowhegan-me/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Skowhegan webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Skowhegan%20webcam",
+      "description": "Live webcams near Skowhegan — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Skowhegan on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Skowhegan%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Skowhegan. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Skowhegan expat blogs (search)",
+      "url": "https://www.google.com/search?q=Skowhegan%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Skowhegan. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-st-augustine-fl/local-info.json
+++ b/data/locations/us-st-augustine-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "St. Augustine webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?St.%20Augustine%20webcam",
+      "description": "Live webcams near St. Augustine — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "St. Augustine on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=St.%20Augustine%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in St. Augustine. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "St. Augustine expat blogs (search)",
+      "url": "https://www.google.com/search?q=St.%20Augustine%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about St. Augustine. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-st-petersburg-fl/local-info.json
+++ b/data/locations/us-st-petersburg-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "St. Petersburg webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?St.%20Petersburg%20webcam",
+      "description": "Live webcams near St. Petersburg — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "St. Petersburg on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=St.%20Petersburg%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in St. Petersburg. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "St. Petersburg expat blogs (search)",
+      "url": "https://www.google.com/search?q=St.%20Petersburg%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about St. Petersburg. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-tafuna-as/local-info.json
+++ b/data/locations/us-tafuna-as/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Tafuna webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Tafuna%20webcam",
+      "description": "Live webcams near Tafuna — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Tafuna on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Tafuna%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Tafuna. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Tafuna expat blogs (search)",
+      "url": "https://www.google.com/search?q=Tafuna%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Tafuna. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-tampa-fl/local-info.json
+++ b/data/locations/us-tampa-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Tampa webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Tampa%20webcam",
+      "description": "Live webcams near Tampa — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Tampa on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Tampa%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Tampa. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Tampa expat blogs (search)",
+      "url": "https://www.google.com/search?q=Tampa%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Tampa. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-tinian-mp/local-info.json
+++ b/data/locations/us-tinian-mp/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Tinian webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Tinian%20webcam",
+      "description": "Live webcams near Tinian — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Tinian on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Tinian%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Tinian. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Tinian expat blogs (search)",
+      "url": "https://www.google.com/search?q=Tinian%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Tinian. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-virginia-beach-va/local-info.json
+++ b/data/locations/us-virginia-beach-va/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": null,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Virginia Beach webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Virginia%20Beach%20webcam",
+      "description": "Live webcams near Virginia Beach — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Virginia Beach on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Virginia%20Beach%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Virginia Beach. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Virginia Beach expat blogs (search)",
+      "url": "https://www.google.com/search?q=Virginia%20Beach%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Virginia Beach. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-williamsport-pa/local-info.json
+++ b/data/locations/us-williamsport-pa/local-info.json
@@ -10,5 +10,29 @@
       "linkCheckedAt": "2026-04-23",
       "linkFinalUrl": "https://cityofwilliamsport.org/"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Williamsport webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Williamsport%20webcam",
+      "description": "Live webcams near Williamsport — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Williamsport on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Williamsport%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Williamsport. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Williamsport expat blogs (search)",
+      "url": "https://www.google.com/search?q=Williamsport%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Williamsport. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/data/locations/us-yulee-fl/local-info.json
+++ b/data/locations/us-yulee-fl/local-info.json
@@ -9,5 +9,29 @@
       "linkHttpStatus": 200,
       "linkCheckedAt": "2026-04-23"
     }
+  ],
+  "webcams": [
+    {
+      "name": "Yulee webcams (search)",
+      "url": "https://www.windy.com/-Webcams/webcams?Yulee%20webcam",
+      "description": "Live webcams near Yulee — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "youtubeChannels": [
+    {
+      "name": "Yulee on YouTube (search)",
+      "url": "https://www.youtube.com/results?search_query=Yulee%20retirement%20expat%20living",
+      "description": "YouTube search for channels covering retirement and expat life in Yulee. Replace with a specific channel once identified.",
+      "accessed": "2026-04-23"
+    }
+  ],
+  "bloggers": [
+    {
+      "name": "Yulee expat blogs (search)",
+      "url": "https://www.google.com/search?q=Yulee%20expat%20retirement%20blog",
+      "description": "Google search for English-language expat and retirement blogs about Yulee. Replace with a specific blog once identified.",
+      "accessed": "2026-04-23"
+    }
   ]
 }

--- a/scripts/augment-local-info-discovery-placeholders.mjs
+++ b/scripts/augment-local-info-discovery-placeholders.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Adds discovery-link placeholders (webcams / YouTube / blogs) for every
+ * location whose local-info.json is missing one of those three groups.
+ *
+ * Each added entry is a single "search" pointer — the user gets an
+ * actionable URL that lists candidates. Matches the same "graceful
+ * fallback" pattern used for religious/cuisine service categories.
+ *
+ * Idempotent: skips any group that already has >=1 entry.
+ *
+ * Usage:
+ *   node scripts/augment-local-info-discovery-placeholders.mjs
+ *   node scripts/augment-local-info-discovery-placeholders.mjs --dry-run
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const DATA_DIR = 'data/locations';
+const TODAY = new Date().toISOString().slice(0, 10);
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function shortCityName(locName) {
+  // "Bogotá (Chapinero, Usaquén), Colombia" -> "Bogotá"
+  // "Austin, Texas" -> "Austin"
+  const first = locName.split(/[,(]/)[0].trim();
+  return first || locName;
+}
+
+function webcamsPlaceholder(cityName) {
+  const q = encodeURIComponent(`${cityName} webcam`);
+  return {
+    name: `${cityName} webcams (search)`,
+    url: `https://www.windy.com/-Webcams/webcams?${q}`,
+    description: `Live webcams near ${cityName} — Windy directory, rating-sorted. Replace with a specific camera once a reliable feed is identified.`,
+  };
+}
+
+function youtubePlaceholder(cityName) {
+  const q = encodeURIComponent(`${cityName} retirement expat living`);
+  return {
+    name: `${cityName} on YouTube (search)`,
+    url: `https://www.youtube.com/results?search_query=${q}`,
+    description: `YouTube search for channels covering retirement and expat life in ${cityName}. Replace with a specific channel once identified.`,
+  };
+}
+
+function blogsPlaceholder(cityName) {
+  const q = encodeURIComponent(`${cityName} expat retirement blog`);
+  return {
+    name: `${cityName} expat blogs (search)`,
+    url: `https://www.google.com/search?q=${q}`,
+    description: `Google search for English-language expat and retirement blogs about ${cityName}. Replace with a specific blog once identified.`,
+  };
+}
+
+const touched = [];
+let filled = 0;
+
+for (const dir of readdirSync(DATA_DIR, { withFileTypes: true })) {
+  if (!dir.isDirectory()) continue;
+  const liPath = join(DATA_DIR, dir.name, 'local-info.json');
+  if (!existsSync(liPath)) continue;
+
+  // Read name from location.json for a clean city label.
+  const locPath = join(DATA_DIR, dir.name, 'location.json');
+  const locData = existsSync(locPath) ? JSON.parse(readFileSync(locPath, 'utf-8')) : { name: dir.name };
+  const cityName = shortCityName(locData.name || dir.name);
+
+  const li = JSON.parse(readFileSync(liPath, 'utf-8'));
+  let changed = false;
+
+  if (!(li.webcams?.length > 0)) {
+    li.webcams = [{ ...webcamsPlaceholder(cityName), accessed: TODAY }];
+    changed = true;
+    filled++;
+  }
+  if (!(li.youtubeChannels?.length > 0)) {
+    li.youtubeChannels = [{ ...youtubePlaceholder(cityName), accessed: TODAY }];
+    changed = true;
+    filled++;
+  }
+  if (!(li.bloggers?.length > 0)) {
+    li.bloggers = [{ ...blogsPlaceholder(cityName), accessed: TODAY }];
+    changed = true;
+    filled++;
+  }
+
+  if (changed) {
+    touched.push(dir.name);
+    if (!DRY_RUN) writeFileSync(liPath, JSON.stringify(li, null, 2) + '\n', 'utf-8');
+  }
+}
+
+console.log(`Locations touched: ${touched.length}`);
+console.log(`Placeholders added: ${filled}`);
+if (DRY_RUN) console.log('(dry-run — no files written)');


### PR DESCRIPTION
## Summary

Of 158 locations, only 21 had webcams/youtubeChannels/bloggers populated (the original hand-curated set). The remaining 137 rendered an empty 'Resources & Links' card on the dashboard's Local Info page.

This PR adds a single "search" pointer per missing group — consistent with the graceful-fallback pattern used for religious and cuisine service categories — so every location surfaces an actionable discovery URL.

## Placeholders added

| Group | Target |
|---|---|
| Webcams | \`windy.com/-Webcams/webcams?<city>%20webcam\` |
| YouTube | \`youtube.com/results?search_query=<city>%20retirement%20expat%20living\` |
| Blogs | \`google.com/search?q=<city>%20expat%20retirement%20blog\` |

## Scope

- **137 locations touched** — those missing one or more groups
- **411 placeholders added** (3 per touched location on average)
- **21 curated locations untouched** — idempotent skip if group already has >=1 entry

## Script

\`scripts/augment-local-info-discovery-placeholders.mjs\` — reads display name from each \`location.json\` (strips parens/region suffixes), dry-run supported, idempotent on re-run.

## Test plan

- [ ] Start API + dashboard, open Local Info for any of these locations: Bogotá, Lisbon, Merida, Puerto Vallarta
- [ ] Verify 'Resources & Links' card now shows 'Webcams', 'YouTube', 'Blogs' groups (alongside the 'Official' group from PR #56)
- [ ] Click one link per group — destination loads and is relevant to the location

## Follow-up (optional)

Upgrade placeholders to real curation via Windy API + YouTube Data API (option B from planning). Tracked as a backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)