### PR TITLE
fix(docker): healthcheck uses 127.0.0.1, not localhost (IPv4-only bind)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,11 @@ ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
 
+# Use 127.0.0.1 explicitly: node:25-alpine's /etc/hosts maps `localhost` to
+# ::1, but Fastify binds IPv4 only (0.0.0.0:3000). wget against `localhost`
+# tries IPv6 first and reports connection refused, marking the container
+# unhealthy even when the server is responding fine.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -q --spider http://localhost:3000/api/health/ready || exit 1
+  CMD wget -q --spider http://127.0.0.1:3000/api/health/ready || exit 1
 
 CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,10 @@ services:
           memory: 128M
           cpus: '0.5'
     healthcheck:
-      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:8080/healthz']
+      # 127.0.0.1, not localhost: nginx:alpine's /etc/hosts maps `localhost`
+      # to ::1, but nginx listens on IPv4 only. Same fix as the api
+      # Dockerfile HEALTHCHECK (PR fix/healthcheck-ipv4-loopback).
+      test: ['CMD', 'wget', '-q', '--spider', 'http://127.0.0.1:8080/healthz']
       interval: 30s
       timeout: 3s
       start_period: 5s


### PR DESCRIPTION
## Summary

Sixth cold-build bug from the rogue deploy — non-blocking but worth fixing before exposing the stack to the internet via Tailscale Funnel.

\`\`\`
$ docker compose ps
NAME                         STATUS
retirement-api-api-1         Up 2 minutes (unhealthy)
retirement-api-dashboard-1   Up 2 minutes (unhealthy)
retirement-api-postgres-1    Up 2 minutes (healthy)
retirement-api-redis-1       Up 2 minutes (healthy)

$ curl http://localhost:3000/api/health/ready
{\"ready\":true}                            ← endpoints fine

$ docker exec retirement-api-api-1 wget -q --spider http://localhost:3000/api/health/ready
exit=1
wget: can't connect to remote host: Connection refused

$ docker exec retirement-api-api-1 wget -q --spider http://127.0.0.1:3000/api/health/ready
exit=0                                       ← works on IPv4
\`\`\`

## Root cause

\`node:25-alpine\` and \`nginx:alpine\` ship an /etc/hosts that maps \`localhost\` to \`::1\` (IPv6 loopback only). Both Fastify (api) and nginx (dashboard) bind IPv4 by default — \`0.0.0.0:3000\` and \`0.0.0.0:8080\` respectively. wget tries IPv6 first, gets connection refused, container marked unhealthy.

## Functional impact pre-fix

Zero. \`restart: unless-stopped\` doesn't trigger on unhealthy (only on stopped/exited), so all traffic through nginx → api worked fine. The signal in \`docker compose ps\` was just wrong.

## Fix

Two one-line changes:
- \`Dockerfile\` HEALTHCHECK: \`localhost\` → \`127.0.0.1\`
- \`docker-compose.yml\` dashboard healthcheck (overrides dashboard image's HEALTHCHECK): \`localhost\` → \`127.0.0.1\`

## Pairs with

[retirement-dashboard-angular#TBD](https://github.com/justice8096/retirement-dashboard-angular/pull/new/fix/healthcheck-ipv4-loopback) — same fix in the dashboard's Dockerfile for parity (mostly cosmetic since compose overrides at runtime, but makes \`docker run\` standalone work).

## The bug-tally pattern

This is the sixth Dockerfile / cold-build bug from this deploy, fifth one-line fix:

| # | PR | Bug |
|---|---|---|
| 1 | [api #75](https://github.com/justice8096/retirement-api/pull/75) | npm-ci postinstall ran prisma generate before schema was COPY'd |
| 2 | [api #75](https://github.com/justice8096/retirement-api/pull/75) | HEALTHCHECK used GNU wget flags on BusyBox |
| 3 | [dashboard #77](https://github.com/justice8096/retirement-dashboard-angular/pull/77) | Production bundle exceeded 1MB budget; PR CI silently ran development build |
| 4 | [api #76](https://github.com/justice8096/retirement-api/pull/76) | Builder stage missing package.json → tsc rejected top-level await |
| 5 | [api #77](https://github.com/justice8096/retirement-api/pull/77) | Runner stage missing prisma.config.ts → migrate deploy fails |
| 6 | this | HEALTHCHECK uses localhost → IPv6 → unhealthy despite working |

Strong case for the \`docker build\` smoke-test CI followup that's tracked separately. After this PR + the dashboard pair land, deploy is functionally complete and ready for Phase 3.4 (Tailscale Funnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)