### PR TITLE
fix(docker): copy prisma.config.ts into runner so migrate deploy works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ COPY --chown=api:nodejs shared ./shared
 COPY --chown=api:nodejs --from=builder /app/dist ./dist
 COPY --chown=api:nodejs package.json ./
 COPY --chown=api:nodejs prisma ./prisma
+# Prisma 7's CLI (`prisma migrate deploy`) reads its datasource URL from
+# prisma.config.ts and refuses to run without it. The migrate compose
+# service uses this image, so the config has to be in the runtime layer
+# even though the runtime PrismaClient itself goes via driver adapter.
+COPY --chown=api:nodejs prisma.config.ts ./
 
 ENV NODE_ENV=production
 ENV PORT=3000


### PR DESCRIPTION
## Summary

Fourth cold-build bug, surfaced once the chain finally reached the migrate one-shot service on rogue. After [#75](https://github.com/justice8096/retirement-api/pull/75) and [#76](https://github.com/justice8096/retirement-api/pull/76), all three images build and \`docker compose up\` gets postgres + redis to healthy and starts migrate. Then:

\`\`\`
$ docker logs retirement-api-migrate-1
Prisma schema loaded from prisma/schema.prisma.
Error: The datasource.url property is required in your Prisma config
        file when using prisma migrate deploy.
$ docker compose ps -a
retirement-api-migrate-1  Exited (1) 54 seconds ago
\`\`\`

api then crash-loops because the schema never landed:

\`\`\`
PrismaClientKnownRequestError:
Invalid \`prisma.user.findFirst()\` invocation:
The table \`public.users\` does not exist in the current database.
    at assertNoDevBypassUserInProd (.../auth.js:85:21)
\`\`\`

## Root cause

Prisma 7 changed how the CLI resolves its datasource URL. \`prisma migrate deploy\` no longer reads \`\$DATABASE_URL\` directly — it requires the URL to come from \`prisma.config.ts\`, which itself does \`url: process.env.DATABASE_URL\`. The Dockerfile's prisma stage copies that file (so \`prisma generate\` works at build time), but the runner stage doesn't. The migrate compose service runs against the runner image, so it has no config file.

Runtime \`PrismaClient\` is unaffected — it goes via driver adapter (\`@prisma/adapter-pg\`) and reads \`DATABASE_URL\` directly from the env. Only the migrate CLI breaks.

## Fix

\`\`\`diff
 COPY --chown=api:nodejs prisma ./prisma
+COPY --chown=api:nodejs prisma.config.ts ./
\`\`\`

## Why dev didn't catch it

Dev runs migrations from \`D:/retirement-api\` directly via \`npx prisma migrate dev\`, where prisma.config.ts is sitting next to the schema. Only the Dockerfile's per-stage copies strip it.

## The pattern

Fourth Dockerfile cold-build bug from this deploy ([#75 deps + healthcheck](https://github.com/justice8096/retirement-api/pull/75), [dashboard #77 bundle budget](https://github.com/justice8096/retirement-dashboard-angular/pull/77), [#76 builder package.json](https://github.com/justice8096/retirement-api/pull/76), this one). Each one is a different stage forgetting to copy something the next stage or the runtime needs. Strong case for a \`docker build\` smoke test in CI — tracked separately.

## Verification

I'll re-run \`docker compose up -d --build\` on rogue once this lands. After this fix the chain should be: build → postgres healthy → redis healthy → migrate runs cleanly → api boots → dashboard binds (after the unrelated 8080→8090 port-collision fix in .env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)