### PR TITLE
feat(deploy): tailscale funnel sidecar for dashboard (Phase 3.4b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ API_REPLICAS=1
 # always listens on 8080 internally — this only changes the host mapping.
 DASHBOARD_PORT=8080
 
+# ─── Tailscale Funnel sidecar (Phase 3.4b) ──────────────────────────────
+# Reusable, pre-approved auth key from https://login.tailscale.com/admin/settings/keys
+# Tagged tag:funnel-dashboard (must have nodeAttrs:["funnel"] in tailnet ACL).
+# Generate fresh per deploy host; back up alongside other secrets.
+TS_AUTHKEY_FUNNEL_DASHBOARD=tskey-auth-...
+
 # ─── Dev Auth Bypass ──────────────────────────────────────────────────────
 # Set DEV_AUTH_BYPASS=1 in local dev to auto-create/sign-in dev@localhost (admin tier)
 # when requests arrive without an Authorization header. Requires NODE_ENV=development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,5 +118,33 @@ services:
         condition: service_started
     restart: unless-stopped
 
+  # Tailscale Funnel sidecar — terminates HTTPS at Tailscale's edge and
+  # proxies cleartext to the dashboard container on the internal network.
+  # Userspace networking (no /dev/net/tun, no NET_ADMIN) keeps the cap
+  # surface minimal. State lives in a named volume so the MagicDNS
+  # hostname survives `docker compose down`.
+  #
+  # Auth via reusable, pre-approved auth key tagged tag:funnel-dashboard
+  # (generate at https://login.tailscale.com/admin/settings/keys).
+  # The tag must have nodeAttrs:["funnel"] in the tailnet ACL.
+  tailscale-dashboard:
+    image: tailscale/tailscale:stable
+    hostname: retirement-dashboard
+    environment:
+      TS_AUTHKEY: ${TS_AUTHKEY_FUNNEL_DASHBOARD:?TS_AUTHKEY_FUNNEL_DASHBOARD is required}
+      TS_HOSTNAME: retirement-dashboard
+      TS_USERSPACE: 'true'
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_SERVE_CONFIG: /config/serve.json
+    volumes:
+      - tailscale-dashboard-state:/var/lib/tailscale
+      - ./tools/tailscale/serve.json:/config/serve.json:ro
+    networks: [internal]
+    depends_on:
+      dashboard:
+        condition: service_started
+    restart: unless-stopped
+
 volumes:
   pgdata:
+  tailscale-dashboard-state:

--- a/tools/tailscale/serve.json
+++ b/tools/tailscale/serve.json
@@ -1,0 +1,19 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://dashboard:8080"
+        }
+      }
+    }
+  },
+  "AllowFunnel": {
+    "${TS_CERT_DOMAIN}:443": true
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3.4b of the rogue deploy. Adds a \`tailscale/tailscale:stable\` sidecar to the compose stack that terminates HTTPS at Tailscale's edge and reverse-proxies cleartext to the dashboard container on the internal docker network. The dashboard becomes reachable on the public internet at \`https://retirement-dashboard.<tailnet>.ts.net\` via Tailscale Funnel.

Pairs with Phase 3.4a (host-level tailscale on rogue, separate concern — see commit notes). Phases 3.4a and 3.4b are independent.

## Architecture choice — sidecar over host

| Property | Sidecar (this PR) | Host \`tailscale serve\` |
|---|---|---|
| Stack self-containment | ✅ \`docker compose up\` brings up exposure | ❌ host config drift risk |
| Per-service tailnet identity | ✅ \`tag:funnel-dashboard\` | ❌ whole-host identity |
| Privilege surface | userspace, no NET_ADMIN | tailscaled has root + kernel TUN |
| Portability | ✅ named volume preserves MagicDNS | ❌ host-bound |
| Admin SSH (\`tailscale ssh\`) | — | ✅ |

This is the \"hybrid\" pattern: host-tailscale handles operator SSH; sidecar-tailscale handles the public funnel. Independent identities, narrow blast radii.

## What's in this PR

- \`tools/tailscale/serve.json\` — Tailscale serve config: terminate HTTPS on :443 with the auto-issued MagicDNS cert, proxy all paths to \`http://dashboard:8080\` (internal compose service), allow funnel exposure for the cert domain
- \`docker-compose.yml\` — \`tailscale-dashboard\` service + \`tailscale-dashboard-state\` named volume + \`depends_on: dashboard: service_started\`
- \`.env.example\` — documents \`TS_AUTHKEY_FUNNEL_DASHBOARD\` requirement

## Setup on a fresh deploy host

1. Generate a reusable + pre-approved auth key at https://login.tailscale.com/admin/settings/keys, tag it \`tag:funnel-dashboard\`.
2. Add to tailnet ACL (https://login.tailscale.com/admin/acls/file):
   \`\`\`jsonc
   \"tagOwners\": { \"tag:funnel-dashboard\": [\"autogroup:admin\"] },
   \"nodeAttrs\": [{
     \"target\": [\"tag:funnel-dashboard\"],
     \"attr\":   [\"funnel\"]
   }]
   \`\`\`
3. \`TS_AUTHKEY_FUNNEL_DASHBOARD=tskey-auth-...\` in \`.env\`.
4. \`docker compose up -d\` — sidecar joins tailnet, requests cert, enables funnel, starts proxying.
5. Update \`APP_URL\` and \`CORS_ORIGIN\` in \`.env\` to the public funnel URL, \`docker compose restart api\` so Clerk OAuth callbacks resolve correctly.

## Verification

After this lands I'll:
1. Pull on rogue
2. \`docker compose up -d\` (will only build the new sidecar; rest cached)
3. Watch \`docker logs retirement-api-tailscale-dashboard-1\` for the cert provisioning + serve registration
4. \`curl https://retirement-dashboard.tailceab8.ts.net/healthz\` from this Windows box (via the public internet)
5. Update APP_URL/CORS_ORIGIN, restart api

## Out of scope

- Phase 3.5 (Uptime Kuma + Obsidian doc updates) — separate
- Phase 3.6 (pg_dump backup as systemd timer on rogue) — separate, chip already spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)