### PR TITLE
fix(portugal): apply IRS brackets to all 5 regions, not just Lisbon

### DIFF
--- a/data/locations/portugal-algarve/location.json
+++ b/data/locations/portugal-algarve/location.json
@@ -198,9 +198,76 @@
     }
   ],
   "taxes": {
-    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%. US-Portugal tax treaty helps avoid double taxation.",
-    "vatRate": 23,
-    "socialChargesRate": 0
+    "federalIncomeTax": {
+      "applies": true,
+      "foreignTaxCredit": true
+    },
+    "stateIncomeTax": {
+      "rate": 0.48,
+      "type": "progressive",
+      "label": "Portuguese Income Tax (IRS)",
+      "brackets": [
+        {
+          "min": 0,
+          "max": 8704,
+          "rate": 0.125
+        },
+        {
+          "min": 8704,
+          "max": 13133,
+          "rate": 0.16
+        },
+        {
+          "min": 13133,
+          "max": 18612,
+          "rate": 0.215
+        },
+        {
+          "min": 18612,
+          "max": 24090,
+          "rate": 0.244
+        },
+        {
+          "min": 24090,
+          "max": 30672,
+          "rate": 0.314
+        },
+        {
+          "min": 30672,
+          "max": 44959,
+          "rate": 0.349
+        },
+        {
+          "min": 44959,
+          "max": 48586,
+          "rate": 0.431
+        },
+        {
+          "min": 48586,
+          "max": 90393,
+          "rate": 0.446
+        },
+        {
+          "min": 90393,
+          "max": null,
+          "rate": 0.48
+        }
+      ],
+      "deduction": 4432,
+      "exemptions": "NHR ended Jan 2024 (IFICI replacement excludes pensions). Foreign pensions/retirement income taxed at standard progressive rates 12.5-48%. US-Portugal treaty provides foreign tax credit."
+    },
+    "salesTax": {
+      "rate": 0
+    },
+    "propertyTax": {
+      "rate": 0
+    },
+    "socialCharges": null,
+    "vatRate": 0.23,
+    "estVehicleTax": 0,
+    "ssExempt": false,
+    "ssTaxedInCountry": true,
+    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%. US-Portugal tax treaty helps avoid double taxation."
   },
   "subregion": "Algarve"
 }

--- a/data/locations/portugal-cascais/location.json
+++ b/data/locations/portugal-cascais/location.json
@@ -198,9 +198,76 @@
     }
   ],
   "taxes": {
-    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
-    "vatRate": 23,
-    "socialChargesRate": 0
+    "federalIncomeTax": {
+      "applies": true,
+      "foreignTaxCredit": true
+    },
+    "stateIncomeTax": {
+      "rate": 0.48,
+      "type": "progressive",
+      "label": "Portuguese Income Tax (IRS)",
+      "brackets": [
+        {
+          "min": 0,
+          "max": 8704,
+          "rate": 0.125
+        },
+        {
+          "min": 8704,
+          "max": 13133,
+          "rate": 0.16
+        },
+        {
+          "min": 13133,
+          "max": 18612,
+          "rate": 0.215
+        },
+        {
+          "min": 18612,
+          "max": 24090,
+          "rate": 0.244
+        },
+        {
+          "min": 24090,
+          "max": 30672,
+          "rate": 0.314
+        },
+        {
+          "min": 30672,
+          "max": 44959,
+          "rate": 0.349
+        },
+        {
+          "min": 44959,
+          "max": 48586,
+          "rate": 0.431
+        },
+        {
+          "min": 48586,
+          "max": 90393,
+          "rate": 0.446
+        },
+        {
+          "min": 90393,
+          "max": null,
+          "rate": 0.48
+        }
+      ],
+      "deduction": 4432,
+      "exemptions": "NHR ended Jan 2024 (IFICI replacement excludes pensions). Foreign pensions/retirement income taxed at standard progressive rates 12.5-48%. US-Portugal treaty provides foreign tax credit."
+    },
+    "salesTax": {
+      "rate": 0
+    },
+    "propertyTax": {
+      "rate": 0
+    },
+    "socialCharges": null,
+    "vatRate": 0.23,
+    "estVehicleTax": 0,
+    "ssExempt": false,
+    "ssTaxedInCountry": true,
+    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%."
   },
   "subregion": "Lisboa"
 }

