### PR TITLE
feat(cons): migrate to sourced shape + attach vault-matched citations

### DIFF
--- a/audits/vault-source-catalog.json
+++ b/audits/vault-source-catalog.json
@@ -1,0 +1,475 @@
+{
+  "catalog": [
+    {
+      "path": "France/Calculate projected monthly occupancy costs for a.md",
+      "title": "Calculate projected monthly occupancy costs for a typical 2-bedroom apartment in {city}, {country}, for years 2025–2035, assuming a two-pers",
+      "locations": [
+        "france-lyon",
+        "france-montpellier",
+        "france-toulouse"
+      ],
+      "topics": [
+        "cost"
+      ],
+      "sourceUrls": [
+        "https://www.morningcroissant.com/blog/furnished-rental-in-lyon-your-complete-guide-for-2025-26",
+        "https://www.jarniascyril.com/international-real-estate/invest-in-french-real-estate/investing-real-estate-lyon-market-neighborhoods-strategies/",
+        "https://adrianleeds.com/subscribe-to-our-publications/french-property-insider/fpi-archives/french-rent-reference-index/",
+        "https://www.capifrance.fr/en/blog/the-french-real-estate-market-what-s-changing-in-2026",
+        "https://en.arcep.fr/news/press-releases/view/n/fixed-broadband-and-superfast-broadband-market-091225.html"
+      ],
+      "sourceCount": 378
+    },
+    {
+      "path": "France/compare prices between Giant grocery store in the.md",
+      "title": "compare prices between Giant grocery store in the US and InterMarche in Toulouse France for the following items: 1 dozen eggs, 1 pound bread",
+      "locations": [
+        "france-montpellier",
+        "france-toulouse"
+      ],
+      "topics": [
+        "cost"
+      ],
+      "sourceUrls": [
+        "https://circular.giantfoodstores.com/flyers/giantfoodstores-weekly?auto_locate=true\\&locale=en-US\\&store_code=6468\\&type=1",
+        "https://circular.giantfood.com/flyers/giantfood?auto_locate=true\\&locale=en-US\\&store_code=0301\\&type=1",
+        "https://www.intermarche.com/produit/jus-d'orange-100%-pur-jus-sans-pulpe/3250392257170",
+        "https://www.intermarche.com/produit/jus-d'orange-presse-du-jour/3091010000019",
+        "https://www.cnn.com/2025/04/09/business/egg-prices-antitrust-cal-maine-foods"
+      ],
+      "sourceCount": 391
+    },
+    {
+      "path": "France/Give a table of average monthly costs (local curre (6).md",
+      "title": "Give a table of average monthly costs (local currency) for renting a 2-bedroom apartment in [CITY], [COUNTRY], from mid-2027 to mid-2035. fo",
+      "locations": [
+        "france-montpellier"
+      ],
+      "topics": [
+        "cost"
+      ],
+      "sourceUrls": [
+        "https://www.globalpropertyguide.com/europe/france/2-bed-rent",
+        "https://wise.com/us/currency-converter/eur-to-usd-rate",
+        "https://www.nestpick.com/montpellier/",
+        "https://tradingeconomics.com/france/inflation-cpi",
+        "https://www.xe.com/en-us/currencyconverter/convert/?Amount=1\\&From=EUR\\&To=USD"
+      ],
+      "sourceCount": 318
+    },
+    {
+      "path": "France/Give Crime Statistics for Hate Crimes, Property Cr (1).md",
+      "title": "Give Crime Statistics for Hate Crimes, Property Crimes, Pickpocketing, Burglary, Robbery and Violent Crime",
+      "locations": [
+        "france-brittany",
+        "france-toulouse"
+      ],
+      "topics": [
+        "housing",
+        "crime"
+      ],
+      "sourceUrls": [
+        "https://www.hrw.org/world-report/2025/country-chapters/france",
+        "https://cica.ismc.ir/en/news-en/41999/france-sees-sharp-rise-in-anti-muslim-incidents-in-2025/",
+        "https://www.covea.com/en/analysis/insurance-and-new-face-burglary",
+        "https://sheltersecurityproducts.com/2025/10/03/crime-robbery-burglaries-france/",
+        "https://reolink.com/blog/most-dangerous-cities-in-europe/"
+      ],
+      "sourceCount": 102
+    },
+    {
+      "path": "France/Give Crime Statistics for Hate Crimes, Property Cr (2).md",
+      "title": "Give Crime Statistics for Hate Crimes, Property Crimes, Pickpocketing, Burglary, Robbery and Violent Crime in percentages of population for ",
+      "locations": [
+        "france-toulouse"
+      ],
+      "topics": [
+        "housing",
+        "crime"
+      ],
+      "sourceUrls": [
+        "https://www.ndtv.com/world-news/32-percent-surge-in-hate-crimes-in-france-following-gaza-war-report-5275592",
+        "https://hatecrime.osce.org/france",
+        "https://www.statista.com/topics/12666/crime-in-france/",
+        "https://www.french-property.com/news/french_property/burglaries_by_department_2020",
+        "https://www.french-property.com/news/french_life/crime_rates_france_2011"
+      ],
+      "sourceCount": 55
+    },
+    {
+      "path": "France/rent for a three bedroom apartment in Brittany.md",
+      "title": "rent for a three bedroom apartment in Brittany",
+      "locations": [
+        "france-brittany"
+      ],
+      "topics": [
+        "housing"
+      ],
+      "sourceUrls": [
+        "https://www.apartments.com/brittany-commons-spotsylvania-va/3-bedrooms/",
+        "https://www.brittanycommonsapts.com/floorplans/3-bedroom-2-bath-with-balcony-or-patio-manor-house-i",
+        "https://livingcost.org/cost/france/bre",
+        "https://www.properstar.com/france/brittany/rent/apartment-house/apartment",
+        "https://www.apartments.com/building/the-brittany-arlington-va/qjvk36y/"
+      ],
+      "sourceCount": 254
+    },
+    {
+      "path": "France/what are average home prices for a small house in (1).md",
+      "title": "what are average home prices for a small house in Toulouse",
+      "locations": [
+        "france-lyon",
+        "france-montpellier",
+        "france-toulouse"
+      ],
+      "topics": [
+        "cost",
+        "housing"
+      ],
+      "sourceUrls": [
+        "https://investropa.com/blogs/news/toulouse-property",
+        "https://www.groupe-mercure.fr/en/blog/latest-news/real-estate-in-toulouse-key-figures-and-trends-in-2024/",
+        "https://www.french-property.com/property/midi_pyrenees/haute_garonne/toulouse/insight",
+        "https://www.tanit-immobilier.com/en/the-real-estate-market/the-property-market-in-2025/",
+        "https://www.exchange-rates.org/exchange-rate-history/eur-usd-2025"
+      ],
+      "sourceCount": 619
+    },
+    {
+      "path": "France/what is the process for building a new home on a l.md",
+      "title": "what is the process for building a new home on a lot in carcassone france",
+      "locations": [
+        "france-brittany",
+        "france-montpellier",
+        "france-toulouse"
+      ],
+      "topics": [
+        "housing"
+      ],
+      "sourceUrls": [
+        "https://www.french-property.com/guides/france/building/new-build",
+        "https://thegoodlifefrance.com/how-to-plan-a-new-build-in-france/",
+        "https://www.notaires.fr/en/housing-tax-system/town-planning-documents/building-permit-france",
+        "https://www.my-french-house.com/blog/article/75297/how-to-apply-for-building-permit-in-france",
+        "https://www.frenchplans.com/brief-guide-to-planning-permits-in-france"
+      ],
+      "sourceCount": 167
+    },
+    {
+      "path": "Panama/once a dog has done the transfer to panama do they.md",
+      "title": "once a dog has done the transfer to panama do they have to get a usda clearance to go back and forth with the us",
+      "locations": [
+        "panama-city"
+      ],
+      "topics": [],
+      "sourceUrls": [
+        "https://www.cdc.gov/importation/dogs/index.html",
+        "https://www.cdc.gov/importation/dogs/faqs.html",
+        "https://www.cdc.gov/importation/dogs/dog-import-form-instructions.html",
+        "https://www.vetsaglik.com/en/post/cdc-dog-import-requirements-2026-dog-import-form-microchip-rabies-rules-high-risk-vs-low-risk-c",
+        "https://www.aphis.usda.gov/pet-travel/another-country-to-us-import"
+      ],
+      "sourceCount": 66
+    },
+    {
+      "path": "Spain/what visas are available for spain.md",
+      "title": "what visas are available for spain",
+      "locations": [
+        "spain-alicante"
+      ],
+      "topics": [
+        "visa"
+      ],
+      "sourceUrls": [
+        "https://myspainvisa.com/non-lucrative-visa-spain/",
+        "https://www.perplexity.ai/search/f2468df5-67e1-42e4-b6b6-35466dc578e0",
+        "https://madridbullfighting.com/blog/do-americans-need-a-visa-for-spain/",
+        "https://etias.com/etias-requirements/etias-for-american-citizens",
+        "https://www.perplexity.ai/search/47c213d3-086e-4252-a282-1166b5b28580"
+      ],
+      "sourceCount": 75
+    },
+    {
+      "path": "US/Given my previous retirement calculations, what wo.md",
+      "title": "Given my previous retirement calculations, what would be the difference in Retirement Cost between Savannah Georgia and Summerville SC",
+      "locations": [
+        "us-savannah",
+        "us-summerville"
+      ],
+      "topics": [],
+      "sourceUrls": [
+        "https://www.salary.com/research/cost-of-living/compare/summerville-sc/savannah-ga",
+        "https://www.bestplaces.net/cost-of-living/savannah-ga/summerville-sc/50000",
+        "https://terrabellaseniorliving.com/senior-living-blog/best-places-to-retire-in-south-carolina-on-a-budget-summerville/",
+        "https://dreamfindershomes.com/blog/what-is-the-cost-of-living-in-summerville-sc/",
+        "https://www.redfin.com/city/17651/GA/Savannah/housing-market"
+      ],
+      "sourceCount": 103
+    },
+    {
+      "path": "US/given my typical questions please list other citie.md",
+      "title": "given my typical questions please list other cities where the temperature doesn't drop below 40 Fahrenheit in the winter, there is an expat ",
+      "locations": [
+        "us-florida",
+        "us-austin"
+      ],
+      "topics": [],
+      "sourceUrls": [
+        "https://www.currentresults.com/Weather-Extremes/US/hottest-cities-winter.php",
+        "https://www.savoryandpartners.com/blog/cheapest-country-world",
+        "https://finance.yahoo.com/news/25-best-cities-where-retire-083839849.html",
+        "https://www.businessinsider.com/hottest-us-cities-where-temperatures-rarely-drop-below-50-degrees-2020-3",
+        "https://www.reddit.com/r/AskAnAmerican/comments/vvc5ys/what_are_the_coldest_big_cities_in_the_us_during/"
+      ],
+      "sourceCount": 24
+    },
+    {
+      "path": "US/how is Virginia as the US residency of retirees wh.md",
+      "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+      "locations": [
+        "us-virginia",
+        "us-florida",
+        "us-philadelphia",
+        "us-austin",
+        "us-summerville"
+      ],
+      "topics": [],
+      "sourceUrls": [
+        "https://www.tax.virginia.gov/residency-status",
+        "https://www.greenbacktaxservices.com/blog/expat-tax-returns-determining-virginia-state-residency/",
+        "https://brighttax.com/blog/virginia-state-taxes/",
+        "https://www.myexpattaxes.com/expat-tax-tips/state-taxes/a-guide-to-filing-virginia-state-taxes-as-a-us-expat/",
+        "https://www.edelmanfinancialengines.com/education/tax/virginia-tax-social-security/"
+      ],
+      "sourceCount": 82
+    }
+  ],
+  "byLocation": {
+    "france-lyon": [
+      {
+        "title": "Calculate projected monthly occupancy costs for a typical 2-bedroom apartment in {city}, {country}, for years 2025–2035, assuming a two-pers",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 378,
+        "path": "France/Calculate projected monthly occupancy costs for a.md"
+      },
+      {
+        "title": "what are average home prices for a small house in Toulouse",
+        "topics": [
+          "cost",
+          "housing"
+        ],
+        "sourceCount": 619,
+        "path": "France/what are average home prices for a small house in (1).md"
+      }
+    ],
+    "france-montpellier": [
+      {
+        "title": "Calculate projected monthly occupancy costs for a typical 2-bedroom apartment in {city}, {country}, for years 2025–2035, assuming a two-pers",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 378,
+        "path": "France/Calculate projected monthly occupancy costs for a.md"
+      },
+      {
+        "title": "compare prices between Giant grocery store in the US and InterMarche in Toulouse France for the following items: 1 dozen eggs, 1 pound bread",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 391,
+        "path": "France/compare prices between Giant grocery store in the.md"
+      },
+      {
+        "title": "Give a table of average monthly costs (local currency) for renting a 2-bedroom apartment in [CITY], [COUNTRY], from mid-2027 to mid-2035. fo",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 318,
+        "path": "France/Give a table of average monthly costs (local curre (6).md"
+      },
+      {
+        "title": "what are average home prices for a small house in Toulouse",
+        "topics": [
+          "cost",
+          "housing"
+        ],
+        "sourceCount": 619,
+        "path": "France/what are average home prices for a small house in (1).md"
+      },
+      {
+        "title": "what is the process for building a new home on a lot in carcassone france",
+        "topics": [
+          "housing"
+        ],
+        "sourceCount": 167,
+        "path": "France/what is the process for building a new home on a l.md"
+      }
+    ],
+    "france-toulouse": [
+      {
+        "title": "Calculate projected monthly occupancy costs for a typical 2-bedroom apartment in {city}, {country}, for years 2025–2035, assuming a two-pers",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 378,
+        "path": "France/Calculate projected monthly occupancy costs for a.md"
+      },
+      {
+        "title": "compare prices between Giant grocery store in the US and InterMarche in Toulouse France for the following items: 1 dozen eggs, 1 pound bread",
+        "topics": [
+          "cost"
+        ],
+        "sourceCount": 391,
+        "path": "France/compare prices between Giant grocery store in the.md"
+      },
+      {
+        "title": "Give Crime Statistics for Hate Crimes, Property Crimes, Pickpocketing, Burglary, Robbery and Violent Crime",
+        "topics": [
+          "housing",
+          "crime"
+        ],
+        "sourceCount": 102,
+        "path": "France/Give Crime Statistics for Hate Crimes, Property Cr (1).md"
+      },
+      {
+        "title": "Give Crime Statistics for Hate Crimes, Property Crimes, Pickpocketing, Burglary, Robbery and Violent Crime in percentages of population for ",
+        "topics": [
+          "housing",
+          "crime"
+        ],
+        "sourceCount": 55,
+        "path": "France/Give Crime Statistics for Hate Crimes, Property Cr (2).md"
+      },
+      {
+        "title": "what are average home prices for a small house in Toulouse",
+        "topics": [
+          "cost",
+          "housing"
+        ],
+        "sourceCount": 619,
+        "path": "France/what are average home prices for a small house in (1).md"
+      },
+      {
+        "title": "what is the process for building a new home on a lot in carcassone france",
+        "topics": [
+          "housing"
+        ],
+        "sourceCount": 167,
+        "path": "France/what is the process for building a new home on a l.md"
+      }
+    ],
+    "france-brittany": [
+      {
+        "title": "Give Crime Statistics for Hate Crimes, Property Crimes, Pickpocketing, Burglary, Robbery and Violent Crime",
+        "topics": [
+          "housing",
+          "crime"
+        ],
+        "sourceCount": 102,
+        "path": "France/Give Crime Statistics for Hate Crimes, Property Cr (1).md"
+      },
+      {
+        "title": "rent for a three bedroom apartment in Brittany",
+        "topics": [
+          "housing"
+        ],
+        "sourceCount": 254,
+        "path": "France/rent for a three bedroom apartment in Brittany.md"
+      },
+      {
+        "title": "what is the process for building a new home on a lot in carcassone france",
+        "topics": [
+          "housing"
+        ],
+        "sourceCount": 167,
+        "path": "France/what is the process for building a new home on a l.md"
+      }
+    ],
+    "panama-city": [
+      {
+        "title": "once a dog has done the transfer to panama do they have to get a usda clearance to go back and forth with the us",
+        "topics": [],
+        "sourceCount": 66,
+        "path": "Panama/once a dog has done the transfer to panama do they.md"
+      }
+    ],
+    "spain-alicante": [
+      {
+        "title": "what visas are available for spain",
+        "topics": [
+          "visa"
+        ],
+        "sourceCount": 75,
+        "path": "Spain/what visas are available for spain.md"
+      }
+    ],
+    "us-savannah": [
+      {
+        "title": "Given my previous retirement calculations, what would be the difference in Retirement Cost between Savannah Georgia and Summerville SC",
+        "topics": [],
+        "sourceCount": 103,
+        "path": "US/Given my previous retirement calculations, what wo.md"
+      }
+    ],
+    "us-summerville": [
+      {
+        "title": "Given my previous retirement calculations, what would be the difference in Retirement Cost between Savannah Georgia and Summerville SC",
+        "topics": [],
+        "sourceCount": 103,
+        "path": "US/Given my previous retirement calculations, what wo.md"
+      },
+      {
+        "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+        "topics": [],
+        "sourceCount": 82,
+        "path": "US/how is Virginia as the US residency of retirees wh.md"
+      }
+    ],
+    "us-florida": [
+      {
+        "title": "given my typical questions please list other cities where the temperature doesn't drop below 40 Fahrenheit in the winter, there is an expat ",
+        "topics": [],
+        "sourceCount": 24,
+        "path": "US/given my typical questions please list other citie.md"
+      },
+      {
+        "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+        "topics": [],
+        "sourceCount": 82,
+        "path": "US/how is Virginia as the US residency of retirees wh.md"
+      }
+    ],
+    "us-austin": [
+      {
+        "title": "given my typical questions please list other cities where the temperature doesn't drop below 40 Fahrenheit in the winter, there is an expat ",
+        "topics": [],
+        "sourceCount": 24,
+        "path": "US/given my typical questions please list other citie.md"
+      },
+      {
+        "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+        "topics": [],
+        "sourceCount": 82,
+        "path": "US/how is Virginia as the US residency of retirees wh.md"
+      }
+    ],
+    "us-virginia": [
+      {
+        "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+        "topics": [],
+        "sourceCount": 82,
+        "path": "US/how is Virginia as the US residency of retirees wh.md"
+      }
+    ],
+    "us-philadelphia": [
+      {
+        "title": "how is Virginia as the US residency of retirees who are expats in France who will have an income under 72,000",
+        "topics": [],
+        "sourceCount": 82,
+        "path": "US/how is Virginia as the US residency of retirees wh.md"
+      }
+    ]
+  }
+}

