### PR TITLE
feat(deploy): add dashboard service to compose stack (Phase 3.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ SENTRY_DSN=
 PORT=3000
 NODE_ENV=development
 API_PORT=3000
+# Optional: number of api replicas behind the compose stack (default 1).
+API_REPLICAS=1
+# Host port for the dashboard nginx (default 8080). The dashboard container
+# always listens on 8080 internally — this only changes the host mapping.
+DASHBOARD_PORT=8080
 
 # ─── Dev Auth Bypass ──────────────────────────────────────────────────────
 # Set DEV_AUTH_BYPASS=1 in local dev to auto-create/sign-in dev@localhost (admin tier)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,17 @@
 version: '3.8'
 
+# Compose stack for the rogue homelab deploy.
+# Expects the dashboard repo cloned as a sibling at `../retirement-dashboard-angular`
+# (see Phase 3.2 of dashboard PR #76 / Dashboard-Infrastructure.md).
+
+networks:
+  internal:
+    driver: bridge
+
 services:
   postgres:
     image: postgres:16-alpine
+    networks: [internal]
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-retirement_saas}
       POSTGRES_USER: ${POSTGRES_USER:-retirement}
@@ -18,6 +27,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    networks: [internal]
     command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
     healthcheck:
       test: ['CMD', 'redis-cli', '-a', '${REDIS_PASSWORD}', 'ping']
@@ -30,6 +40,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    networks: [internal]
     ports:
       - '${API_PORT:-3000}:3000'
     deploy:
@@ -51,7 +62,10 @@ services:
       STRIPE_PRICE_PREMIUM: ${STRIPE_PRICE_PREMIUM:-}
       ENCRYPTION_MASTER_KEY: ${ENCRYPTION_MASTER_KEY:?ENCRYPTION_MASTER_KEY is required}
       APP_URL: ${APP_URL:-http://localhost:8080}
-      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:5173}
+      # CORS isn't actually exercised on the deploy path because nginx
+      # proxies /api/* same-origin. Default kept for direct-to-api callers
+      # (e.g. local Angular dev server) — bump to the deploy host via .env.
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:8080}
       SENTRY_DSN: ${SENTRY_DSN:-}
     depends_on:
       postgres:
@@ -65,6 +79,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    networks: [internal]
     command: npx prisma migrate deploy --schema=prisma/schema.prisma
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-retirement}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-retirement_saas}
@@ -72,6 +87,33 @@ services:
       postgres:
         condition: service_healthy
     restart: 'no'
+
+  # Angular SPA + nginx reverse-proxy fronting the api.
+  # Build context is a sibling clone — repo layout on the deploy host
+  # must place retirement-api/ and retirement-dashboard-angular/ in the
+  # same parent directory.
+  dashboard:
+    build:
+      context: ../retirement-dashboard-angular
+      dockerfile: Dockerfile
+    networks: [internal]
+    ports:
+      - '${DASHBOARD_PORT:-8080}:8080'
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: '0.5'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:8080/healthz']
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+    depends_on:
+      api:
+        condition: service_started
+    restart: unless-stopped
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Phase 3.2 of the rogue deploy. Folds the Angular SPA + nginx container into the existing compose stack so a single \`docker compose up -d --build\` on rogue brings up the full system: postgres, redis, api, migrate (one-shot), and dashboard.

Pairs with [retirement-dashboard-angular#76](https://github.com/justice8096/retirement-dashboard-angular/pull/76) — already merged.

## What's added

- **\`dashboard\` service** — builds from \`../retirement-dashboard-angular\` (sibling clone)
- **\`internal\` bridge network** — every service explicitly attached, so nginx resolves \`api:3000\` via Docker DNS rather than relying on the implicit default network
- **\`DASHBOARD_PORT\` env** — host port mapping (default \`8080\`); container always listens on \`8080\` internally
- **\`.env.example\` updates** — documents \`DASHBOARD_PORT\` and the previously-undocumented \`API_REPLICAS\`

## Cross-vetted decisions

| Decision | Choice | Why |
|---|---|---|
| Build context | hardcoded sibling path \`../retirement-dashboard-angular\` | matches Phase 3.3 deploy plan (clone both repos to rogue:/srv/retirement/) and keeps compose readable. Documented in a comment at the top of the file. |
| Dashboard \`depends_on\` | \`api: service_started\` (not \`service_healthy\`) | Static UI is usable before the API is healthy. Chain delay through postgres-healthy → redis-healthy → api-healthy would block the dashboard from booting; first \`/api/*\` calls may 502 for a few seconds during cold start but recover automatically. |
| CORS_ORIGIN default | bumped \`http://localhost:5173\` → \`http://localhost:8080\` | Old default pointed at the legacy Vite dashboard (decommissioned). Same-origin nginx proxy means CORS isn't actually exercised on the deploy path; this only affects direct-to-api callers, which after this change use the new port. |
| Dashboard healthcheck | \`wget -q --spider /healthz\` | Mirrors the Dockerfile's HEALTHCHECK so compose-level status matches container-level status. BusyBox-compatible. |
| Resource limits | 128M / 0.5 CPU | nginx static-serve doesn't need more. |

## Verification

\`docker compose config\` and \`yaml.parse\` both confirm the file is well-formed and all 5 services + the new network are wired correctly. First real \`docker compose build\` happens on rogue in Phase 3.3 — that's where unknown-unknowns will surface (Linux build behaviour, network DNS resolution, healthcheck timing).

## Next

- **Phase 3.3** — clone both repos to \`rogue\` (\`192.168.68.77\`), write \`.env\`, run \`docker compose up -d --build\`, run migrations + seed
- **Phase 3.4** — \`tailscale serve --bg --https=443 localhost:8080\` + \`tailscale funnel 443 on\` on rogue
- **Phase 3.5** — Uptime Kuma monitor + Obsidian doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)