### PR TITLE
fix(docker): cold-build fixes uncovered during rogue deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@ FROM node:25-alpine@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+# `--ignore-scripts` is required: package.json has a `postinstall` that runs
+# `prisma generate --schema=prisma/schema.prisma`, but the prisma/ directory
+# is not copied into this stage. Stage 2 handles `prisma generate` explicitly
+# after copying the schema, so skipping postinstall here is safe.
+RUN npm ci --ignore-scripts
 
 # ─── Stage 2: Generate Prisma client ──────────────────────────────────────
 FROM node:25-alpine@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4 AS prisma
@@ -61,6 +65,6 @@ ENV PORT=3000
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health/ready || exit 1
+  CMD wget -q --spider http://localhost:3000/api/health/ready || exit 1
 
 CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary

Two real bugs that only surfaced when running \`docker compose up -d --build\` from scratch on rogue (192.168.68.77) during Phase 3.3 of the deploy. The dev workflow uses \`npm run dev\` against a host-installed Postgres, so the Dockerfile had never been exercised cold-build.

## Bug 1 — \`npm ci\` runs \`prisma generate\` against a missing schema

**Symptom:**
\`\`\`
#17 [api deps 4/4] RUN npm ci
#17 5.572 > prisma generate --schema=prisma/schema.prisma
#17 6.299 Error: Could not load \`--schema\` from provided path
        \`prisma/schema.prisma\`: file or directory not found
target migrate: failed to solve: process \"/bin/sh -c npm ci\"
        did not complete successfully: exit code: 1
\`\`\`

**Cause:** package.json has \`\"postinstall\": \"prisma generate --schema=prisma/schema.prisma\"\`. In the deps stage, only \`package.json\` and \`package-lock.json\` are COPY'd; the \`prisma/\` directory is COPY'd in Stage 2.

**Fix:** \`npm ci --ignore-scripts\` in the deps stage. Stage 2 already runs \`npx prisma generate\` explicitly after the schema is in place, so the client is still generated. The dev-time \`npm install\` outside Docker is unaffected.

## Bug 2 — BusyBox wget flags in HEALTHCHECK

Same Codex P1 finding as [retirement-dashboard-angular#76](https://github.com/justice8096/retirement-dashboard-angular/pull/76): node:25-alpine ships BusyBox wget, which doesn't recognise \`--no-verbose\` or \`--tries=1\`. Container is marked unhealthy even when \`/api/health/ready\` is fine.

**Fix:** \`-q --spider\` (BusyBox-supported), same as the dashboard fix.

## Verification

- Re-running \`docker compose up -d --build\` on rogue after these changes is the next step. I'll re-run it once this lands and report back.
- No behaviour change for local dev (\`npm run dev\`) — postinstall still runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)