### PR TITLE
fix(docker): copy package.json into builder stage so tsc sees type:module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,11 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=prisma /app/node_modules/.prisma ./node_modules/.prisma
 COPY shared ./shared
 COPY src ./src
-COPY tsconfig.json ./
+# package.json is required so tsc sees `"type": "module"` and treats source
+# files as ES modules (top-level await in server.ts otherwise errors with
+# TS1309 because tsc defaults to CommonJS classification when no package.json
+# is reachable).
+COPY tsconfig.json package.json ./
 
 RUN npx tsc
 


### PR DESCRIPTION
## Summary

Third cold-build bug uncovered on rogue, same shape as PR #75 — Dockerfile-only path that the dev workflow never exercises.

\`\`\`
src/server.ts(247,1): error TS1309: The current file is a CommonJS
        module and cannot use 'await' at the top level.
... (10 similar errors in server.ts)
target migrate: failed to solve: process \"/bin/sh -c npx tsc\"
        did not complete successfully: exit code: 2
\`\`\`

## Root cause

The builder stage runs \`npx tsc\` against \`src/\` but only copies \`tsconfig.json\`. tsc walks up looking for a package.json to determine the **module system** (separate from the output format set by tsconfig's \`\"module\"\`). Without one, it defaults source files to CJS classification — and CJS rejects top-level await.

\`server.ts\` uses TLA (\`await registerCors(app)\` etc. at module scope), so TS1309 fires for every TLA usage. \`package.json\` declares \`\"type\": \"module\"\`; getting that into the builder stage flips classification to ESM and the build proceeds.

## Why dev didn't catch it

The dev workflow uses \`npm run dev\` which is \`tsx --watch src/server.ts\` — tsx reads package.json's \`\"type\"\` directly and runs source as ESM. Only the Dockerfile builder stage strips package.json from the build context, so this is purely a packaging-isolation bug.

## Fix

\`\`\`diff
-COPY tsconfig.json ./
+COPY tsconfig.json package.json ./
\`\`\`

The runner stage (Stage 4) already copies package.json — it's needed at runtime for the same module-system reason when Node loads \`dist/server.js\`. This makes the builder stage consistent.

## Verification plan

I'll re-run \`docker compose up -d --build\` on rogue after this lands. That's the third cold-build bug from the rogue deploy ([api PR #75](https://github.com/justice8096/retirement-api/pull/75) was the npm-ci-postinstall + healthcheck fixes, [dashboard PR #77](https://github.com/justice8096/retirement-dashboard-angular/pull/77) was the bundle budget). After this lands, the api build chain should be clean end-to-end.

## Followup tracked separately

A \`docker build\` smoke job for both repos' PR CI would catch this whole class of issue before merge instead of at deploy time. Tracking in session todos; happy to open a separate PR after the deploy stabilises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)