--- a/data/locations/colombia-bogota/location.json
+++ b/data/locations/colombia-bogota/location.json
@@ -160,9 +160,15 @@
     "Affordable compared to major world capitals"
   ],
   "cons": [
-    "Cool and rainy climate (8,600 ft elevation)",
-    "Traffic congestion is severe",
-    "Altitude adjustment can be difficult"
+    {
+      "text": "Cool and rainy climate (8,600 ft elevation)"
+    },
+    {
+      "text": "Traffic congestion is severe"
+    },
+    {
+      "text": "Altitude adjustment can be difficult"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income if under 183 days/year.",

--- a/data/locations/colombia-cartagena/location.json
+++ b/data/locations/colombia-cartagena/location.json
@@ -160,9 +160,15 @@
     "Growing international community"
   ],
   "cons": [
-    "Hot and humid year-round",
-    "Tourist area prices can be high",
-    "Aggressive street vendors in tourist zones"
+    {
+      "text": "Hot and humid year-round"
+    },
+    {
+      "text": "Tourist area prices can be high"
+    },
+    {
+      "text": "Aggressive street vendors in tourist zones"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income if under 183 days/year.",

--- a/data/locations/colombia-medellin/location.json
+++ b/data/locations/colombia-medellin/location.json
@@ -160,9 +160,15 @@
     "Large and growing expat community"
   ],
   "cons": [
-    "Security varies significantly by neighborhood",
-    "Expat reputation issues in some areas (El Poblado)",
-    "Language barrier—Spanish essential outside expat zones"
+    {
+      "text": "Security varies significantly by neighborhood"
+    },
+    {
+      "text": "Expat reputation issues in some areas (El Poblado)"
+    },
+    {
+      "text": "Language barrier—Spanish essential outside expat zones"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income if not a tax resident (under 183 days). If tax resident, worldwide income is taxed at progressive rates up to 39%.",

--- a/data/locations/colombia-pereira/location.json
+++ b/data/locations/colombia-pereira/location.json
@@ -162,9 +162,15 @@
     "Pleasant spring-like climate in coffee region"
   ],
   "cons": [
-    "Very limited English spoken",
-    "Small expat community",
-    "Less developed infrastructure than Medellín"
+    {
+      "text": "Very limited English spoken"
+    },
+    {
+      "text": "Small expat community"
+    },
+    {
+      "text": "Less developed infrastructure than Medellín"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income if under 183 days/year.",

--- a/data/locations/colombia-santa-marta/location.json
+++ b/data/locations/colombia-santa-marta/location.json
@@ -160,9 +160,15 @@
     "Less touristy than Cartagena"
   ],
   "cons": [
-    "Infrastructure less developed than other cities",
-    "Limited English spoken",
-    "Hot year-round with fewer services"
+    {
+      "text": "Infrastructure less developed than other cities"
+    },
+    {
+      "text": "Limited English spoken"
+    },
+    {
+      "text": "Hot year-round with fewer services"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income if under 183 days/year.",

--- a/data/locations/costa-rica-arenal/location.json
+++ b/data/locations/costa-rica-arenal/location.json
@@ -162,9 +162,15 @@
     "Affordable with cooler highland climate"
   ],
   "cons": [
-    "Windy conditions around the lake",
-    "Significant rainfall year-round",
-    "Remote from major healthcare facilities"
+    {
+      "text": "Windy conditions around the lake"
+    },
+    {
+      "text": "Significant rainfall year-round"
+    },
+    {
+      "text": "Remote from major healthcare facilities"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: foreign income not taxed.",

--- a/data/locations/costa-rica-atenas/location.json
+++ b/data/locations/costa-rica-atenas/location.json
@@ -160,9 +160,15 @@
     "Established expat community in small-town setting"
   ],
   "cons": [
-    "Small town with limited nightlife",
-    "Car needed for most errands",
-    "Growing popularity increasing prices"
+    {
+      "text": "Small town with limited nightlife"
+    },
+    {
+      "text": "Car needed for most errands"
+    },
+    {
+      "text": "Growing popularity increasing prices"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: foreign income not taxed.",

--- a/data/locations/costa-rica-central-valley/location.json
+++ b/data/locations/costa-rica-central-valley/location.json
@@ -162,9 +162,15 @@
     "Large established expat community in Escazú/Santa Ana"
   ],
   "cons": [
-    "Traffic congestion in San José metro area",
-    "Higher cost of living than other Costa Rica areas",
-    "Air quality issues in urban core"
+    {
+      "text": "Traffic congestion in San José metro area"
+    },
+    {
+      "text": "Higher cost of living than other Costa Rica areas"
+    },
+    {
+      "text": "Air quality issues in urban core"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: only Costa Rica-sourced income is taxed. Foreign pensions and Social Security not taxed. CAJA mandatory contribution ~11% of declared income.",

--- a/data/locations/costa-rica-grecia/location.json
+++ b/data/locations/costa-rica-grecia/location.json
@@ -160,9 +160,15 @@
     "Famous red metal church and charming town center"
   ],
   "cons": [
-    "Smaller expat community than other CR locations",
-    "Limited English spoken outside expat circles",
-    "Small-town pace may not suit everyone"
+    {
+      "text": "Smaller expat community than other CR locations"
+    },
+    {
+      "text": "Limited English spoken outside expat circles"
+    },
+    {
+      "text": "Small-town pace may not suit everyone"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: foreign income not taxed.",

--- a/data/locations/costa-rica-guanacaste/location.json
+++ b/data/locations/costa-rica-guanacaste/location.json
@@ -162,9 +162,15 @@
     "International airport in Liberia for easy access"
   ],
   "cons": [
-    "Tourist prices in Tamarindo and Nosara",
-    "Very hot during dry season",
-    "Car essential; roads can be rough in rainy season"
+    {
+      "text": "Tourist prices in Tamarindo and Nosara"
+    },
+    {
+      "text": "Very hot during dry season"
+    },
+    {
+      "text": "Car essential; roads can be rough in rainy season"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: foreign income not taxed.",

--- a/data/locations/costa-rica-puerto-viejo/location.json
+++ b/data/locations/costa-rica-puerto-viejo/location.json
@@ -160,9 +160,15 @@
     "Diverse international community"
   ],
   "cons": [
-    "Very rainy with frequent flooding",
-    "Remote from quality healthcare",
-    "Petty theft can be an issue"
+    {
+      "text": "Very rainy with frequent flooding"
+    },
+    {
+      "text": "Remote from quality healthcare"
+    },
+    {
+      "text": "Petty theft can be an issue"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax system: foreign income not taxed.",

--- a/data/locations/croatia-dubrovnik/location.json
+++ b/data/locations/croatia-dubrovnik/location.json
@@ -167,9 +167,15 @@
     "Croatia in EU and Schengen since 2023"
   ],
   "cons": [
-    "Extremely tourism-heavy (Game of Thrones effect)",
-    "Higher cost than rest of Croatia",
-    "Very crowded May-October"
+    {
+      "text": "Extremely tourism-heavy (Game of Thrones effect)"
+    },
+    {
+      "text": "Higher cost than rest of Croatia"
+    },
+    {
+      "text": "Very crowded May-October"
+    }
   ],
   "taxes": {
     "notes": "Croatian progressive income tax 20% (up to €50,400) and 30% above. Surtax may apply (0-18% depending on municipality). No US-Croatia tax treaty.",

--- a/data/locations/croatia-istria/location.json
+++ b/data/locations/croatia-istria/location.json
@@ -167,9 +167,15 @@
     "Close to Italy and Slovenia for day trips"
   ],
   "cons": [
-    "Cooler winters than Dalmatian coast",
-    "Tourism-driven economy (quiet off-season)",
-    "Car essential for exploring the peninsula"
+    {
+      "text": "Cooler winters than Dalmatian coast"
+    },
+    {
+      "text": "Tourism-driven economy (quiet off-season)"
+    },
+    {
+      "text": "Car essential for exploring the peninsula"
+    }
   ],
   "taxes": {
     "notes": "Croatian progressive income tax 20%/30%. Municipal surtax may apply. No US-Croatia tax treaty.",

--- a/data/locations/croatia-split/location.json
+++ b/data/locations/croatia-split/location.json
@@ -167,9 +167,15 @@
     "More affordable than Dubrovnik with better daily infrastructure"
   ],
   "cons": [
-    "Tourist crowds in summer",
-    "Limited public transit",
-    "Winter can feel quiet and grey"
+    {
+      "text": "Tourist crowds in summer"
+    },
+    {
+      "text": "Limited public transit"
+    },
+    {
+      "text": "Winter can feel quiet and grey"
+    }
   ],
   "taxes": {
     "notes": "Croatian progressive income tax 20%/30%. Municipal surtax may apply. No US-Croatia tax treaty.",

--- a/data/locations/croatia-zagreb/location.json
+++ b/data/locations/croatia-zagreb/location.json
@@ -167,9 +167,15 @@
     "Good public tram and bus system"
   ],
   "cons": [
-    "Cold continental winters (below freezing)",
-    "No coast (2+ hours to the sea)",
-    "Earthquake damage (2020) still being repaired in some areas"
+    {
+      "text": "Cold continental winters (below freezing)"
+    },
+    {
+      "text": "No coast (2+ hours to the sea)"
+    },
+    {
+      "text": "Earthquake damage (2020) still being repaired in some areas"
+    }
   ],
   "taxes": {
     "notes": "Croatian progressive income tax 20%/30%. Zagreb has 18% municipal surtax. No US-Croatia tax treaty.",

--- a/data/locations/cyprus-larnaca/location.json
+++ b/data/locations/cyprus-larnaca/location.json
@@ -167,9 +167,15 @@
     "Relaxed beach town atmosphere"
   ],
   "cons": [
-    "Smaller and less cosmopolitan than Limassol",
-    "Limited cultural and dining scene",
-    "Very hot summers"
+    {
+      "text": "Smaller and less cosmopolitan than Limassol"
+    },
+    {
+      "text": "Limited cultural and dining scene"
+    },
+    {
+      "text": "Very hot summers"
+    }
   ],
   "taxes": {
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Very favorable for retirees.",

--- a/data/locations/cyprus-limassol/location.json
+++ b/data/locations/cyprus-limassol/location.json
@@ -167,9 +167,15 @@
     "New marina and waterfront development"
   ],
   "cons": [
-    "Higher cost than other Cypriot cities",
-    "Traffic congestion in city center",
-    "Very hot and humid summers"
+    {
+      "text": "Higher cost than other Cypriot cities"
+    },
+    {
+      "text": "Traffic congestion in city center"
+    },
+    {
+      "text": "Very hot and humid summers"
+    }
   ],
   "taxes": {
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Very favorable for retirees.",

--- a/data/locations/cyprus-paphos/location.json
+++ b/data/locations/cyprus-paphos/location.json
@@ -167,9 +167,15 @@
     "Very favorable tax treatment for retirees (2.65% on pensions)"
   ],
   "cons": [
-    "Island isolation from mainland Europe",
-    "Hot, dry summers (93F+)",
-    "Car essential outside city centers"
+    {
+      "text": "Island isolation from mainland Europe"
+    },
+    {
+      "text": "Hot, dry summers (93F+)"
+    },
+    {
+      "text": "Car essential outside city centers"
+    }
   ],
   "taxes": {
     "notes": "Cyprus: flat 2.65% on pension income for first €3,420, then 0%. Or opt for standard progressive rates 20%-35%. Very favorable for retirees. US-Cyprus tax treaty.",

--- a/data/locations/ecuador-cotacachi/location.json
+++ b/data/locations/ecuador-cotacachi/location.json
@@ -160,9 +160,15 @@
     "Small but established expat community"
   ],
   "cons": [
-    "Cool climate at altitude",
-    "Very small town with limited services",
-    "Far from quality healthcare"
+    {
+      "text": "Cool climate at altitude"
+    },
+    {
+      "text": "Very small town with limited services"
+    },
+    {
+      "text": "Far from quality healthcare"
+    }
   ],
   "taxes": {
     "notes": "Ecuador uses USD. Jubilado discounts apply.",

--- a/data/locations/ecuador-cuenca/location.json
+++ b/data/locations/ecuador-cuenca/location.json
@@ -160,9 +160,15 @@
     "Very affordable with USD currency (no exchange risk)"
   ],
   "cons": [
-    "Altitude (8,400 ft) may cause adjustment issues",
-    "Cool climate may not suit warm-weather seekers",
-    "Political instability and occasional unrest in Ecuador"
+    {
+      "text": "Altitude (8,400 ft) may cause adjustment issues"
+    },
+    {
+      "text": "Cool climate may not suit warm-weather seekers"
+    },
+    {
+      "text": "Political instability and occasional unrest in Ecuador"
+    }
   ],
   "taxes": {
     "notes": "Ecuador uses USD. Income tax on worldwide income if fiscal resident, but retiree visa holders may qualify for exemptions. Progressive rates 0-37%. Jubilado discount benefits offset many costs.",

--- a/data/locations/ecuador-quito/location.json
+++ b/data/locations/ecuador-quito/location.json
@@ -160,9 +160,15 @@
     "Uses USD with no exchange rate risk"
   ],
   "cons": [
-    "High altitude (9,350 ft) causes adjustment issues",
-    "Cool and rainy climate",
-    "Security concerns in some neighborhoods"
+    {
+      "text": "High altitude (9,350 ft) causes adjustment issues"
+    },
+    {
+      "text": "Cool and rainy climate"
+    },
+    {
+      "text": "Security concerns in some neighborhoods"
+    }
   ],
   "taxes": {
     "notes": "Ecuador uses USD. Progressive income tax 0-37% on worldwide income for residents.",

--- a/data/locations/ecuador-salinas/location.json
+++ b/data/locations/ecuador-salinas/location.json
@@ -160,9 +160,15 @@
     "Popular with Ecuadorian and expat retirees"
   ],
   "cons": [
-    "Very seasonal—dead during off-season",
-    "Limited healthcare locally",
-    "Can feel isolated from major services"
+    {
+      "text": "Very seasonal—dead during off-season"
+    },
+    {
+      "text": "Limited healthcare locally"
+    },
+    {
+      "text": "Can feel isolated from major services"
+    }
   ],
   "taxes": {
     "notes": "Ecuador uses USD. Jubilado discounts apply.",

--- a/data/locations/ecuador-vilcabamba/location.json
+++ b/data/locations/ecuador-vilcabamba/location.json
@@ -160,9 +160,15 @@
     "Peaceful rural setting with organic food culture"
   ],
   "cons": [
-    "Very remote with minimal services",
-    "Healthcare extremely limited",
-    "Small, isolated community"
+    {
+      "text": "Very remote with minimal services"
+    },
+    {
+      "text": "Healthcare extremely limited"
+    },
+    {
+      "text": "Small, isolated community"
+    }
   ],
   "taxes": {
     "notes": "Ecuador uses USD. Jubilado discounts apply.",

--- a/data/locations/france-brittany/location.json
+++ b/data/locations/france-brittany/location.json
@@ -263,10 +263,18 @@
     "Beautiful coastline"
   ],
   "cons": [
-    "Cool/rainy winters (38F lows)",
-    "Limited English",
-    "Complex tax situation with US",
-    "Distance from US"
+    {
+      "text": "Cool/rainy winters (38F lows)"
+    },
+    {
+      "text": "Limited English"
+    },
+    {
+      "text": "Complex tax situation with US"
+    },
+    {
+      "text": "Distance from US"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/france-dordogne/location.json
+++ b/data/locations/france-dordogne/location.json
@@ -167,9 +167,15 @@
     "Very affordable housing with large properties available"
   ],
   "cons": [
-    "Cold and damp winters",
-    "Car absolutely essential",
-    "Very limited public transit"
+    {
+      "text": "Cold and damp winters"
+    },
+    {
+      "text": "Car absolutely essential"
+    },
+    {
+      "text": "Very limited public transit"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",

--- a/data/locations/france-gascony/location.json
+++ b/data/locations/france-gascony/location.json
@@ -167,9 +167,15 @@
     "Peaceful rural lifestyle with friendly locals"
   ],
   "cons": [
-    "Very limited English spoken",
-    "Car essential, minimal public transit",
-    "Small expat community, can feel isolated"
+    {
+      "text": "Very limited English spoken"
+    },
+    {
+      "text": "Car essential, minimal public transit"
+    },
+    {
+      "text": "Small expat community, can feel isolated"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",

--- a/data/locations/france-languedoc/location.json
+++ b/data/locations/france-languedoc/location.json
@@ -167,9 +167,15 @@
     "Montpellier is a vibrant university city with tram system"
   ],
   "cons": [
-    "French language essential for daily life",
-    "Mistral winds can be intense",
-    "Smaller international community than Côte d'Azur"
+    {
+      "text": "French language essential for daily life"
+    },
+    {
+      "text": "Mistral winds can be intense"
+    },
+    {
+      "text": "Smaller international community than Côte d'Azur"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income (CSG/CRDS). US-France tax treaty.",

--- a/data/locations/france-lyon/location.json
+++ b/data/locations/france-lyon/location.json
@@ -243,10 +243,35 @@
     "Central Europe location"
   ],
   "cons": [
-    "Cold winters (30F)",
-    "Higher rents",
-    "Air quality concerns",
-    "Crowded"
+    {
+      "text": "Cold winters (30F)"
+    },
+    {
+      "text": "Higher rents",
+      "sources": [
+        {
+          "title": "morningcroissant.com",
+          "url": "https://www.morningcroissant.com/blog/furnished-rental-in-lyon-your-complete-guide-for-2025-26",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "jarniascyril.com",
+          "url": "https://www.jarniascyril.com/international-real-estate/invest-in-french-real-estate/investing-real-estate-lyon-market-neighborhoods-strategies/",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "adrianleeds.com",
+          "url": "https://adrianleeds.com/subscribe-to-our-publications/french-property-insider/fpi-archives/french-rent-reference-index/",
+          "accessed": "2026-04-23"
+        }
+      ]
+    },
+    {
+      "text": "Air quality concerns"
+    },
+    {
+      "text": "Crowded"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/france-montpellier/location.json
+++ b/data/locations/france-montpellier/location.json
@@ -244,9 +244,15 @@
     "Near beaches"
   ],
   "cons": [
-    "Hot summers (88F)",
-    "Occasional flooding",
-    "Crowded in summer"
+    {
+      "text": "Hot summers (88F)"
+    },
+    {
+      "text": "Occasional flooding"
+    },
+    {
+      "text": "Crowded in summer"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/france-nice/location.json
+++ b/data/locations/france-nice/location.json
@@ -167,9 +167,15 @@
     "Large international community and English widely understood"
   ],
   "cons": [
-    "Very high cost of living, especially rent",
-    "Crowded in summer tourist season",
-    "Petty crime (pickpocketing) in tourist areas"
+    {
+      "text": "Very high cost of living, especially rent"
+    },
+    {
+      "text": "Crowded in summer tourist season"
+    },
+    {
+      "text": "Petty crime (pickpocketing) in tourist areas"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",

--- a/data/locations/france-paris/location.json
+++ b/data/locations/france-paris/location.json
@@ -167,9 +167,15 @@
     "International city with huge expat community"
   ],
   "cons": [
-    "Very high cost of living, especially rent",
-    "Cold, grey winters",
-    "Can feel overwhelming and fast-paced"
+    {
+      "text": "Very high cost of living, especially rent"
+    },
+    {
+      "text": "Cold, grey winters"
+    },
+    {
+      "text": "Can feel overwhelming and fast-paced"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",

--- a/data/locations/france-toulon/location.json
+++ b/data/locations/france-toulon/location.json
@@ -167,9 +167,15 @@
     "Access to Porquerolles and Hyères islands"
   ],
   "cons": [
-    "Less glamorous and fewer amenities than Nice/Cannes",
-    "Smaller expat community",
-    "Some rougher neighborhoods in the city center"
+    {
+      "text": "Less glamorous and fewer amenities than Nice/Cannes"
+    },
+    {
+      "text": "Smaller expat community"
+    },
+    {
+      "text": "Some rougher neighborhoods in the city center"
+    }
   ],
   "taxes": {
     "notes": "French progressive income tax 11%-45%. Social charges ~9.1% on foreign income.",

--- a/data/locations/france-toulouse/location.json
+++ b/data/locations/france-toulouse/location.json
@@ -253,10 +253,18 @@
     "Near Pyrenees and Mediterranean"
   ],
   "cons": [
-    "Cold snaps in winter (34F lows)",
-    "Hot summers (86F)",
-    "Less English spoken than major tourist cities",
-    "Complex French tax situation with US"
+    {
+      "text": "Cold snaps in winter (34F lows)"
+    },
+    {
+      "text": "Hot summers (86F)"
+    },
+    {
+      "text": "Less English spoken than major tourist cities"
+    },
+    {
+      "text": "Complex French tax situation with US"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/greece-athens/location.json
+++ b/data/locations/greece-athens/location.json
@@ -167,9 +167,15 @@
     "Good public transit (metro, buses, tram)"
   ],
   "cons": [
-    "Extreme summer heat (95F+ for weeks)",
-    "Air pollution can be poor in summer",
-    "Bureaucracy can be challenging for residents"
+    {
+      "text": "Extreme summer heat (95F+ for weeks)"
+    },
+    {
+      "text": "Air pollution can be poor in summer"
+    },
+    {
+      "text": "Bureaucracy can be challenging for residents"
+    }
   ],
   "taxes": {
     "notes": "Greek progressive income tax 9%-44%. Special 7% flat tax for foreign retirees transferring tax residency (10-year program). US-Greece tax treaty.",

--- a/data/locations/greece-corfu/location.json
+++ b/data/locations/greece-corfu/location.json
@@ -167,9 +167,15 @@
     "Affordable and peaceful year-round lifestyle"
   ],
   "cons": [
-    "Rainier than other Greek islands",
-    "Very quiet in winter (many businesses close)",
-    "Limited healthcare facilities on island"
+    {
+      "text": "Rainier than other Greek islands"
+    },
+    {
+      "text": "Very quiet in winter (many businesses close)"
+    },
+    {
+      "text": "Limited healthcare facilities on island"
+    }
   ],
   "taxes": {
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",

--- a/data/locations/greece-crete/location.json
+++ b/data/locations/greece-crete/location.json
@@ -167,9 +167,15 @@
     "Excellent Cretan cuisine and food culture"
   ],
   "cons": [
-    "Island isolation - ferry or flights to mainland",
-    "Limited specialist healthcare",
-    "Car essentially required outside cities"
+    {
+      "text": "Island isolation - ferry or flights to mainland"
+    },
+    {
+      "text": "Limited specialist healthcare"
+    },
+    {
+      "text": "Car essentially required outside cities"
+    }
   ],
   "taxes": {
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",

--- a/data/locations/greece-peloponnese/location.json
+++ b/data/locations/greece-peloponnese/location.json
@@ -167,9 +167,15 @@
     "Authentic Greek mainland experience without mass tourism"
   ],
   "cons": [
-    "Very small expat community",
-    "Car essential for daily life",
-    "Limited English spoken outside tourist spots"
+    {
+      "text": "Very small expat community"
+    },
+    {
+      "text": "Car essential for daily life"
+    },
+    {
+      "text": "Limited English spoken outside tourist spots"
+    }
   ],
   "taxes": {
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",

--- a/data/locations/greece-rhodes/location.json
+++ b/data/locations/greece-rhodes/location.json
@@ -167,9 +167,15 @@
     "Affordable cost of living"
   ],
   "cons": [
-    "Tourism-dominated economy (very quiet off-season)",
-    "Limited specialist healthcare",
-    "Island isolation with seasonal flight connections"
+    {
+      "text": "Tourism-dominated economy (very quiet off-season)"
+    },
+    {
+      "text": "Limited specialist healthcare"
+    },
+    {
+      "text": "Island isolation with seasonal flight connections"
+    }
   ],
   "taxes": {
     "notes": "Greek progressive income tax 9%-44%. 7% flat tax option for foreign retirees.",

--- a/data/locations/ireland-cork/location.json
+++ b/data/locations/ireland-cork/location.json
@@ -167,9 +167,15 @@
     "Good airport with European connections"
   ],
   "cons": [
-    "Rainy climate (185+ days/year)",
-    "Housing market very competitive",
-    "Public transit limited compared to Dublin"
+    {
+      "text": "Rainy climate (185+ days/year)"
+    },
+    {
+      "text": "Housing market very competitive"
+    },
+    {
+      "text": "Public transit limited compared to Dublin"
+    }
   ],
   "taxes": {
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",

--- a/data/locations/ireland-galway/location.json
+++ b/data/locations/ireland-galway/location.json
@@ -167,9 +167,15 @@
     "English-speaking with welcoming community"
   ],
   "cons": [
-    "Very rainy (200+ days/year)",
-    "Higher rents due to university town demand",
-    "Remote from major airports"
+    {
+      "text": "Very rainy (200+ days/year)"
+    },
+    {
+      "text": "Higher rents due to university town demand"
+    },
+    {
+      "text": "Remote from major airports"
+    }
   ],
   "taxes": {
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",

--- a/data/locations/ireland-limerick/location.json
+++ b/data/locations/ireland-limerick/location.json
@@ -167,9 +167,15 @@
     "Strong rugby culture and community spirit"
   ],
   "cons": [
-    "Rainy climate",
-    "Some areas have reputation for anti-social behavior",
-    "Fewer cultural amenities than Cork or Galway"
+    {
+      "text": "Rainy climate"
+    },
+    {
+      "text": "Some areas have reputation for anti-social behavior"
+    },
+    {
+      "text": "Fewer cultural amenities than Cork or Galway"
+    }
   ],
   "taxes": {
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",

--- a/data/locations/ireland-waterford/location.json
+++ b/data/locations/ireland-waterford/location.json
@@ -302,15 +302,33 @@
     "Strong pub and community culture"
   ],
   "cons": [
-    "Very rainy (200+ days/year of precipitation)",
-    "Does not meet warm winter requirement (35F lows)",
-    "Smaller city with fewer amenities than Dublin or Cork",
-    "Long public healthcare waiting lists (HSE system)",
-    "High tax rates (income tax 40% + USC 8% + PRSI 4%)",
-    "Car-dependent outside Waterford city center",
-    "Far from family in US (7+ hour flight to East Coast)",
-    "High cost of living compared to continental Europe",
-    "Limited direct international flights from Waterford Airport"
+    {
+      "text": "Very rainy (200+ days/year of precipitation)"
+    },
+    {
+      "text": "Does not meet warm winter requirement (35F lows)"
+    },
+    {
+      "text": "Smaller city with fewer amenities than Dublin or Cork"
+    },
+    {
+      "text": "Long public healthcare waiting lists (HSE system)"
+    },
+    {
+      "text": "High tax rates (income tax 40% + USC 8% + PRSI 4%)"
+    },
+    {
+      "text": "Car-dependent outside Waterford city center"
+    },
+    {
+      "text": "Far from family in US (7+ hour flight to East Coast)"
+    },
+    {
+      "text": "High cost of living compared to continental Europe"
+    },
+    {
+      "text": "Limited direct international flights from Waterford Airport"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.88,

--- a/data/locations/ireland-wexford/location.json
+++ b/data/locations/ireland-wexford/location.json
@@ -167,9 +167,15 @@
     "Beautiful beaches and historic Norman heritage"
   ],
   "cons": [
-    "Very small expat community",
-    "Limited cultural and dining scene",
-    "Car essential for daily life"
+    {
+      "text": "Very small expat community"
+    },
+    {
+      "text": "Limited cultural and dining scene"
+    },
+    {
+      "text": "Car essential for daily life"
+    }
   ],
   "taxes": {
     "notes": "Irish progressive income tax 20%/40%. USC 0.5-8%. US-Ireland tax treaty.",

--- a/data/locations/italy-abruzzo/location.json
+++ b/data/locations/italy-abruzzo/location.json
@@ -167,9 +167,15 @@
     "Authentic Italian lifestyle without mass tourism"
   ],
   "cons": [
-    "Very limited English spoken",
-    "Small expat community",
-    "L'Aquila still recovering from 2009 earthquake"
+    {
+      "text": "Very limited English spoken"
+    },
+    {
+      "text": "Small expat community"
+    },
+    {
+      "text": "L'Aquila still recovering from 2009 earthquake"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. Italy offers 7% flat tax for retirees moving to southern regions (towns under 20K population). US-Italy tax treaty.",

--- a/data/locations/italy-lake-region/location.json
+++ b/data/locations/italy-lake-region/location.json
@@ -167,9 +167,15 @@
     "Mild microclimate (warmer than surrounding areas due to lakes)"
   ],
   "cons": [
-    "Higher cost of living than southern Italy",
-    "Cold winters with fog",
-    "Tourist-heavy in summer months"
+    {
+      "text": "Higher cost of living than southern Italy"
+    },
+    {
+      "text": "Cold winters with fog"
+    },
+    {
+      "text": "Tourist-heavy in summer months"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax not available (northern Italy, larger towns).",

--- a/data/locations/italy-puglia/location.json
+++ b/data/locations/italy-puglia/location.json
@@ -167,9 +167,15 @@
     "Stunning coastline and trulli houses in Ostuni/Alberobello"
   ],
   "cons": [
-    "Limited English spoken outside tourist areas",
-    "Public transit limited outside Bari",
-    "Southern Italian bureaucracy can be slow"
+    {
+      "text": "Limited English spoken outside tourist areas"
+    },
+    {
+      "text": "Public transit limited outside Bari"
+    },
+    {
+      "text": "Southern Italian bureaucracy can be slow"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax for retirees in southern towns under 20K population.",

--- a/data/locations/italy-sardinia/location.json
+++ b/data/locations/italy-sardinia/location.json
@@ -167,9 +167,15 @@
     "Unique Sardinian culture and cuisine"
   ],
   "cons": [
-    "Island isolation - flights or ferry to mainland",
-    "Car essential outside Cagliari",
-    "Limited English and smaller expat scene"
+    {
+      "text": "Island isolation - flights or ferry to mainland"
+    },
+    {
+      "text": "Car essential outside Cagliari"
+    },
+    {
+      "text": "Limited English and smaller expat scene"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax may apply in qualifying small towns.",

--- a/data/locations/italy-sicily/location.json
+++ b/data/locations/italy-sicily/location.json
@@ -167,9 +167,15 @@
     "Warm climate with mild winters"
   ],
   "cons": [
-    "Infrastructure and bureaucracy can be challenging",
-    "Limited specialist healthcare quality",
-    "Organized crime still present in some areas"
+    {
+      "text": "Infrastructure and bureaucracy can be challenging"
+    },
+    {
+      "text": "Limited specialist healthcare quality"
+    },
+    {
+      "text": "Organized crime still present in some areas"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax for retirees in southern towns under 20K population.",

--- a/data/locations/italy-tuscany/location.json
+++ b/data/locations/italy-tuscany/location.json
@@ -167,9 +167,15 @@
     "Excellent food and wine at every price point"
   ],
   "cons": [
-    "Higher cost of living than southern Italy",
-    "Tourist congestion in popular areas",
-    "Car needed for rural living"
+    {
+      "text": "Higher cost of living than southern Italy"
+    },
+    {
+      "text": "Tourist congestion in popular areas"
+    },
+    {
+      "text": "Car needed for rural living"
+    }
   ],
   "taxes": {
     "notes": "Italian progressive income tax 23%-43%. 7% flat tax not available in most Tuscan towns (population over 20K).",

--- a/data/locations/malta-gozo/location.json
+++ b/data/locations/malta-gozo/location.json
@@ -167,9 +167,15 @@
     "English spoken, very safe, warm climate"
   ],
   "cons": [
-    "Dependent on ferry to Malta for specialist healthcare and shopping",
-    "Limited entertainment and dining options",
-    "Can feel isolated, especially in winter"
+    {
+      "text": "Dependent on ferry to Malta for specialist healthcare and shopping"
+    },
+    {
+      "text": "Limited entertainment and dining options"
+    },
+    {
+      "text": "Can feel isolated, especially in winter"
+    }
   ],
   "taxes": {
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year. Gozo has reduced property requirements.",

--- a/data/locations/malta-sliema/location.json
+++ b/data/locations/malta-sliema/location.json
@@ -167,9 +167,15 @@
     "English widely spoken everywhere"
   ],
   "cons": [
-    "Construction boom causing noise and disruption",
-    "Higher rents than rest of Malta",
-    "Very crowded and built-up"
+    {
+      "text": "Construction boom causing noise and disruption"
+    },
+    {
+      "text": "Higher rents than rest of Malta"
+    },
+    {
+      "text": "Very crowded and built-up"
+    }
   ],
   "taxes": {
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year.",

--- a/data/locations/malta-valletta/location.json
+++ b/data/locations/malta-valletta/location.json
@@ -167,9 +167,15 @@
     "Stunning historic capital (UNESCO World Heritage)"
   ],
   "cons": [
-    "Very small and densely populated island",
-    "Traffic congestion is severe",
-    "Limited green spaces and dog-walking areas"
+    {
+      "text": "Very small and densely populated island"
+    },
+    {
+      "text": "Traffic congestion is severe"
+    },
+    {
+      "text": "Limited green spaces and dog-walking areas"
+    }
   ],
   "taxes": {
     "notes": "Malta Retirement Programme: 15% flat tax on remitted income, min €7,500/year. Standard rates 0%-35% otherwise. US-Malta tax treaty.",

--- a/data/locations/mexico-lake-chapala/location.json
+++ b/data/locations/mexico-lake-chapala/location.json
@@ -162,9 +162,15 @@
     "Extremely well-established expat infrastructure"
   ],
   "cons": [
-    "Can feel like an American bubble",
-    "Lake water quality concerns",
-    "Limited direct international flights"
+    {
+      "text": "Can feel like an American bubble"
+    },
+    {
+      "text": "Lake water quality concerns"
+    },
+    {
+      "text": "Limited direct international flights"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents: only Mexican-source income taxed. US pensions and Social Security not taxed by Mexico for temporary residents.",

--- a/data/locations/mexico-mazatlan/location.json
+++ b/data/locations/mexico-mazatlan/location.json
@@ -160,9 +160,15 @@
     "Growing expat community with authentic Mexican feel"
   ],
   "cons": [
-    "Hot and humid summers",
-    "Sinaloa state has security reputation issues",
-    "Seasonal—quieter in summer heat"
+    {
+      "text": "Hot and humid summers"
+    },
+    {
+      "text": "Sinaloa state has security reputation issues"
+    },
+    {
+      "text": "Seasonal—quieter in summer heat"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-merida/location.json
+++ b/data/locations/mexico-merida/location.json
@@ -160,9 +160,15 @@
     "Affordable with good infrastructure"
   ],
   "cons": [
-    "Extremely hot and humid summers",
-    "Less English spoken than other expat hubs",
-    "Hurricane zone (though inland)"
+    {
+      "text": "Extremely hot and humid summers"
+    },
+    {
+      "text": "Less English spoken than other expat hubs"
+    },
+    {
+      "text": "Hurricane zone (though inland)"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-oaxaca/location.json
+++ b/data/locations/mexico-oaxaca/location.json
@@ -160,9 +160,15 @@
     "Very affordable cost of living"
   ],
   "cons": [
-    "Periodic political protests and road blockades",
-    "Winter nights can be chilly",
-    "Limited healthcare for complex needs"
+    {
+      "text": "Periodic political protests and road blockades"
+    },
+    {
+      "text": "Winter nights can be chilly"
+    },
+    {
+      "text": "Limited healthcare for complex needs"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-playa-del-carmen/location.json
+++ b/data/locations/mexico-playa-del-carmen/location.json
@@ -160,9 +160,15 @@
     "Convenient to Cancún airport for US flights"
   ],
   "cons": [
-    "Sargassum seaweed issues seasonally",
-    "Rising security concerns in Quintana Roo",
-    "Tourism-driven prices; less authentic feel"
+    {
+      "text": "Sargassum seaweed issues seasonally"
+    },
+    {
+      "text": "Rising security concerns in Quintana Roo"
+    },
+    {
+      "text": "Tourism-driven prices; less authentic feel"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-puerto-vallarta/location.json
+++ b/data/locations/mexico-puerto-vallarta/location.json
@@ -160,9 +160,15 @@
     "Excellent dining and nightlife"
   ],
   "cons": [
-    "Hot and humid summers with heavy rain",
-    "Tourist prices in popular zones",
-    "Seasonal (many expats leave in summer)"
+    {
+      "text": "Hot and humid summers with heavy rain"
+    },
+    {
+      "text": "Tourist prices in popular zones"
+    },
+    {
+      "text": "Seasonal (many expats leave in summer)"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-queretaro/location.json
+++ b/data/locations/mexico-queretaro/location.json
@@ -160,9 +160,15 @@
     "Growing tech/business hub with good jobs"
   ],
   "cons": [
-    "Winter nights can be cold",
-    "Smaller expat community than Chapala or SMA",
-    "Less tourist infrastructure than beach towns"
+    {
+      "text": "Winter nights can be cold"
+    },
+    {
+      "text": "Smaller expat community than Chapala or SMA"
+    },
+    {
+      "text": "Less tourist infrastructure than beach towns"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/mexico-san-miguel-de-allende/location.json
+++ b/data/locations/mexico-san-miguel-de-allende/location.json
@@ -160,9 +160,15 @@
     "Large welcoming expat community"
   ],
   "cons": [
-    "Winter nights can be cold (no central heating)",
-    "Prices inflated by tourism and expat demand",
-    "Cobblestone streets difficult for mobility issues"
+    {
+      "text": "Winter nights can be cold (no central heating)"
+    },
+    {
+      "text": "Prices inflated by tourism and expat demand"
+    },
+    {
+      "text": "Cobblestone streets difficult for mobility issues"
+    }
   ],
   "taxes": {
     "notes": "Territorial tax for temporary residents. Foreign income not taxed.",

--- a/data/locations/panama-bocas-del-toro/location.json
+++ b/data/locations/panama-bocas-del-toro/location.json
@@ -160,9 +160,15 @@
     "Growing expat and digital nomad community"
   ],
   "cons": [
-    "Isolated island location limits healthcare access",
-    "Very rainy climate year-round",
-    "Infrastructure can be unreliable (power, water)"
+    {
+      "text": "Isolated island location limits healthcare access"
+    },
+    {
+      "text": "Very rainy climate year-round"
+    },
+    {
+      "text": "Infrastructure can be unreliable (power, water)"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-boquete/location.json
+++ b/data/locations/panama-boquete/location.json
@@ -230,11 +230,21 @@
     "Pensionado discounts (20-50% on many services)"
   ],
   "cons": [
-    "Heavy rainy season (Apr-Dec)",
-    "Limited specialty healthcare (David 40 min)",
-    "Fewer pet services than cities",
-    "Internet not gigabit yet",
-    "Small town with limited nightlife"
+    {
+      "text": "Heavy rainy season (Apr-Dec)"
+    },
+    {
+      "text": "Limited specialty healthcare (David 40 min)"
+    },
+    {
+      "text": "Fewer pet services than cities"
+    },
+    {
+      "text": "Internet not gigabit yet"
+    },
+    {
+      "text": "Small town with limited nightlife"
+    }
   ],
   "subregion": "Chiriquí"
 }

--- a/data/locations/panama-chitre/location.json
+++ b/data/locations/panama-chitre/location.json
@@ -160,9 +160,15 @@
     "Authentic Panamanian culture and festivals"
   ],
   "cons": [
-    "Very hot during dry season",
-    "Minimal expat community",
-    "Limited English spoken"
+    {
+      "text": "Very hot during dry season"
+    },
+    {
+      "text": "Minimal expat community"
+    },
+    {
+      "text": "Limited English spoken"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-city-bella-vista/location.json
+++ b/data/locations/panama-city-bella-vista/location.json
@@ -160,9 +160,15 @@
     "Major international hub with direct flights"
   ],
   "cons": [
-    "Hot and humid year-round",
-    "Traffic congestion is severe",
-    "Higher cost of living than other Panama locations"
+    {
+      "text": "Hot and humid year-round"
+    },
+    {
+      "text": "Traffic congestion is severe"
+    },
+    {
+      "text": "Higher cost of living than other Panama locations"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income. Panama City has higher living costs but extensive urban amenities.",

--- a/data/locations/panama-city-casco-viejo/location.json
+++ b/data/locations/panama-city-casco-viejo/location.json
@@ -160,9 +160,15 @@
     "Walkable cobblestone streets with ocean views"
   ],
   "cons": [
-    "Ongoing construction and renovation noise",
-    "Limited parking and narrow streets",
-    "Some surrounding areas still transitioning"
+    {
+      "text": "Ongoing construction and renovation noise"
+    },
+    {
+      "text": "Limited parking and narrow streets"
+    },
+    {
+      "text": "Some surrounding areas still transitioning"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-city-costa-del-este/location.json
+++ b/data/locations/panama-city-costa-del-este/location.json
@@ -160,9 +160,15 @@
     "Newer construction with good building standards"
   ],
   "cons": [
-    "Car-dependent suburban layout",
-    "Further from downtown attractions",
-    "Hot and humid year-round"
+    {
+      "text": "Car-dependent suburban layout"
+    },
+    {
+      "text": "Further from downtown attractions"
+    },
+    {
+      "text": "Hot and humid year-round"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-city-el-cangrejo/location.json
+++ b/data/locations/panama-city-el-cangrejo/location.json
@@ -160,9 +160,15 @@
     "Walkable neighborhood with metro access"
   ],
   "cons": [
-    "Hot and humid climate",
-    "Some areas feel congested",
-    "Noise from busy streets"
+    {
+      "text": "Hot and humid climate"
+    },
+    {
+      "text": "Some areas feel congested"
+    },
+    {
+      "text": "Noise from busy streets"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-city-punta-pacifica/location.json
+++ b/data/locations/panama-city-punta-pacifica/location.json
@@ -160,9 +160,15 @@
     "Modern amenities, pools, gyms in buildings"
   ],
   "cons": [
-    "Most expensive Panama neighborhood",
-    "Somewhat sterile/corporate feel",
-    "Hot and humid year-round"
+    {
+      "text": "Most expensive Panama neighborhood"
+    },
+    {
+      "text": "Somewhat sterile/corporate feel"
+    },
+    {
+      "text": "Hot and humid year-round"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-city/location.json
+++ b/data/locations/panama-city/location.json
@@ -233,11 +233,21 @@
     "Pensionado discounts"
   ],
   "cons": [
-    "Pet transport expensive ($7.5-9K)",
-    "Private healthcare only",
-    "Rainy season (May-Dec)",
-    "Safety concerns",
-    "Limited gigabit internet outside city"
+    {
+      "text": "Pet transport expensive ($7.5-9K)"
+    },
+    {
+      "text": "Private healthcare only"
+    },
+    {
+      "text": "Rainy season (May-Dec)"
+    },
+    {
+      "text": "Safety concerns"
+    },
+    {
+      "text": "Limited gigabit internet outside city"
+    }
   ],
   "subregion": "Panama Province"
 }

--- a/data/locations/panama-coronado/location.json
+++ b/data/locations/panama-coronado/location.json
@@ -160,9 +160,15 @@
     "Reasonably close to Panama City for services"
   ],
   "cons": [
-    "Hot and humid beach climate",
-    "Car required for most errands",
-    "Beach can be rough for swimming"
+    {
+      "text": "Hot and humid beach climate"
+    },
+    {
+      "text": "Car required for most errands"
+    },
+    {
+      "text": "Beach can be rough for swimming"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-david/location.json
+++ b/data/locations/panama-david/location.json
@@ -160,9 +160,15 @@
     "Affordable with urban conveniences"
   ],
   "cons": [
-    "Very hot lowland climate",
-    "Limited cultural/entertainment options",
-    "Not as scenic as highland or beach alternatives"
+    {
+      "text": "Very hot lowland climate"
+    },
+    {
+      "text": "Limited cultural/entertainment options"
+    },
+    {
+      "text": "Not as scenic as highland or beach alternatives"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-el-valle/location.json
+++ b/data/locations/panama-el-valle/location.json
@@ -160,9 +160,15 @@
     "Famous Sunday market and natural hot springs"
   ],
   "cons": [
-    "Very small town with limited services",
-    "Heavy rainfall during rainy season",
-    "Far from quality healthcare"
+    {
+      "text": "Very small town with limited services"
+    },
+    {
+      "text": "Heavy rainfall during rainy season"
+    },
+    {
+      "text": "Far from quality healthcare"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-pedasi/location.json
+++ b/data/locations/panama-pedasi/location.json
@@ -160,9 +160,15 @@
     "Very affordable with low crime"
   ],
   "cons": [
-    "Very small town with minimal services",
-    "Far from quality healthcare",
-    "Limited shopping and dining options"
+    {
+      "text": "Very small town with minimal services"
+    },
+    {
+      "text": "Far from quality healthcare"
+    },
+    {
+      "text": "Limited shopping and dining options"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-puerto-armuelles/location.json
+++ b/data/locations/panama-puerto-armuelles/location.json
@@ -160,9 +160,15 @@
     "Small but friendly expat community"
   ],
   "cons": [
-    "Former banana company town still recovering economically",
-    "Very limited services and infrastructure",
-    "Remote location far from major amenities"
+    {
+      "text": "Former banana company town still recovering economically"
+    },
+    {
+      "text": "Very limited services and infrastructure"
+    },
+    {
+      "text": "Remote location far from major amenities"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/panama-volcan/location.json
+++ b/data/locations/panama-volcan/location.json
@@ -160,9 +160,15 @@
     "Rich agricultural area with fresh produce"
   ],
   "cons": [
-    "Small town with limited amenities",
-    "Heavy rainfall during rainy season",
-    "Less developed expat infrastructure than Boquete"
+    {
+      "text": "Small town with limited amenities"
+    },
+    {
+      "text": "Heavy rainfall during rainy season"
+    },
+    {
+      "text": "Less developed expat infrastructure than Boquete"
+    }
   ],
   "taxes": {
     "notes": "No tax on foreign-source income.",

--- a/data/locations/portugal-algarve/location.json
+++ b/data/locations/portugal-algarve/location.json
@@ -167,9 +167,15 @@
     "Affordable cost of living by Western European standards"
   ],
   "cons": [
-    "Tourist-heavy areas can feel less authentic",
-    "Limited public transit outside Faro",
-    "Summer heat can be intense (90F+)"
+    {
+      "text": "Tourist-heavy areas can feel less authentic"
+    },
+    {
+      "text": "Limited public transit outside Faro"
+    },
+    {
+      "text": "Summer heat can be intense (90F+)"
+    }
   ],
   "taxes": {
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%. US-Portugal tax treaty helps avoid double taxation.",

--- a/data/locations/portugal-cascais/location.json
+++ b/data/locations/portugal-cascais/location.json
@@ -167,9 +167,15 @@
     "Strong international community and English widely spoken"
   ],
   "cons": [
-    "One of the most expensive areas in Portugal",
-    "Crowded in summer tourist season",
-    "Housing market very competitive"
+    {
+      "text": "One of the most expensive areas in Portugal"
+    },
+    {
+      "text": "Crowded in summer tourist season"
+    },
+    {
+      "text": "Housing market very competitive"
+    }
   ],
   "taxes": {
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",

--- a/data/locations/portugal-lisbon/location.json
+++ b/data/locations/portugal-lisbon/location.json
@@ -275,9 +275,15 @@
     "Strong expat community"
   ],
   "cons": [
-    "Rising rents (especially Lisbon)",
-    "Longer healthcare waits",
-    "Language barrier for permanent residency"
+    {
+      "text": "Rising rents (especially Lisbon)"
+    },
+    {
+      "text": "Longer healthcare waits"
+    },
+    {
+      "text": "Language barrier for permanent residency"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/portugal-porto/location.json
+++ b/data/locations/portugal-porto/location.json
@@ -167,9 +167,15 @@
     "UNESCO World Heritage riverside district"
   ],
   "cons": [
-    "Cooler and rainier than southern Portugal",
-    "Hilly terrain throughout the city",
-    "Smaller international community than Lisbon"
+    {
+      "text": "Cooler and rainier than southern Portugal"
+    },
+    {
+      "text": "Hilly terrain throughout the city"
+    },
+    {
+      "text": "Smaller international community than Lisbon"
+    }
   ],
   "taxes": {
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",

--- a/data/locations/portugal-silver-coast/location.json
+++ b/data/locations/portugal-silver-coast/location.json
@@ -167,9 +167,15 @@
     "Close to Lisbon (1 hour) while maintaining small-town feel"
   ],
   "cons": [
-    "Smaller expat community than Algarve or Lisbon",
-    "Limited public transit between towns",
-    "Cooler and windier than southern Portugal"
+    {
+      "text": "Smaller expat community than Algarve or Lisbon"
+    },
+    {
+      "text": "Limited public transit between towns"
+    },
+    {
+      "text": "Cooler and windier than southern Portugal"
+    }
   ],
   "taxes": {
     "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",

--- a/data/locations/spain-alicante/location.json
+++ b/data/locations/spain-alicante/location.json
@@ -250,10 +250,52 @@
     "Beautiful beaches"
   ],
   "cons": [
-    "Higher visa income requirement (EUR 2400/mo)",
-    "Private insurance needed initially",
-    "A2 Spanish required for permanent residency",
-    "Hot summers"
+    {
+      "text": "Higher visa income requirement (EUR 2400/mo)",
+      "sources": [
+        {
+          "title": "myspainvisa.com",
+          "url": "https://myspainvisa.com/non-lucrative-visa-spain/",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "madridbullfighting.com",
+          "url": "https://madridbullfighting.com/blog/do-americans-need-a-visa-for-spain/",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "etias.com",
+          "url": "https://etias.com/etias-requirements/etias-for-american-citizens",
+          "accessed": "2026-04-23"
+        }
+      ]
+    },
+    {
+      "text": "Private insurance needed initially"
+    },
+    {
+      "text": "A2 Spanish required for permanent residency",
+      "sources": [
+        {
+          "title": "myspainvisa.com",
+          "url": "https://myspainvisa.com/non-lucrative-visa-spain/",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "madridbullfighting.com",
+          "url": "https://madridbullfighting.com/blog/do-americans-need-a-visa-for-spain/",
+          "accessed": "2026-04-23"
+        },
+        {
+          "title": "etias.com",
+          "url": "https://etias.com/etias-requirements/etias-for-american-citizens",
+          "accessed": "2026-04-23"
+        }
+      ]
+    },
+    {
+      "text": "Hot summers"
+    }
   ],
   "exchangeRates": {
     "optimistic": 0.85,

--- a/data/locations/spain-barcelona/location.json
+++ b/data/locations/spain-barcelona/location.json
@@ -167,9 +167,15 @@
     "Beach city with Mediterranean climate"
   ],
   "cons": [
-    "High cost of living, especially rent",
-    "Pickpocketing and petty crime in tourist areas",
-    "Political tensions around Catalan independence"
+    {
+      "text": "High cost of living, especially rent"
+    },
+    {
+      "text": "Pickpocketing and petty crime in tourist areas"
+    },
+    {
+      "text": "Political tensions around Catalan independence"
+    }
   ],
   "taxes": {
     "notes": "Spanish progressive income tax 19%-47%. Catalonia has slightly higher regional surcharges.",

--- a/data/locations/spain-canary-islands/location.json
+++ b/data/locations/spain-canary-islands/location.json
@@ -167,9 +167,15 @@
     "Large Northern European expat community"
   ],
   "cons": [
-    "Island isolation - flights to mainland are 2.5+ hours",
-    "Limited shopping and cultural options vs mainland",
-    "Some goods more expensive due to shipping costs"
+    {
+      "text": "Island isolation - flights to mainland are 2.5+ hours"
+    },
+    {
+      "text": "Limited shopping and cultural options vs mainland"
+    },
+    {
+      "text": "Some goods more expensive due to shipping costs"
+    }
   ],
   "taxes": {
     "notes": "Spanish progressive income tax 19%-47%. Canary Islands use IGIC (7%) instead of mainland IVA/VAT (21%).",

--- a/data/locations/spain-costa-del-sol/location.json
+++ b/data/locations/spain-costa-del-sol/location.json
@@ -167,9 +167,15 @@
     "Excellent healthcare infrastructure in Málaga"
   ],
   "cons": [
-    "Tourist-heavy areas can feel like enclaves",
-    "Marbella significantly more expensive",
-    "Summer heat extreme in July-August"
+    {
+      "text": "Tourist-heavy areas can feel like enclaves"
+    },
+    {
+      "text": "Marbella significantly more expensive"
+    },
+    {
+      "text": "Summer heat extreme in July-August"
+    }
   ],
   "taxes": {
     "notes": "Spanish progressive income tax 19%-47%. Beckham Law may apply for new residents (flat 24% up to €600K). US-Spain tax treaty.",

--- a/data/locations/spain-valencia/location.json
+++ b/data/locations/spain-valencia/location.json
@@ -167,9 +167,15 @@
     "Good metro and bus system, bikeable"
   ],
   "cons": [
-    "Less English spoken than Costa del Sol",
-    "Flash flooding risk in autumn (DANA events)",
-    "Summer humidity can be uncomfortable"
+    {
+      "text": "Less English spoken than Costa del Sol"
+    },
+    {
+      "text": "Flash flooding risk in autumn (DANA events)"
+    },
+    {
+      "text": "Summer humidity can be uncomfortable"
+    }
   ],
   "taxes": {
     "notes": "Spanish progressive income tax 19%-47%. Valencia region may have slightly different regional rates.",

--- a/data/locations/uruguay-colonia/location.json
+++ b/data/locations/uruguay-colonia/location.json
@@ -160,9 +160,15 @@
     "Ferry access to Buenos Aires for services and culture"
   ],
   "cons": [
-    "Small town with limited services",
-    "Cool winters",
-    "Very limited English spoken"
+    {
+      "text": "Small town with limited services"
+    },
+    {
+      "text": "Cool winters"
+    },
+    {
+      "text": "Very limited English spoken"
+    }
   ],
   "taxes": {
     "notes": "Foreign income tax-exempt year 1, then 12% flat rate on foreign income.",

--- a/data/locations/uruguay-montevideo/location.json
+++ b/data/locations/uruguay-montevideo/location.json
@@ -160,9 +160,15 @@
     "Good healthcare system and infrastructure"
   ],
   "cons": [
-    "Higher cost of living than most Latin American options",
-    "Cool winters (not warm-weather destination)",
-    "Smaller expat community; Spanish essential"
+    {
+      "text": "Higher cost of living than most Latin American options"
+    },
+    {
+      "text": "Cool winters (not warm-weather destination)"
+    },
+    {
+      "text": "Smaller expat community; Spanish essential"
+    }
   ],
   "taxes": {
     "notes": "Foreign income tax-exempt in year 1. After that, foreign income taxed at flat 12% (reduced from standard rates). Uruguay has 22% IVA (VAT).",

--- a/data/locations/uruguay-punta-del-este/location.json
+++ b/data/locations/uruguay-punta-del-este/location.json
@@ -160,9 +160,15 @@
     "Very safe with high quality of life"
   ],
   "cons": [
-    "Very seasonal—dead in winter, expensive in summer",
-    "One of the most expensive places in South America",
-    "Cool winters and windy conditions"
+    {
+      "text": "Very seasonal—dead in winter, expensive in summer"
+    },
+    {
+      "text": "One of the most expensive places in South America"
+    },
+    {
+      "text": "Cool winters and windy conditions"
+    }
   ],
   "taxes": {
     "notes": "Foreign income tax-exempt year 1, then 12% flat rate on foreign income.",

--- a/data/locations/us-albuquerque-nm/location.json
+++ b/data/locations/us-albuquerque-nm/location.json
@@ -172,9 +172,15 @@
     "Rich Native American and Hispanic cultural heritage"
   ],
   "cons": [
-    "Higher crime rates in some areas",
-    "Limited public transportation",
-    "Fewer major metro amenities"
+    {
+      "text": "Higher crime rates in some areas"
+    },
+    {
+      "text": "Limited public transportation"
+    },
+    {
+      "text": "Fewer major metro amenities"
+    }
   ],
   "taxes": {
     "notes": "Federal + NM state income tax (1.7-5.9%); SS benefits exempt",

--- a/data/locations/us-annandale-va/location.json
+++ b/data/locations/us-annandale-va/location.json
@@ -235,10 +235,18 @@
     "Same world-class healthcare (Inova)"
   ],
   "cons": [
-    "Older housing stock — may need more maintenance",
-    "Interstate 495 traffic",
-    "Fewer single-family homes than outer Northern Virginia suburbs",
-    "Still Northern Virginia-premium vs national average"
+    {
+      "text": "Older housing stock — may need more maintenance"
+    },
+    {
+      "text": "Interstate 495 traffic"
+    },
+    {
+      "text": "Fewer single-family homes than outer Northern Virginia suburbs"
+    },
+    {
+      "text": "Still Northern Virginia-premium vs national average"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-annapolis-md/location.json
+++ b/data/locations/us-annapolis-md/location.json
@@ -259,11 +259,21 @@
     "Walkable historic downtown"
   ],
   "cons": [
-    "Higher combined state+county income tax than VA",
-    "Bay Bridge tolls + summer traffic on Route 50",
-    "Coastal flood insurance premium in low-lying areas",
-    "No Metro; longer commute to DC than Fairfax",
-    "Humid summers, nor'easter exposure"
+    {
+      "text": "Higher combined state+county income tax than VA"
+    },
+    {
+      "text": "Bay Bridge tolls + summer traffic on Route 50"
+    },
+    {
+      "text": "Coastal flood insurance premium in low-lying areas"
+    },
+    {
+      "text": "No Metro; longer commute to DC than Fairfax"
+    },
+    {
+      "text": "Humid summers, nor'easter exposure"
+    }
   ],
   "subregion": "Maryland"
 }

--- a/data/locations/us-armstrong-county-pa/location.json
+++ b/data/locations/us-armstrong-county-pa/location.json
@@ -173,9 +173,15 @@
     "Low crime rate and quiet community"
   ],
   "cons": [
-    "Very limited amenities and healthcare",
-    "Cold winters",
-    "Remote â€” Pittsburgh is 45+ min drive"
+    {
+      "text": "Very limited amenities and healthcare"
+    },
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "Remote â€” Pittsburgh is 45+ min drive"
+    }
   ],
   "taxes": {
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",

--- a/data/locations/us-asheville-nc/location.json
+++ b/data/locations/us-asheville-nc/location.json
@@ -172,9 +172,15 @@
     "Strong farm-to-table food culture"
   ],
   "cons": [
-    "Limited public transportation",
-    "Tourism crowds in peak seasons",
-    "Higher COL than NC average"
+    {
+      "text": "Limited public transportation"
+    },
+    {
+      "text": "Tourism crowds in peak seasons"
+    },
+    {
+      "text": "Higher COL than NC average"
+    }
   ],
   "taxes": {
     "notes": "Federal + NC state income tax (flat 4.5%)",

--- a/data/locations/us-atlanta/location.json
+++ b/data/locations/us-atlanta/location.json
@@ -260,11 +260,21 @@
     "No state income tax on first $65K retirement income per person"
   ],
   "cons": [
-    "Hot, humid summers (89F)",
-    "Traffic congestion among worst in the US",
-    "Higher cost of living than rural Georgia",
-    "Georgia state income tax (1-5.49%)",
-    "Some areas have higher crime rates"
+    {
+      "text": "Hot, humid summers (89F)"
+    },
+    {
+      "text": "Traffic congestion among worst in the US"
+    },
+    {
+      "text": "Higher cost of living than rural Georgia"
+    },
+    {
+      "text": "Georgia state income tax (1-5.49%)"
+    },
+    {
+      "text": "Some areas have higher crime rates"
+    }
   ],
   "subregion": "Georgia"
 }

--- a/data/locations/us-austin/location.json
+++ b/data/locations/us-austin/location.json
@@ -251,13 +251,27 @@
     "Growing healthcare infrastructure"
   ],
   "cons": [
-    "Extreme summer heat (97F+ highs, 100+ heat index)",
-    "Rising cost of living due to tech migration",
-    "Heavy traffic congestion on I-35 and MoPac",
-    "High property taxes reflected in rent",
-    "Car-dependent for most areas",
-    "Allergies — cedar fever season (Dec-Feb)",
-    "Flash flood risk in hill country areas"
+    {
+      "text": "Extreme summer heat (97F+ highs, 100+ heat index)"
+    },
+    {
+      "text": "Rising cost of living due to tech migration"
+    },
+    {
+      "text": "Heavy traffic congestion on I-35 and MoPac"
+    },
+    {
+      "text": "High property taxes reflected in rent"
+    },
+    {
+      "text": "Car-dependent for most areas"
+    },
+    {
+      "text": "Allergies — cedar fever season (Dec-Feb)"
+    },
+    {
+      "text": "Flash flood risk in hill country areas"
+    }
   ],
   "subregion": "Texas"
 }

--- a/data/locations/us-baltimore-md/location.json
+++ b/data/locations/us-baltimore-md/location.json
@@ -172,9 +172,15 @@
     "Inner Harbor and cultural attractions"
   ],
   "cons": [
-    "Higher crime rates",
-    "Cold winters",
-    "MD state income tax (2-5.75%) plus county tax"
+    {
+      "text": "Higher crime rates"
+    },
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "MD state income tax (2-5.75%) plus county tax"
+    }
   ],
   "taxes": {
     "notes": "Federal + MD state income tax (2-5.75%) + county income tax",

--- a/data/locations/us-birmingham-al/location.json
+++ b/data/locations/us-birmingham-al/location.json
@@ -172,9 +172,15 @@
     "UAB Hospital â€” excellent medical center"
   ],
   "cons": [
-    "Hot, humid summers",
-    "Car-dependent with limited transit",
-    "Higher crime rates in some areas"
+    {
+      "text": "Hot, humid summers"
+    },
+    {
+      "text": "Car-dependent with limited transit"
+    },
+    {
+      "text": "Higher crime rates in some areas"
+    }
   ],
   "taxes": {
     "notes": "Federal + AL state income tax (2-5%); SS benefits exempt",

--- a/data/locations/us-bowie-md/location.json
+++ b/data/locations/us-bowie-md/location.json
@@ -255,11 +255,21 @@
     "Planned community with established schools + parks"
   ],
   "cons": [
-    "Highest county piggyback rate in MD (3.20%) — combined state+county up to 8.95%",
-    "Car-dependent outside MARC corridor",
-    "Bay Bridge / Route 50 summer traffic",
-    "Prince George's County (PG County) has higher crime perception than Anne Arundel",
-    "Limited walkable downtown compared to Annapolis"
+    {
+      "text": "Highest county piggyback rate in MD (3.20%) — combined state+county up to 8.95%"
+    },
+    {
+      "text": "Car-dependent outside MARC corridor"
+    },
+    {
+      "text": "Bay Bridge / Route 50 summer traffic"
+    },
+    {
+      "text": "Prince George's County (PG County) has higher crime perception than Anne Arundel"
+    },
+    {
+      "text": "Limited walkable downtown compared to Annapolis"
+    }
   ],
   "subregion": "Maryland"
 }

--- a/data/locations/us-camden-nj/location.json
+++ b/data/locations/us-camden-nj/location.json
@@ -271,11 +271,21 @@
     "Access to Philly cultural institutions and healthcare"
   ],
   "cons": [
-    "Cold winters (24F lows)",
-    "Higher crime rates than average (though improving)",
-    "Less car-dependent than suburbs but PATCO focused on commuters",
-    "Limited gig internet coverage (75% vs 95%+ in suburbs)",
-    "Urban location with mixed neighborhoods"
+    {
+      "text": "Cold winters (24F lows)"
+    },
+    {
+      "text": "Higher crime rates than average (though improving)"
+    },
+    {
+      "text": "Less car-dependent than suburbs but PATCO focused on commuters"
+    },
+    {
+      "text": "Limited gig internet coverage (75% vs 95%+ in suburbs)"
+    },
+    {
+      "text": "Urban location with mixed neighborhoods"
+    }
   ],
   "subregion": "New Jersey"
 }

--- a/data/locations/us-catonsville-md/location.json
+++ b/data/locations/us-catonsville-md/location.json
@@ -257,12 +257,24 @@
     "Diverse community"
   ],
   "cons": [
-    "Baltimore County piggyback 3.20% — tied for highest in MD",
-    "No direct MARC station (15 min to Penn Station)",
-    "~55 mi from Fairfax — longer drive than Bowie",
-    "Not on the water (unlike Annapolis)",
-    "Some older housing requires maintenance",
-    "Baltimore metro reputation concerns (though Catonsville itself is safe)"
+    {
+      "text": "Baltimore County piggyback 3.20% — tied for highest in MD"
+    },
+    {
+      "text": "No direct MARC station (15 min to Penn Station)"
+    },
+    {
+      "text": "~55 mi from Fairfax — longer drive than Bowie"
+    },
+    {
+      "text": "Not on the water (unlike Annapolis)"
+    },
+    {
+      "text": "Some older housing requires maintenance"
+    },
+    {
+      "text": "Baltimore metro reputation concerns (though Catonsville itself is safe)"
+    }
   ],
   "subregion": "Maryland"
 }

--- a/data/locations/us-charlotte-amalie-vi/location.json
+++ b/data/locations/us-charlotte-amalie-vi/location.json
@@ -180,10 +180,18 @@
     "Direct flights to US mainland"
   ],
   "cons": [
-    "High cost of living (imports)",
-    "Hurricane risk and recovery lag",
-    "Electricity among the most expensive in the US",
-    "Limited medical specialists — off-island travel common"
+    {
+      "text": "High cost of living (imports)"
+    },
+    {
+      "text": "Hurricane risk and recovery lag"
+    },
+    {
+      "text": "Electricity among the most expensive in the US"
+    },
+    {
+      "text": "Limited medical specialists — off-island travel common"
+    }
   ],
   "taxes": {
     "notes": "USVI residents file a mirror-code return with Bureau of Internal Revenue instead of IRS.",

--- a/data/locations/us-cherry-hill/location.json
+++ b/data/locations/us-cherry-hill/location.json
@@ -271,11 +271,21 @@
     "Lower crime than Philadelphia"
   ],
   "cons": [
-    "Cold winters (24F lows)",
-    "Higher NJ state income tax rates",
-    "Car-dependent",
-    "Higher property insurance than some areas",
-    "NJ cost of living above national average"
+    {
+      "text": "Cold winters (24F lows)"
+    },
+    {
+      "text": "Higher NJ state income tax rates"
+    },
+    {
+      "text": "Car-dependent"
+    },
+    {
+      "text": "Higher property insurance than some areas"
+    },
+    {
+      "text": "NJ cost of living above national average"
+    }
   ],
   "subregion": "New Jersey"
 }

--- a/data/locations/us-chesapeake-va/location.json
+++ b/data/locations/us-chesapeake-va/location.json
@@ -245,13 +245,27 @@
     "Strong military community and VA healthcare access"
   ],
   "cons": [
-    "Car-dependent suburban layout",
-    "Limited public transit (HRT bus only)",
-    "VA state income tax (2-5.75%)",
-    "Flood risk in low-lying areas — may require flood insurance",
-    "Humid summers with high heat index",
-    "Limited walkability in most neighborhoods",
-    "Vehicle personal property tax adds ~$1,000/year"
+    {
+      "text": "Car-dependent suburban layout"
+    },
+    {
+      "text": "Limited public transit (HRT bus only)"
+    },
+    {
+      "text": "VA state income tax (2-5.75%)"
+    },
+    {
+      "text": "Flood risk in low-lying areas — may require flood insurance"
+    },
+    {
+      "text": "Humid summers with high heat index"
+    },
+    {
+      "text": "Limited walkability in most neighborhoods"
+    },
+    {
+      "text": "Vehicle personal property tax adds ~$1,000/year"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-chicago-il/location.json
+++ b/data/locations/us-chicago-il/location.json
@@ -172,9 +172,15 @@
     "Beautiful lakefront and parks"
   ],
   "cons": [
-    "Harsh, long winters",
-    "High state and local taxes",
-    "Higher crime in some neighborhoods"
+    {
+      "text": "Harsh, long winters"
+    },
+    {
+      "text": "High state and local taxes"
+    },
+    {
+      "text": "Higher crime in some neighborhoods"
+    }
   ],
   "taxes": {
     "notes": "Federal + IL flat state income tax (4.95%)",

--- a/data/locations/us-christiansted-vi/location.json
+++ b/data/locations/us-christiansted-vi/location.json
@@ -176,10 +176,18 @@
     "Strong snorkeling/diving"
   ],
   "cons": [
-    "Healthcare infrastructure weaker than STT",
-    "Hurricane exposure (direct hits 2017)",
-    "Limited direct flights (mostly via STT/SJU/MIA)",
-    "Crime rates higher than US average"
+    {
+      "text": "Healthcare infrastructure weaker than STT"
+    },
+    {
+      "text": "Hurricane exposure (direct hits 2017)"
+    },
+    {
+      "text": "Limited direct flights (mostly via STT/SJU/MIA)"
+    },
+    {
+      "text": "Crime rates higher than US average"
+    }
   ],
   "taxes": {
     "notes": "USVI residents file a mirror-code return with Bureau of Internal Revenue.",

--- a/data/locations/us-cleveland-oh/location.json
+++ b/data/locations/us-cleveland-oh/location.json
@@ -172,9 +172,15 @@
     "Lake Erie waterfront and cultural institutions"
   ],
   "cons": [
-    "Cold, gray winters with lake-effect snow",
-    "Population decline and economic challenges",
-    "Higher crime in some areas"
+    {
+      "text": "Cold, gray winters with lake-effect snow"
+    },
+    {
+      "text": "Population decline and economic challenges"
+    },
+    {
+      "text": "Higher crime in some areas"
+    }
   ],
   "taxes": {
     "notes": "Federal + OH state income tax (0-3.75%) + city income tax (~2%)",

--- a/data/locations/us-dallas-tx/location.json
+++ b/data/locations/us-dallas-tx/location.json
@@ -172,9 +172,15 @@
     "Major sports and cultural scene"
   ],
   "cons": [
-    "Extreme summer heat",
-    "Car-dependent sprawl",
-    "High property taxes offset income tax savings"
+    {
+      "text": "Extreme summer heat"
+    },
+    {
+      "text": "Car-dependent sprawl"
+    },
+    {
+      "text": "High property taxes offset income tax savings"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no TX state income tax (high property taxes)",

--- a/data/locations/us-dededo-gu/location.json
+++ b/data/locations/us-dededo-gu/location.json
@@ -175,10 +175,18 @@
     "Warm tropical climate year-round"
   ],
   "cons": [
-    "Typhoon exposure (northern Guam)",
-    "Traffic on Marine Corps Drive during peak hours",
-    "Healthcare specialists limited",
-    "Long travel to mainland US"
+    {
+      "text": "Typhoon exposure (northern Guam)"
+    },
+    {
+      "text": "Traffic on Marine Corps Drive during peak hours"
+    },
+    {
+      "text": "Healthcare specialists limited"
+    },
+    {
+      "text": "Long travel to mainland US"
+    }
   ],
   "taxes": {
     "notes": "Guam mirrors the federal tax code; residents file with Department of Revenue and Taxation.",

--- a/data/locations/us-denver-co/location.json
+++ b/data/locations/us-denver-co/location.json
@@ -172,9 +172,15 @@
     "Strong economy and cultural amenities"
   ],
   "cons": [
-    "Higher cost of living",
-    "Cold winters with snow",
-    "Altitude adjustment needed (5,280 ft)"
+    {
+      "text": "Higher cost of living"
+    },
+    {
+      "text": "Cold winters with snow"
+    },
+    {
+      "text": "Altitude adjustment needed (5,280 ft)"
+    }
   ],
   "taxes": {
     "notes": "Federal + CO flat state income tax (4.4%)",

--- a/data/locations/us-elkridge-md/location.json
+++ b/data/locations/us-elkridge-md/location.json
@@ -256,11 +256,21 @@
     "Central between DC + Baltimore — access to both metros"
   ],
   "cons": [
-    "Howard County piggyback 3.20% — tied for highest in MD",
-    "Interstate 95 traffic can be brutal; Capital Beltway worse",
-    "Affluent area — premium pricing on services",
-    "Limited walkable core (car-dependent outside MARC corridor)",
-    "~40 mi from Fairfax — further than closer VA alternatives"
+    {
+      "text": "Howard County piggyback 3.20% — tied for highest in MD"
+    },
+    {
+      "text": "Interstate 95 traffic can be brutal; Capital Beltway worse"
+    },
+    {
+      "text": "Affluent area — premium pricing on services"
+    },
+    {
+      "text": "Limited walkable core (car-dependent outside MARC corridor)"
+    },
+    {
+      "text": "~40 mi from Fairfax — further than closer VA alternatives"
+    }
   ],
   "subregion": "Maryland"
 }

--- a/data/locations/us-florida/location.json
+++ b/data/locations/us-florida/location.json
@@ -239,11 +239,21 @@
     "Close to Latin America (Panama flights)"
   ],
   "cons": [
-    "Hurricane risk",
-    "High insurance costs",
-    "Rising rents",
-    "Humidity",
-    "Car-dependent"
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "High insurance costs"
+    },
+    {
+      "text": "Rising rents"
+    },
+    {
+      "text": "Humidity"
+    },
+    {
+      "text": "Car-dependent"
+    }
   ],
   "subregion": "Florida"
 }

--- a/data/locations/us-fort-lauderdale-fl/location.json
+++ b/data/locations/us-fort-lauderdale-fl/location.json
@@ -172,9 +172,15 @@
     "Warm year-round weather"
   ],
   "cons": [
-    "High housing and insurance costs",
-    "Hurricane risk",
-    "Heavy tourist traffic in season"
+    {
+      "text": "High housing and insurance costs"
+    },
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Heavy tourist traffic in season"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-fort-wayne-in/location.json
+++ b/data/locations/us-fort-wayne-in/location.json
@@ -172,9 +172,15 @@
     "Friendly Midwest community feel"
   ],
   "cons": [
-    "Cold winters",
-    "Limited public transit",
-    "IN flat state income tax (3.05%) plus county tax"
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "Limited public transit"
+    },
+    {
+      "text": "IN flat state income tax (3.05%) plus county tax"
+    }
   ],
   "taxes": {
     "notes": "Federal + IN flat state income tax (3.05%) + county income tax; SS exempt",

--- a/data/locations/us-fort-worth-tx/location.json
+++ b/data/locations/us-fort-worth-tx/location.json
@@ -172,9 +172,15 @@
     "Stockyards district and Western heritage"
   ],
   "cons": [
-    "Extreme summer heat",
-    "Car-dependent",
-    "High property taxes"
+    {
+      "text": "Extreme summer heat"
+    },
+    {
+      "text": "Car-dependent"
+    },
+    {
+      "text": "High property taxes"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no TX state income tax (high property taxes)",

--- a/data/locations/us-gainesville-va/location.json
+++ b/data/locations/us-gainesville-va/location.json
@@ -239,11 +239,21 @@
     "Access to Bull Run Mountains and wineries"
   ],
   "cons": [
-    "Longer commute to DC / inner NOVA",
-    "Car-dependent, I-66 traffic during rush",
-    "Fewer restaurants and cultural amenities than Fairfax",
-    "Cold winters (23°F lows)",
-    "Specialty healthcare may require drive to Fairfax/DC"
+    {
+      "text": "Longer commute to DC / inner NOVA"
+    },
+    {
+      "text": "Car-dependent, I-66 traffic during rush"
+    },
+    {
+      "text": "Fewer restaurants and cultural amenities than Fairfax"
+    },
+    {
+      "text": "Cold winters (23°F lows)"
+    },
+    {
+      "text": "Specialty healthcare may require drive to Fairfax/DC"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-glen-burnie-md/location.json
+++ b/data/locations/us-glen-burnie-md/location.json
@@ -257,12 +257,24 @@
     "No bay-bridge premium (unlike Annapolis)"
   ],
   "cons": [
-    "Working-class suburb — less charm than Annapolis or Catonsville",
-    "Car-dependent outside Light Rail corridor",
-    "Interstate 97 + Route 2 traffic during commute hours",
-    "Airport noise near BWI flight paths",
-    "~45 mi from Fairfax — longer drive than Bowie or Annapolis",
-    "Limited walkable downtown core"
+    {
+      "text": "Working-class suburb — less charm than Annapolis or Catonsville"
+    },
+    {
+      "text": "Car-dependent outside Light Rail corridor"
+    },
+    {
+      "text": "Interstate 97 + Route 2 traffic during commute hours"
+    },
+    {
+      "text": "Airport noise near BWI flight paths"
+    },
+    {
+      "text": "~45 mi from Fairfax — longer drive than Bowie or Annapolis"
+    },
+    {
+      "text": "Limited walkable downtown core"
+    }
   ],
   "subregion": "Maryland"
 }

--- a/data/locations/us-grand-forks-nd/location.json
+++ b/data/locations/us-grand-forks-nd/location.json
@@ -172,9 +172,15 @@
     "Low crime and safe community"
   ],
   "cons": [
-    "Extreme cold â€” winter lows below 0F",
-    "Flood risk from Red River",
-    "Very remote and isolated"
+    {
+      "text": "Extreme cold â€” winter lows below 0F"
+    },
+    {
+      "text": "Flood risk from Red River"
+    },
+    {
+      "text": "Very remote and isolated"
+    }
   ],
   "taxes": {
     "notes": "Federal + ND state income tax (0-2.5%); very low rates",

--- a/data/locations/us-hagatna-gu/location.json
+++ b/data/locations/us-hagatna-gu/location.json
@@ -179,10 +179,18 @@
     "Large military-linked community"
   ],
   "cons": [
-    "Typhoon risk (peak Aug–Dec)",
-    "Long flights to US mainland (12h+)",
-    "Healthcare specialists limited",
-    "Import-driven prices on most goods"
+    {
+      "text": "Typhoon risk (peak Aug–Dec)"
+    },
+    {
+      "text": "Long flights to US mainland (12h+)"
+    },
+    {
+      "text": "Healthcare specialists limited"
+    },
+    {
+      "text": "Import-driven prices on most goods"
+    }
   ],
   "taxes": {
     "notes": "Guam mirrors the federal tax code; residents file with Department of Revenue and Taxation.",

--- a/data/locations/us-killeen-tx/location.json
+++ b/data/locations/us-killeen-tx/location.json
@@ -172,9 +172,15 @@
     "Near Fort Cavazos military base"
   ],
   "cons": [
-    "Extreme summer heat",
-    "Military-dependent economy",
-    "Limited cultural amenities"
+    {
+      "text": "Extreme summer heat"
+    },
+    {
+      "text": "Military-dependent economy"
+    },
+    {
+      "text": "Limited cultural amenities"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no TX state income tax (high property taxes)",

--- a/data/locations/us-lapeer-mi/location.json
+++ b/data/locations/us-lapeer-mi/location.json
@@ -172,9 +172,15 @@
     "Low crime for the area"
   ],
   "cons": [
-    "Very cold winters",
-    "Very limited amenities and dining",
-    "Car required â€” no public transit"
+    {
+      "text": "Very cold winters"
+    },
+    {
+      "text": "Very limited amenities and dining"
+    },
+    {
+      "text": "Car required â€” no public transit"
+    }
   ],
   "taxes": {
     "notes": "Federal + MI flat state income tax (4.25%); SS partially exempt",

--- a/data/locations/us-little-rock-ar/location.json
+++ b/data/locations/us-little-rock-ar/location.json
@@ -172,9 +172,15 @@
     "Mild winters compared to northern cities"
   ],
   "cons": [
-    "Higher crime rates",
-    "Hot, humid summers",
-    "Limited public transportation"
+    {
+      "text": "Higher crime rates"
+    },
+    {
+      "text": "Hot, humid summers"
+    },
+    {
+      "text": "Limited public transportation"
+    }
   ],
   "taxes": {
     "notes": "Federal + AR state income tax (2-4.4%); SS exempt up to $6,000",

--- a/data/locations/us-lorain-oh/location.json
+++ b/data/locations/us-lorain-oh/location.json
@@ -172,9 +172,15 @@
     "Close to Cleveland metro amenities"
   ],
   "cons": [
-    "Cold, gray winters with lake-effect snow",
-    "Economic decline and population loss",
-    "Limited local amenities"
+    {
+      "text": "Cold, gray winters with lake-effect snow"
+    },
+    {
+      "text": "Economic decline and population loss"
+    },
+    {
+      "text": "Limited local amenities"
+    }
   ],
   "taxes": {
     "notes": "Federal + OH state income tax (0-3.75%) + city income tax (~2.5%)",

--- a/data/locations/us-lorton-va/location.json
+++ b/data/locations/us-lorton-va/location.json
@@ -233,10 +233,18 @@
     "Quieter suburban environment"
   ],
   "cons": [
-    "Longer DC commute (Interstate 95 or VRE)",
-    "Fewer dining/shopping options than Fairfax City",
-    "Some neighborhoods have heavy HOAs (homeowners associations)",
-    "Limited public transit beyond VRE"
+    {
+      "text": "Longer DC commute (Interstate 95 or VRE)"
+    },
+    {
+      "text": "Fewer dining/shopping options than Fairfax City"
+    },
+    {
+      "text": "Some neighborhoods have heavy HOAs (homeowners associations)"
+    },
+    {
+      "text": "Limited public transit beyond VRE"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-lynchburg-va/location.json
+++ b/data/locations/us-lynchburg-va/location.json
@@ -172,9 +172,15 @@
     "Small-city charm with college-town feel"
   ],
   "cons": [
-    "Limited job market and amenities",
-    "Socially conservative community",
-    "Cold winters for Virginia"
+    {
+      "text": "Limited job market and amenities"
+    },
+    {
+      "text": "Socially conservative community"
+    },
+    {
+      "text": "Cold winters for Virginia"
+    }
   ],
   "taxes": {
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",

--- a/data/locations/us-manassas-va/location.json
+++ b/data/locations/us-manassas-va/location.json
@@ -234,10 +234,18 @@
     "Novant UVA Health + Sentara hospitals in town"
   ],
   "cons": [
-    "Longest commute to Fairfax/DC (~45–60 min)",
-    "Fewer dining/cultural options than inner Northern Virginia",
-    "Specialty healthcare may require Fairfax/DC trip",
-    "Interstate 66 + VRE (Virginia Railway Express) traffic/crowding at peak"
+    {
+      "text": "Longest commute to Fairfax/DC (~45–60 min)"
+    },
+    {
+      "text": "Fewer dining/cultural options than inner Northern Virginia"
+    },
+    {
+      "text": "Specialty healthcare may require Fairfax/DC trip"
+    },
+    {
+      "text": "Interstate 66 + VRE (Virginia Railway Express) traffic/crowding at peak"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-miami-fl/location.json
+++ b/data/locations/us-miami-fl/location.json
@@ -172,9 +172,15 @@
     "Warm tropical climate year-round"
   ],
   "cons": [
-    "Very high cost of living",
-    "Hurricane and flooding risk",
-    "Heavy traffic and car dependency"
+    {
+      "text": "Very high cost of living"
+    },
+    {
+      "text": "Hurricane and flooding risk"
+    },
+    {
+      "text": "Heavy traffic and car dependency"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-milwaukee-wi/location.json
+++ b/data/locations/us-milwaukee-wi/location.json
@@ -172,9 +172,15 @@
     "Strong brewery and food culture"
   ],
   "cons": [
-    "Very cold, snowy winters",
-    "WI state income tax (3.54-7.65%)",
-    "Some neighborhoods have higher crime"
+    {
+      "text": "Very cold, snowy winters"
+    },
+    {
+      "text": "WI state income tax (3.54-7.65%)"
+    },
+    {
+      "text": "Some neighborhoods have higher crime"
+    }
   ],
   "taxes": {
     "notes": "Federal + WI state income tax (3.54-7.65%); SS benefits exempt",

--- a/data/locations/us-minneapolis-mn/location.json
+++ b/data/locations/us-minneapolis-mn/location.json
@@ -172,9 +172,15 @@
     "Extensive parks and bike trail network"
   ],
   "cons": [
-    "Extremely cold, long winters",
-    "High state income tax (5.35-9.85%)",
-    "SS benefits partially taxed by state"
+    {
+      "text": "Extremely cold, long winters"
+    },
+    {
+      "text": "High state income tax (5.35-9.85%)"
+    },
+    {
+      "text": "SS benefits partially taxed by state"
+    }
   ],
   "taxes": {
     "notes": "Federal + MN state income tax (5.35-9.85%); SS partially taxed",

--- a/data/locations/us-nashville-tn/location.json
+++ b/data/locations/us-nashville-tn/location.json
@@ -172,9 +172,15 @@
     "Strong job market and growing economy"
   ],
   "cons": [
-    "Rapid growth driving up housing costs",
-    "Hot, humid summers",
-    "Car-dependent with limited transit"
+    {
+      "text": "Rapid growth driving up housing costs"
+    },
+    {
+      "text": "Hot, humid summers"
+    },
+    {
+      "text": "Car-dependent with limited transit"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no TN state income tax",

--- a/data/locations/us-new-york-city/location.json
+++ b/data/locations/us-new-york-city/location.json
@@ -315,13 +315,27 @@
     "EPIC program for senior prescription assistance"
   ],
   "cons": [
-    "Highest cost of living in US",
-    "Triple taxation (federal + state + city income tax)",
-    "Cold winters",
-    "Apartment living — limited space",
-    "Noise and density",
-    "If keeping a car: insurance and parking extremely expensive",
-    "Healthcare premiums higher than national average"
+    {
+      "text": "Highest cost of living in US"
+    },
+    {
+      "text": "Triple taxation (federal + state + city income tax)"
+    },
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "Apartment living — limited space"
+    },
+    {
+      "text": "Noise and density"
+    },
+    {
+      "text": "If keeping a car: insurance and parking extremely expensive"
+    },
+    {
+      "text": "Healthcare premiums higher than national average"
+    }
   ],
   "subregion": "New York"
 }

--- a/data/locations/us-norfolk-va/location.json
+++ b/data/locations/us-norfolk-va/location.json
@@ -172,9 +172,15 @@
     "Proximity to Virginia Beach and Chesapeake Bay"
   ],
   "cons": [
-    "Flood-prone low-lying areas",
-    "Military-dependent economy",
-    "VA state income tax (2-5.75%)"
+    {
+      "text": "Flood-prone low-lying areas"
+    },
+    {
+      "text": "Military-dependent economy"
+    },
+    {
+      "text": "VA state income tax (2-5.75%)"
+    }
   ],
   "taxes": {
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",

--- a/data/locations/us-oakland-county-mi/location.json
+++ b/data/locations/us-oakland-county-mi/location.json
@@ -175,9 +175,15 @@
     "Diverse communities with good dining"
   ],
   "cons": [
-    "Cold winters",
-    "Car-dependent suburbs",
-    "MI state income tax (4.25%) plus some city taxes"
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "Car-dependent suburbs"
+    },
+    {
+      "text": "MI state income tax (4.25%) plus some city taxes"
+    }
   ],
   "taxes": {
     "notes": "Federal + MI flat state income tax (4.25%); some cities add local tax; SS partially exempt",

--- a/data/locations/us-pago-pago-as/location.json
+++ b/data/locations/us-pago-pago-as/location.json
@@ -181,10 +181,18 @@
     "Low property crime"
   ],
   "cons": [
-    "Very remote — few flights, long travel to mainland",
-    "Healthcare limited — medevac common",
-    "High import costs on most goods",
-    "Cyclone season (Nov–Apr)"
+    {
+      "text": "Very remote — few flights, long travel to mainland"
+    },
+    {
+      "text": "Healthcare limited — medevac common"
+    },
+    {
+      "text": "High import costs on most goods"
+    },
+    {
+      "text": "Cyclone season (Nov–Apr)"
+    }
   ],
   "taxes": {
     "notes": "American Samoa has its own tax code (mirrored with modifications); residents file with ASG Tax Office, not IRS.",

--- a/data/locations/us-palm-bay-fl/location.json
+++ b/data/locations/us-palm-bay-fl/location.json
@@ -172,9 +172,15 @@
     "Near Kennedy Space Center and beaches"
   ],
   "cons": [
-    "Hurricane risk",
-    "Limited dining and cultural options",
-    "Car-dependent suburban sprawl"
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Limited dining and cultural options"
+    },
+    {
+      "text": "Car-dependent suburban sprawl"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-philadelphia/location.json
+++ b/data/locations/us-philadelphia/location.json
@@ -247,11 +247,21 @@
     "More affordable than NYC/DC"
   ],
   "cons": [
-    "Cold winters (25F lows)",
-    "Philadelphia city wage tax (3.75%)",
-    "Higher crime in some areas",
-    "High sales tax (8%)",
-    "Aging infrastructure"
+    {
+      "text": "Cold winters (25F lows)"
+    },
+    {
+      "text": "Philadelphia city wage tax (3.75%)"
+    },
+    {
+      "text": "Higher crime in some areas"
+    },
+    {
+      "text": "High sales tax (8%)"
+    },
+    {
+      "text": "Aging infrastructure"
+    }
   ],
   "subregion": "Pennsylvania"
 }

--- a/data/locations/us-pittsburgh-pa/location.json
+++ b/data/locations/us-pittsburgh-pa/location.json
@@ -172,9 +172,15 @@
     "Revitalized neighborhoods and food scene"
   ],
   "cons": [
-    "Cold, gray winters",
-    "Hilly terrain can be challenging",
-    "PA state income tax (3.07%) plus local taxes"
+    {
+      "text": "Cold, gray winters"
+    },
+    {
+      "text": "Hilly terrain can be challenging"
+    },
+    {
+      "text": "PA state income tax (3.07%) plus local taxes"
+    }
   ],
   "taxes": {
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",

--- a/data/locations/us-ponce-pr/location.json
+++ b/data/locations/us-ponce-pr/location.json
@@ -173,10 +173,18 @@
     "Less traffic, slower pace"
   ],
   "cons": [
-    "Limited specialist healthcare — travel to San Juan common",
-    "Fewer flight options (IATA: PSE, limited)",
-    "Spanish strongly preferred in daily life",
-    "Earthquake activity (2020 sequence)"
+    {
+      "text": "Limited specialist healthcare — travel to San Juan common"
+    },
+    {
+      "text": "Fewer flight options (IATA: PSE, limited)"
+    },
+    {
+      "text": "Spanish strongly preferred in daily life"
+    },
+    {
+      "text": "Earthquake activity (2020 sequence)"
+    }
   ],
   "taxes": {
     "notes": "PR residents pay PR income tax, not federal, on PR-source income.",

--- a/data/locations/us-port-huron-mi/location.json
+++ b/data/locations/us-port-huron-mi/location.json
@@ -172,9 +172,15 @@
     "Small-city pace with scenic beauty"
   ],
   "cons": [
-    "Very cold winters",
-    "Limited job market",
-    "Fewer amenities than larger metros"
+    {
+      "text": "Very cold winters"
+    },
+    {
+      "text": "Limited job market"
+    },
+    {
+      "text": "Fewer amenities than larger metros"
+    }
   ],
   "taxes": {
     "notes": "Federal + MI flat state income tax (4.25%); SS partially exempt",

--- a/data/locations/us-portsmouth-va/location.json
+++ b/data/locations/us-portsmouth-va/location.json
@@ -172,9 +172,15 @@
     "Access to Hampton Roads metro amenities"
   ],
   "cons": [
-    "Higher crime rates",
-    "Flood-prone areas",
-    "Limited local job market"
+    {
+      "text": "Higher crime rates"
+    },
+    {
+      "text": "Flood-prone areas"
+    },
+    {
+      "text": "Limited local job market"
+    }
   ],
   "taxes": {
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",

--- a/data/locations/us-quincy-fl/location.json
+++ b/data/locations/us-quincy-fl/location.json
@@ -172,9 +172,15 @@
     "Small-town quiet living near Tallahassee"
   ],
   "cons": [
-    "Very limited amenities and services",
-    "Rural with no public transit",
-    "Limited healthcare options nearby"
+    {
+      "text": "Very limited amenities and services"
+    },
+    {
+      "text": "Rural with no public transit"
+    },
+    {
+      "text": "Limited healthcare options nearby"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-raleigh/location.json
+++ b/data/locations/us-raleigh/location.json
@@ -252,11 +252,21 @@
     "Diverse food scene"
   ],
   "cons": [
-    "Hot humid summers",
-    "Growing rapidly (traffic increasing)",
-    "State income tax on retirement withdrawals (no exclusion beyond SS)",
-    "Tornado risk",
-    "Car-dependent outside downtown cores"
+    {
+      "text": "Hot humid summers"
+    },
+    {
+      "text": "Growing rapidly (traffic increasing)"
+    },
+    {
+      "text": "State income tax on retirement withdrawals (no exclusion beyond SS)"
+    },
+    {
+      "text": "Tornado risk"
+    },
+    {
+      "text": "Car-dependent outside downtown cores"
+    }
   ],
   "subregion": "North Carolina"
 }

--- a/data/locations/us-richmond/location.json
+++ b/data/locations/us-richmond/location.json
@@ -262,11 +262,21 @@
     "Historic charm (Church Hill, Fan District)"
   ],
   "cons": [
-    "Cold winters (28F lows)",
-    "Car-dependent",
-    "Hot humid summers",
-    "Higher crime in some neighborhoods",
-    "Smaller job market than NoVA"
+    {
+      "text": "Cold winters (28F lows)"
+    },
+    {
+      "text": "Car-dependent"
+    },
+    {
+      "text": "Hot humid summers"
+    },
+    {
+      "text": "Higher crime in some neighborhoods"
+    },
+    {
+      "text": "Smaller job market than NoVA"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-saint-paul-mn/location.json
+++ b/data/locations/us-saint-paul-mn/location.json
@@ -172,9 +172,15 @@
     "Strong cultural scene and parks"
   ],
   "cons": [
-    "Extremely cold winters",
-    "High state income tax (5.35-9.85%)",
-    "Shorter outdoor season"
+    {
+      "text": "Extremely cold winters"
+    },
+    {
+      "text": "High state income tax (5.35-9.85%)"
+    },
+    {
+      "text": "Shorter outdoor season"
+    }
   ],
   "taxes": {
     "notes": "Federal + MN state income tax (5.35-9.85%); SS partially taxed",

--- a/data/locations/us-saipan-mp/location.json
+++ b/data/locations/us-saipan-mp/location.json
@@ -180,10 +180,18 @@
     "Dive and beach lifestyle"
   ],
   "cons": [
-    "Typhoon risk (Super Typhoon Yutu, 2018)",
-    "Healthcare capacity very limited",
-    "Electricity among the most expensive in the US",
-    "Long travel to US mainland (14h+ via Guam or Tokyo)"
+    {
+      "text": "Typhoon risk (Super Typhoon Yutu, 2018)"
+    },
+    {
+      "text": "Healthcare capacity very limited"
+    },
+    {
+      "text": "Electricity among the most expensive in the US"
+    },
+    {
+      "text": "Long travel to US mainland (14h+ via Guam or Tokyo)"
+    }
   ],
   "taxes": {
     "notes": "CNMI mirrors federal tax code; residents file with CNMI Division of Revenue and Taxation.",

--- a/data/locations/us-san-juan-pr/location.json
+++ b/data/locations/us-san-juan-pr/location.json
@@ -179,10 +179,18 @@
     "Direct flights to US East Coast"
   ],
   "cons": [
-    "Hurricane risk (Sep–Nov)",
-    "Electricity grid fragile — outages common",
-    "Higher import-driven grocery prices",
-    "Traffic congestion in metro area"
+    {
+      "text": "Hurricane risk (Sep–Nov)"
+    },
+    {
+      "text": "Electricity grid fragile — outages common"
+    },
+    {
+      "text": "Higher import-driven grocery prices"
+    },
+    {
+      "text": "Traffic congestion in metro area"
+    }
   ],
   "taxes": {
     "notes": "PR residents pay PR income tax, not federal, on PR-source income. Complex rules; consult specialist.",

--- a/data/locations/us-san-marcos-tx/location.json
+++ b/data/locations/us-san-marcos-tx/location.json
@@ -172,9 +172,15 @@
     "Affordable college town between Austin and San Antonio"
   ],
   "cons": [
-    "Hot summers",
-    "College-town dynamics (noise, parking)",
-    "Limited metro amenities"
+    {
+      "text": "Hot summers"
+    },
+    {
+      "text": "College-town dynamics (noise, parking)"
+    },
+    {
+      "text": "Limited metro amenities"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no TX state income tax (high property taxes)",

--- a/data/locations/us-savannah/location.json
+++ b/data/locations/us-savannah/location.json
@@ -257,11 +257,21 @@
     "Near beaches (Tybee Island)"
   ],
   "cons": [
-    "Hot, humid summers (92F)",
-    "Hurricane risk",
-    "Car-dependent outside historic core",
-    "GA state income tax",
-    "Higher crime in some areas"
+    {
+      "text": "Hot, humid summers (92F)"
+    },
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Car-dependent outside historic core"
+    },
+    {
+      "text": "GA state income tax"
+    },
+    {
+      "text": "Higher crime in some areas"
+    }
   ],
   "subregion": "Georgia"
 }

--- a/data/locations/us-skowhegan-me/location.json
+++ b/data/locations/us-skowhegan-me/location.json
@@ -172,9 +172,15 @@
     "Low crime and safe community"
   ],
   "cons": [
-    "Extremely cold, long winters",
-    "Very remote with limited services",
-    "Higher heating costs"
+    {
+      "text": "Extremely cold, long winters"
+    },
+    {
+      "text": "Very remote with limited services"
+    },
+    {
+      "text": "Higher heating costs"
+    }
   ],
   "taxes": {
     "notes": "Federal + ME state income tax (5.8-7.15%); SS exempt",

--- a/data/locations/us-st-augustine-fl/location.json
+++ b/data/locations/us-st-augustine-fl/location.json
@@ -172,9 +172,15 @@
     "Beautiful beaches and walkable downtown"
   ],
   "cons": [
-    "Tourism-driven economy with seasonal crowds",
-    "Hurricane risk",
-    "Higher housing costs for a small city"
+    {
+      "text": "Tourism-driven economy with seasonal crowds"
+    },
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Higher housing costs for a small city"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-st-petersburg-fl/location.json
+++ b/data/locations/us-st-petersburg-fl/location.json
@@ -172,9 +172,15 @@
     "Sunshine City â€” 361 days of sun average"
   ],
   "cons": [
-    "Hurricane risk",
-    "Rising housing costs",
-    "Hot and humid summers"
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Rising housing costs"
+    },
+    {
+      "text": "Hot and humid summers"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-summerville/location.json
+++ b/data/locations/us-summerville/location.json
@@ -267,13 +267,27 @@
     "Mild winters"
   ],
   "cons": [
-    "Hot humid summers (92F+, high humidity)",
-    "Car-dependent — minimal public transit",
-    "Hurricane risk zone (coastal proximity)",
-    "State income tax (6.5% top rate)",
-    "Limited nightlife in Summerville proper",
-    "Flood insurance may be needed in some areas",
-    "Limited direct flight options (CHS airport)"
+    {
+      "text": "Hot humid summers (92F+, high humidity)"
+    },
+    {
+      "text": "Car-dependent — minimal public transit"
+    },
+    {
+      "text": "Hurricane risk zone (coastal proximity)"
+    },
+    {
+      "text": "State income tax (6.5% top rate)"
+    },
+    {
+      "text": "Limited nightlife in Summerville proper"
+    },
+    {
+      "text": "Flood insurance may be needed in some areas"
+    },
+    {
+      "text": "Limited direct flight options (CHS airport)"
+    }
   ],
   "subregion": "South Carolina"
 }

--- a/data/locations/us-tafuna-as/location.json
+++ b/data/locations/us-tafuna-as/location.json
@@ -175,10 +175,18 @@
     "Lower rent than Pago Pago"
   ],
   "cons": [
-    "Healthcare limited — sole hospital shared with Pago Pago",
-    "Cyclone exposure",
-    "Few direct flights",
-    "Import-driven prices"
+    {
+      "text": "Healthcare limited — sole hospital shared with Pago Pago"
+    },
+    {
+      "text": "Cyclone exposure"
+    },
+    {
+      "text": "Few direct flights"
+    },
+    {
+      "text": "Import-driven prices"
+    }
   ],
   "taxes": {
     "notes": "American Samoa has its own tax code; residents file with ASG Tax Office, not IRS.",

--- a/data/locations/us-tampa-fl/location.json
+++ b/data/locations/us-tampa-fl/location.json
@@ -172,9 +172,15 @@
     "Growing metro with good healthcare"
   ],
   "cons": [
-    "Hurricane risk",
-    "Hot and humid summers",
-    "Car-dependent sprawl"
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Hot and humid summers"
+    },
+    {
+      "text": "Car-dependent sprawl"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/data/locations/us-tinian-mp/location.json
+++ b/data/locations/us-tinian-mp/location.json
@@ -177,10 +177,18 @@
     "Low crime"
   ],
   "cons": [
-    "Healthcare is minimal — serious care requires travel",
-    "Small rental market; housing options limited",
-    "Limited retail and dining",
-    "Typhoon exposure"
+    {
+      "text": "Healthcare is minimal — serious care requires travel"
+    },
+    {
+      "text": "Small rental market; housing options limited"
+    },
+    {
+      "text": "Limited retail and dining"
+    },
+    {
+      "text": "Typhoon exposure"
+    }
   ],
   "taxes": {
     "notes": "CNMI mirrors federal tax code; residents file with CNMI Division of Revenue and Taxation.",

--- a/data/locations/us-virginia-beach-va/location.json
+++ b/data/locations/us-virginia-beach-va/location.json
@@ -172,9 +172,15 @@
     "Good schools and family-friendly"
   ],
   "cons": [
-    "Tourist crowds in summer",
-    "Higher housing costs than inland VA",
-    "VA state income tax (2-5.75%)"
+    {
+      "text": "Tourist crowds in summer"
+    },
+    {
+      "text": "Higher housing costs than inland VA"
+    },
+    {
+      "text": "VA state income tax (2-5.75%)"
+    }
   ],
   "taxes": {
     "notes": "Federal + VA state income tax (2-5.75%); SS partially exempt for age 65+",

--- a/data/locations/us-virginia/location.json
+++ b/data/locations/us-virginia/location.json
@@ -272,12 +272,24 @@
     "Metro access from Vienna/Falls Church"
   ],
   "cons": [
-    "Highest costs in Virginia",
-    "Cold winters (24°F lows)",
-    "Heavy traffic congestion",
-    "Car-dependent outside Metro corridors",
-    "High property tax on vehicles",
-    "Healthcare expensive pre-Medicare"
+    {
+      "text": "Highest costs in Virginia"
+    },
+    {
+      "text": "Cold winters (24°F lows)"
+    },
+    {
+      "text": "Heavy traffic congestion"
+    },
+    {
+      "text": "Car-dependent outside Metro corridors"
+    },
+    {
+      "text": "High property tax on vehicles"
+    },
+    {
+      "text": "Healthcare expensive pre-Medicare"
+    }
   ],
   "subregion": "Virginia"
 }

--- a/data/locations/us-williamsport-pa/location.json
+++ b/data/locations/us-williamsport-pa/location.json
@@ -172,9 +172,15 @@
     "Scenic Susquehanna River setting"
   ],
   "cons": [
-    "Cold winters",
-    "Limited job market and metro amenities",
-    "PA state income tax plus local taxes"
+    {
+      "text": "Cold winters"
+    },
+    {
+      "text": "Limited job market and metro amenities"
+    },
+    {
+      "text": "PA state income tax plus local taxes"
+    }
   ],
   "taxes": {
     "notes": "Federal + PA flat state income tax (3.07%) + local earned income tax",

--- a/data/locations/us-yulee-fl/location.json
+++ b/data/locations/us-yulee-fl/location.json
@@ -172,9 +172,15 @@
     "Warm climate with proximity to Jacksonville"
   ],
   "cons": [
-    "Suburban/rural with limited walkability",
-    "Hurricane risk",
-    "Limited local dining and entertainment"
+    {
+      "text": "Suburban/rural with limited walkability"
+    },
+    {
+      "text": "Hurricane risk"
+    },
+    {
+      "text": "Limited local dining and entertainment"
+    }
   ],
   "taxes": {
     "notes": "Federal only â€” no FL state income tax",

--- a/scripts/build-vault-source-catalog.mjs
+++ b/scripts/build-vault-source-catalog.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Scan Obsidian vault (D:/SecondBrainData/Retirement) for research notes
+ * whose YAML frontmatter declares `locations: [...]`, and extract:
+ *   - note title (from # heading or filename)
+ *   - primary external URLs (from Markdown footnote refs, oldest first)
+ *   - topic keywords (from tags + filename)
+ *   - mapped dashboard location IDs
+ *
+ * Writes the result to audits/vault-source-catalog.json. Also prints a
+ * per-location summary.
+ *
+ * Usage: node scripts/build-vault-source-catalog.mjs
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, statSync } from 'fs';
+import { join, relative, basename } from 'path';
+
+const VAULT_ROOT = 'D:/SecondBrainData/Retirement';
+const OUT_DIR = 'audits';
+const OUT_FILE = join(OUT_DIR, 'vault-source-catalog.json');
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (entry.startsWith('.')) continue;
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...walk(p));
+    else if (entry.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+function parseFrontmatter(txt) {
+  if (txt.charCodeAt(0) === 0xFEFF) txt = txt.slice(1);
+  if (!txt.startsWith('---')) return {};
+  const end = txt.indexOf('\n---', 3);
+  if (end < 0) return {};
+  const fm = txt.slice(4, end);
+  const out = {};
+  for (const line of fm.split('\n')) {
+    const m = line.match(/^([a-zA-Z_]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (v.startsWith('[') && v.endsWith(']')) {
+      out[k] = v.slice(1, -1).split(',').map(s => s.trim()).filter(Boolean);
+    } else {
+      out[k] = v.trim().replace(/^"|"$/g, '');
+    }
+  }
+  return out;
+}
+
+function extractTitle(txt, fallback) {
+  const m = txt.match(/^#\s+(.+)$/m);
+  return m ? m[1].trim() : fallback;
+}
+
+function extractFootnoteUrls(txt) {
+  const urls = [];
+  const re = /\[\^[^\]]+\]:\s*(https?:\/\/\S+)/g;
+  for (const m of txt.matchAll(re)) {
+    const u = m[1].replace(/[.,;)\]]+$/, '');
+    if (!urls.includes(u)) urls.push(u);
+  }
+  return urls;
+}
+
+function inferTopics(filename, tags, title) {
+  const ttl = (title || '').toLowerCase();
+  const topics = new Set();
+
+  const tagMap = {
+    'cost-of-living': 'cost',
+    food: 'cost',
+    housing: 'housing',
+    taxes: 'taxes',
+    visa: 'visa',
+    weather: 'climate',
+    climate: 'climate',
+    health: 'health',
+    healthcare: 'health',
+    crime: 'crime',
+    safety: 'crime',
+  };
+  for (const t of tags) {
+    const lc = t.toLowerCase();
+    if (tagMap[lc]) topics.add(tagMap[lc]);
+  }
+
+  // Titles in this vault are the full question prompt — too noisy for
+  // substring matching. Only add crime as a title-based override since the
+  // vault's crime notes are tagged `housing` (not `crime`), and the title
+  // explicitly says "Crime Statistics".
+  if (/^give\s+crime\s+statistics/.test(ttl) || /\bhate\s+crimes?\b/.test(ttl)) topics.add('crime');
+
+  return [...topics];
+}
+
+const files = walk(VAULT_ROOT);
+const catalog = [];
+
+for (const f of files) {
+  const txt = readFileSync(f, 'utf-8');
+  const fm = parseFrontmatter(txt);
+  const locs = Array.isArray(fm.locations) ? fm.locations.filter(l => l && l.includes('-')) : [];
+  if (!locs.length) continue;
+  const title = extractTitle(txt, basename(f, '.md'));
+  const urls = extractFootnoteUrls(txt);
+  const tags = Array.isArray(fm.tags) ? fm.tags : [];
+  const topics = inferTopics(basename(f), tags, title);
+  catalog.push({
+    path: relative(VAULT_ROOT, f).replace(/\\/g, '/'),
+    title: title.slice(0, 140),
+    locations: locs,
+    topics,
+    sourceUrls: urls.slice(0, 5),
+    sourceCount: urls.length,
+  });
+}
+
+const byLoc = {};
+for (const c of catalog) {
+  for (const l of c.locations) {
+    (byLoc[l] ||= []).push({ title: c.title, topics: c.topics, sourceCount: c.sourceCount, path: c.path });
+  }
+}
+
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(OUT_FILE, JSON.stringify({ catalog, byLocation: byLoc }, null, 2), 'utf-8');
+
+console.log(`Vault notes indexed: ${catalog.length}`);
+console.log(`Locations with vault sources: ${Object.keys(byLoc).length}`);
+console.log(`\nPer-location summary:`);
+for (const [loc, notes] of Object.entries(byLoc).sort()) {
+  const topicSet = new Set(notes.flatMap(n => n.topics));
+  console.log(`  ${loc}: ${notes.length} notes, topics=[${[...topicSet].join(', ')}]`);
+}
+console.log(`\nWritten: ${OUT_FILE}`);

--- a/scripts/migrate-cons-to-sourced-shape.mjs
+++ b/scripts/migrate-cons-to-sourced-shape.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Migrate every location.json's `cons: string[]` to `cons: {text, sources?}[]`,
+ * and attach vault-derived sources where confident keyword matches exist.
+ *
+ * Only cons whose text clearly relates to a vault note's topic get sources
+ * attached — avoids misleading citations for unrelated claims.
+ *
+ * Topic matching (case-insensitive substring on con text):
+ *   crime/safety/theft/pickpocket/burglary/violence  -> crime note
+ *   cost/expensive/rent/price/housing                -> cost note
+ *   tax/taxes/taxation                               -> taxes note
+ *   visa/residency/permit                            -> visa note
+ *   ev/electric/car/transport                        -> transport note
+ *   dog/pet                                          -> pets note
+ *
+ * Usage:
+ *   node scripts/migrate-cons-to-sourced-shape.mjs
+ *   node scripts/migrate-cons-to-sourced-shape.mjs --dry-run
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const DATA_DIR = 'data/locations';
+const CATALOG_PATH = 'audits/vault-source-catalog.json';
+const TODAY = new Date().toISOString().slice(0, 10);
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const catalog = JSON.parse(readFileSync(CATALOG_PATH, 'utf-8'));
+const byLoc = {};
+for (const note of catalog.catalog) {
+  for (const loc of note.locations) {
+    (byLoc[loc] ||= []).push(note);
+  }
+}
+
+const TOPIC_KEYWORDS = {
+  crime: ['crime', 'safety', 'theft', 'pickpocket', 'burglary', 'violent', 'violence', 'unsafe', 'hate'],
+  cost: ['cost', 'expensive', 'pricey', 'rent', 'price', 'housing', 'afford', 'hous'],
+  taxes: ['tax', 'taxes', 'taxation', 'taxed'],
+  visa: ['visa', 'residency', 'permit', 'immigrat'],
+  transport: ['ev', 'electric', 'car', 'transport', 'parking'],
+  pets: ['dog', 'pet'],
+  climate: ['weather', 'winter', 'rain', 'humid', 'cold', 'hot', 'storm', 'flood'],
+  health: ['healthcare', 'health', 'medical'],
+  housing: ['hous', 'rent', 'property', 'apartment'],
+};
+
+function hostname(url) {
+  try { return new URL(url).hostname.replace(/^www\./, ''); }
+  catch { return url.slice(0, 50); }
+}
+
+function matchTopic(conText) {
+  const lc = conText.toLowerCase();
+  const matched = [];
+  for (const [topic, kws] of Object.entries(TOPIC_KEYWORDS)) {
+    if (kws.some(kw => lc.includes(kw))) matched.push(topic);
+  }
+  return matched;
+}
+
+const BLOCKED_HOSTS = new Set(['perplexity.ai', 'www.perplexity.ai']);
+
+function sourcesForCon(locId, conText) {
+  const notes = byLoc[locId];
+  if (!notes) return [];
+  const conTopics = matchTopic(conText);
+  if (!conTopics.length) return [];
+  const match = notes.find(n => n.topics.some(t => conTopics.includes(t)));
+  if (!match) return [];
+  const seenHosts = new Set();
+  const sources = [];
+  for (const url of match.sourceUrls) {
+    const h = hostname(url);
+    if (BLOCKED_HOSTS.has(h) || seenHosts.has(h)) continue;
+    seenHosts.add(h);
+    sources.push({ title: h, url, accessed: TODAY });
+    if (sources.length >= 3) break;
+  }
+  return sources;
+}
+
+let migrated = 0, withSources = 0, skipped = 0;
+for (const loc of readdirSync(DATA_DIR)) {
+  const p = join(DATA_DIR, loc, 'location.json');
+  if (!existsSync(p)) continue;
+  const data = JSON.parse(readFileSync(p, 'utf-8'));
+  const cons = data.cons;
+  if (!Array.isArray(cons) || !cons.length) { skipped++; continue; }
+  // If already migrated (first entry is an object), skip.
+  if (typeof cons[0] === 'object' && cons[0] !== null) { skipped++; continue; }
+
+  const newCons = cons.map(text => {
+    const sources = sourcesForCon(loc, text);
+    if (sources.length) withSources++;
+    const entry = { text };
+    if (sources.length) entry.sources = sources;
+    return entry;
+  });
+
+  data.cons = newCons;
+  if (!DRY_RUN) writeFileSync(p, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  migrated++;
+}
+
+console.log(`Migrated: ${migrated} locations`);
+console.log(`Cons with vault sources attached: ${withSources}`);
+console.log(`Skipped (no cons or already object-shaped): ${skipped}`);
+if (DRY_RUN) console.log('(dry-run — no files written)');


### PR DESCRIPTION
## Summary

Restructure every location's \`cons[]\` from plain \`string[]\` to \`{ text, sources? }[]\` so the dashboard can render citation tooltips per-con. Attach vault-derived source URLs where the con text clearly matches a vault research note's topic.

The dashboard's \`ProConBullet\` type already accepts both shapes (via \`bulletText\` / \`bulletSources\` helpers), so this is a data-only change — no frontend work needed.

## Vault sourcing

Scanned the Obsidian vault at \`D:/SecondBrainData/Retirement\` for research notes with \`locations: [...]\` frontmatter. Extracted footnoted citation URLs from each, inferred topics from tags + title, and attached 2-3 top sources to cons whose text clearly matches the note's topic.

## Results

| Scope | Count |
|---|---|
| Locations migrated to new shape | 158 |
| Cons with vault citations attached | **3** |
| Vault notes indexed | 13 |
| Locations with any vault research | 12 |

The 3 sourced cons:
- \`france-lyon\` — "Higher rents" → 3 Lyon property-market sources
- \`spain-alicante\` — "Higher visa income requirement (EUR 2400/mo)" → 3 Spain visa sources
- \`spain-alicante\` — "A2 Spanish required for permanent residency" → same 3 Spain visa sources

Why only 3? Most cons in the 158 locations are climate/lifestyle/cultural claims (e.g. "cold grey winters", "less English spoken", "altitude adjustment difficult") that the vault's research notes don't cover. The vault is strongest on France costs/crime and Spain/US visas — and matching is deliberately conservative (tag-based with a crime-title override) to avoid misleading citations on unrelated claims.

## Scripts

- \`scripts/build-vault-source-catalog.mjs\` — walks vault, extracts footnote URLs + topics, writes \`audits/vault-source-catalog.json\`
- \`scripts/migrate-cons-to-sourced-shape.mjs\` — applies catalog, restructures every location's cons[]

## Future work

The migration unlocks per-con citations. Adding sources for the remaining 155 locations is a one-liner per con in \`location.json\` once a citation URL is identified.

## Test plan

- [ ] Dashboard Local Info → Lyon → "Higher rents" con shows an info icon with 3 sources tooltip
- [ ] Dashboard Local Info → Alicante → "Higher visa income requirement" con shows same
- [ ] Other locations' cons render as plain bullets (no info icon since no sources) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)