### PR TITLE
fix(api): strip HSTS + upgrade-insecure-requests on HTTP-arriving requests

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -78,6 +78,35 @@ await app.register(helmet, {
   // paired dashboard and marketing-site origins to consume the API.
   crossOriginResourcePolicy: { policy: 'same-site' },
 });
+
+// Helmet sets `Strict-Transport-Security` and includes `upgrade-insecure-requests`
+// in the CSP on every response. Both directives tell HTTP clients to "from now on,
+// always use HTTPS for this host". That's the right behaviour when the response is
+// actually traversing HTTPS (e.g. via the Tailscale Funnel). It's actively harmful
+// when the response travels over HTTP (e.g. LAN-internal Uptime Kuma probe to
+// `http://192.168.68.77:3000/api/health/ready`) — HSTS-aware HTTP clients (axios
+// included) cache the directive, then on the *next* request attempt to scheme-
+// upgrade to HTTPS. The upgrade strips the non-default port (8090) and falls back
+// to default HTTP port 80, where nothing is listening → ECONNREFUSED.
+//
+// Strip both directives when the request did NOT arrive over HTTPS. Detected via
+// the `X-Forwarded-Proto` header (set by reverse proxies that terminate TLS) or
+// Fastify's resolved `request.protocol`. The effect: HSTS is preserved on the
+// public Funnel path (sidecar sets X-Forwarded-Proto: https before the request
+// reaches the api) and dropped on direct LAN HTTP, which is exactly what we want.
+app.addHook('onSend', async (request, reply) => {
+  const xfp = request.headers['x-forwarded-proto'];
+  const proto = (Array.isArray(xfp) ? xfp[0] : xfp) ?? request.protocol;
+  if (proto === 'https') return;
+  reply.removeHeader('strict-transport-security');
+  const csp = reply.getHeader('content-security-policy');
+  if (typeof csp === 'string' && csp.includes('upgrade-insecure-requests')) {
+    const stripped = csp
+      .replace(/;\s*upgrade-insecure-requests\s*/gi, '')
+      .replace(/^\s*upgrade-insecure-requests\s*;?/i, '');
+    reply.header('content-security-policy', stripped);
+  }
+});
 // Build Redis store for distributed rate limiting (falls back to in-memory)
 let redisClient: { quit: () => Promise<void> } | undefined;
 try {


### PR DESCRIPTION
## Summary

Uptime Kuma monitor on \`http://192.168.68.77:8090/api/health/ready\` fails with \`ECONNREFUSED 192.168.68.77:80\` while curl from the same Kuma container returns 200 cleanly. The \`/healthz\` endpoint (nginx-only, no api) works fine. Difference: api responses carry Helmet-set \`Strict-Transport-Security\` and \`upgrade-insecure-requests\` (in CSP). \`/healthz\` doesn't go through the api so it doesn't get these headers.

## Diagnosis

axios caches the HSTS directive from the first response. On the next probe, it scheme-upgrades the request to HTTPS, strips the non-default port \`8090\` (per HSTS upgrade semantics), falls back to default HTTP port \`80\` when HTTPS-on-8090 fails the TLS handshake → \`ECONNREFUSED 192.168.68.77:80\`.

Both directives are correct when responses traverse HTTPS (the Funnel public path). They're incorrect when responses traverse HTTP (LAN-internal Kuma, future internal tooling, \`docker exec curl\` style probes).

## Fix

Fastify \`onSend\` hook registered **after** Helmet — runs after Helmet's header-setting hook so it can strip what Helmet just added. Reads \`X-Forwarded-Proto\` (set by the Tailscale Funnel sidecar before requests reach the api) and falls back to \`request.protocol\`. If neither resolves to \`https\`, strip:
- \`Strict-Transport-Security\` header
- \`upgrade-insecure-requests\` from \`Content-Security-Policy\`

\`\`\`diff
+ app.addHook('onSend', async (request, reply) => {
+   const xfp = request.headers['x-forwarded-proto'];
+   const proto = (Array.isArray(xfp) ? xfp[0] : xfp) ?? request.protocol;
+   if (proto === 'https') return;
+   reply.removeHeader('strict-transport-security');
+   const csp = reply.getHeader('content-security-policy');
+   if (typeof csp === 'string' && csp.includes('upgrade-insecure-requests')) {
+     const stripped = csp
+       .replace(/;\s*upgrade-insecure-requests\s*/gi, '')
+       .replace(/^\s*upgrade-insecure-requests\s*;?/i, '');
+     reply.header('content-security-policy', stripped);
+   }
+ });
\`\`\`

## Net effect

| Path | HSTS preserved? |
|---|---|
| Funnel public HTTPS (\`https://retirement-dashboard.tailceab8.ts.net/api/...\`) | ✅ yes (sidecar sets X-Forwarded-Proto: https) |
| LAN direct HTTP to api (\`http://192.168.68.77:3000/api/...\`) | ❌ stripped — was breaking Kuma |
| LAN direct HTTP to nginx → api (\`http://192.168.68.77:8090/api/...\`) | ❌ stripped — was breaking Kuma |

## Verification plan

After merge + redeploy on rogue:
\`\`\`
ssh root@192.168.68.77 'docker exec uptime-kuma sh -c \"curl -sSI http://192.168.68.77:8090/api/health/ready | grep -iE strict-transport-security\|content-security\"'
# expect: NO Strict-Transport-Security header; CSP without upgrade-insecure-requests
\`\`\`
Then watch Uptime Kuma — monitor #9 (Retirement API LAN) should flip green within 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)