--- a/data/locations/portugal-porto/location.json
+++ b/data/locations/portugal-porto/location.json
@@ -198,9 +198,76 @@
     }
   ],
   "taxes": {
-    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
-    "vatRate": 23,
-    "socialChargesRate": 0
+    "federalIncomeTax": {
+      "applies": true,
+      "foreignTaxCredit": true
+    },
+    "stateIncomeTax": {
+      "rate": 0.48,
+      "type": "progressive",
+      "label": "Portuguese Income Tax (IRS)",
+      "brackets": [
+        {
+          "min": 0,
+          "max": 8704,
+          "rate": 0.125
+        },
+        {
+          "min": 8704,
+          "max": 13133,
+          "rate": 0.16
+        },
+        {
+          "min": 13133,
+          "max": 18612,
+          "rate": 0.215
+        },
+        {
+          "min": 18612,
+          "max": 24090,
+          "rate": 0.244
+        },
+        {
+          "min": 24090,
+          "max": 30672,
+          "rate": 0.314
+        },
+        {
+          "min": 30672,
+          "max": 44959,
+          "rate": 0.349
+        },
+        {
+          "min": 44959,
+          "max": 48586,
+          "rate": 0.431
+        },
+        {
+          "min": 48586,
+          "max": 90393,
+          "rate": 0.446
+        },
+        {
+          "min": 90393,
+          "max": null,
+          "rate": 0.48
+        }
+      ],
+      "deduction": 4432,
+      "exemptions": "NHR ended Jan 2024 (IFICI replacement excludes pensions). Foreign pensions/retirement income taxed at standard progressive rates 12.5-48%. US-Portugal treaty provides foreign tax credit."
+    },
+    "salesTax": {
+      "rate": 0
+    },
+    "propertyTax": {
+      "rate": 0
+    },
+    "socialCharges": null,
+    "vatRate": 0.23,
+    "estVehicleTax": 0,
+    "ssExempt": false,
+    "ssTaxedInCountry": true,
+    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%."
   },
   "subregion": "Norte"
 }

--- a/data/locations/portugal-silver-coast/location.json
+++ b/data/locations/portugal-silver-coast/location.json
@@ -198,9 +198,76 @@
     }
   ],
   "taxes": {
-    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%.",
-    "vatRate": 23,
-    "socialChargesRate": 0
+    "federalIncomeTax": {
+      "applies": true,
+      "foreignTaxCredit": true
+    },
+    "stateIncomeTax": {
+      "rate": 0.48,
+      "type": "progressive",
+      "label": "Portuguese Income Tax (IRS)",
+      "brackets": [
+        {
+          "min": 0,
+          "max": 8704,
+          "rate": 0.125
+        },
+        {
+          "min": 8704,
+          "max": 13133,
+          "rate": 0.16
+        },
+        {
+          "min": 13133,
+          "max": 18612,
+          "rate": 0.215
+        },
+        {
+          "min": 18612,
+          "max": 24090,
+          "rate": 0.244
+        },
+        {
+          "min": 24090,
+          "max": 30672,
+          "rate": 0.314
+        },
+        {
+          "min": 30672,
+          "max": 44959,
+          "rate": 0.349
+        },
+        {
+          "min": 44959,
+          "max": 48586,
+          "rate": 0.431
+        },
+        {
+          "min": 48586,
+          "max": 90393,
+          "rate": 0.446
+        },
+        {
+          "min": 90393,
+          "max": null,
+          "rate": 0.48
+        }
+      ],
+      "deduction": 4432,
+      "exemptions": "NHR ended Jan 2024 (IFICI replacement excludes pensions). Foreign pensions/retirement income taxed at standard progressive rates 12.5-48%. US-Portugal treaty provides foreign tax credit."
+    },
+    "salesTax": {
+      "rate": 0
+    },
+    "propertyTax": {
+      "rate": 0
+    },
+    "socialCharges": null,
+    "vatRate": 0.23,
+    "estVehicleTax": 0,
+    "ssExempt": false,
+    "ssTaxedInCountry": true,
+    "notes": "NHR ended Jan 2024. IFICI replacement excludes pensions. Standard progressive rates 14.5%-48%."
   },
   "subregion": "Centro"
 }


### PR DESCRIPTION
## Summary

Portugal has one national income tax (IRS) with no regional variation, but only \`portugal-lisbon\` shipped the structured bracket table. The other 4 regions (Algarve, Cascais, Porto, Silver Coast) had only a summary note + VAT rate, so the dashboard fell through to a flat \`monthlyCosts.taxes.typical\` = \$600/mo — labelled "data" instead of "computed" on the Taxes screen.

## Fix

Copied the shared Portuguese IRS structure from Lisbon to the other 4 locations:
- 12.5 → 48% progressive brackets (9 bands)
- EUR 4,432 standard deduction  
- 23% VAT
- US-Portugal treaty flags (\`ssExempt: false\`, \`ssTaxedInCountry: true\`)

Each region keeps its existing narrative notes — no other content changes.

## Known cosmetic drift

Lisbon's notes say "12.5-48%", the other 4 still say "14.5-48%" (the 12.5 is correct per the brackets). Narrative text only, not computed data — easy follow-up.

## Test plan

- [ ] Dashboard Taxes screen → switch between Portugal locations → all 5 show "computed" badge instead of "data" for Algarve/Cascais/Porto/Silver Coast
- [ ] Monthly tax values should match Lisbon for same household income (no regional variation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)