### PR TITLE
feat(taxes): add 2026 LTCG brackets + NIIT helper (#33 item 1)

### DIFF
--- a/shared/__tests__/taxes.test.js
+++ b/shared/__tests__/taxes.test.js
@@ -5,6 +5,11 @@ import {
   obbbaSeniorDeduction,
   FED_STD_DEDUCTION_2026,
   FED_BRACKETS_2026_MFJ,
+  LTCG_BRACKETS_2026,
+  NIIT_THRESHOLDS,
+  NIIT_RATE,
+  ltcgFederalTax,
+  niit,
 } from '../taxes.js';
 
 describe('calcBracketTax', () => {
@@ -352,5 +357,126 @@ describe('obbbaSeniorDeduction', () => {
     // 12% bracket. Reducing AGI by $12k keeps it in the 12% bracket, so
     // the savings are $12,000 × 12% = $1,440.
     expect(without.federal - with65.federal).toBeCloseTo(1440, 2);
+  });
+});
+
+describe('LTCG_BRACKETS_2026', () => {
+  it('matches Rev Proc 2025-32 thresholds for all 4 filing statuses', () => {
+    expect(LTCG_BRACKETS_2026.single).toEqual({ zeroTop:  49450, fifteenTop: 545500 });
+    expect(LTCG_BRACKETS_2026.mfj   ).toEqual({ zeroTop:  98900, fifteenTop: 613700 });
+    expect(LTCG_BRACKETS_2026.mfs   ).toEqual({ zeroTop:  49450, fifteenTop: 306850 });
+    expect(LTCG_BRACKETS_2026.hoh   ).toEqual({ zeroTop:  66200, fifteenTop: 579600 });
+  });
+});
+
+describe('ltcgFederalTax', () => {
+  it('returns 0 for non-positive LTCG', () => {
+    expect(ltcgFederalTax(0, 80000, 'mfj')).toBe(0);
+    expect(ltcgFederalTax(-100, 80000, 'mfj')).toBe(0);
+  });
+
+  it('all 0% when ordinary + LTCG fits in the 0% bracket', () => {
+    // MFJ 0% top is $98,900. Ordinary $50k + LTCG $40k = $90k < $98.9k.
+    expect(ltcgFederalTax(40000, 50000, 'mfj')).toBe(0);
+  });
+
+  it('all 15% when ordinary already exceeds 0% top and combined fits 15% top', () => {
+    // MFJ: ordinary $120k > $98.9k → no 0% room. Combined $120k + $30k = $150k < $613.7k.
+    // All $30k of LTCG taxed at 15% = $4,500.
+    expect(ltcgFederalTax(30000, 120000, 'mfj')).toBeCloseTo(4500, 2);
+  });
+
+  it('split 0% / 15% when ordinary is below the 0% top but combined exceeds it', () => {
+    // MFJ: ordinary $80k. 0% top $98.9k → first $18.9k of LTCG at 0%.
+    // Remaining $11.1k at 15% = $1,665.
+    expect(ltcgFederalTax(30000, 80000, 'mfj')).toBeCloseTo(1665, 2);
+  });
+
+  it('all 20% when ordinary already exceeds the 15% top', () => {
+    // MFJ: ordinary $700k > $613.7k → all LTCG at 20%.
+    // $50k × 0.20 = $10,000.
+    expect(ltcgFederalTax(50000, 700000, 'mfj')).toBeCloseTo(10000, 2);
+  });
+
+  it('split 15% / 20% when ordinary is in the 15% range but combined exceeds 20% threshold', () => {
+    // MFJ: ordinary $500k (above 0% top $98.9k, below 15% top $613.7k).
+    // LTCG $200k stacks → combined $700k > $613.7k.
+    // Dollars at 15%: from $500k up to $613.7k = $113.7k.
+    // Dollars at 20%: $200k − $113.7k = $86.3k.
+    // Tax = 113700 * 0.15 + 86300 * 0.20 = 17055 + 17260 = $34,315.
+    expect(ltcgFederalTax(200000, 500000, 'mfj')).toBeCloseTo(34315, 2);
+  });
+
+  it('three-way split 0% / 15% / 20% when LTCG straddles all three brackets', () => {
+    // MFJ: ordinary $80k (below 0% top $98.9k). LTCG $700k stacks.
+    // 0% portion: $98.9k − $80k = $18.9k (taxed at 0%).
+    // 20% portion: combined $780k − $613.7k = $166.3k (taxed at 20%).
+    // 15% portion: $700k − $18.9k − $166.3k = $514.8k (taxed at 15%).
+    // Tax = 514800 * 0.15 + 166300 * 0.20 = 77220 + 33260 = $110,480.
+    expect(ltcgFederalTax(700000, 80000, 'mfj')).toBeCloseTo(110480, 2);
+  });
+
+  it('respects single filing status thresholds (lower than MFJ)', () => {
+    // Single 0% top is $49,450. Ordinary $40k → first $9.45k of LTCG at 0%.
+    // LTCG $20k → remaining $10.55k at 15% = $1,582.50.
+    expect(ltcgFederalTax(20000, 40000, 'single')).toBeCloseTo(1582.5, 2);
+  });
+
+  it('treats negative ordinary income as 0 for bracket purposes', () => {
+    // Carry-forward losses can produce negative taxable ordinary income;
+    // for LTCG bracket placement we floor at 0 so all LTCG sees the full
+    // 0% bracket headroom.
+    expect(ltcgFederalTax(50000, -10000, 'mfj')).toBe(0); // $50k < $98.9k zeroTop
+  });
+
+  it('falls back to MFJ when filing status is unknown', () => {
+    expect(ltcgFederalTax(30000, 120000, 'bogus')).toBeCloseTo(4500, 2);
+  });
+});
+
+describe('NIIT_THRESHOLDS / niit', () => {
+  it('matches statutory unindexed thresholds', () => {
+    expect(NIIT_THRESHOLDS).toEqual({
+      single: 200000,
+      mfj:    250000,
+      mfs:    125000,
+      hoh:    200000,
+    });
+    expect(NIIT_RATE).toBe(0.038);
+  });
+
+  it('returns 0 when MAGI is at or below threshold', () => {
+    expect(niit(50000, 250000, 'mfj')).toBe(0);
+    expect(niit(50000, 100000, 'mfj')).toBe(0);
+  });
+
+  it('returns 0 for non-positive net investment income', () => {
+    expect(niit(0,  300000, 'mfj')).toBe(0);
+    expect(niit(-1, 300000, 'mfj')).toBe(0);
+  });
+
+  it('taxes the lesser of net investment income or MAGI excess', () => {
+    // MFJ threshold $250k. MAGI $300k → excess $50k.
+    // Net investment income $30k < $50k → tax $30k × 3.8% = $1,140.
+    expect(niit(30000, 300000, 'mfj')).toBeCloseTo(1140, 2);
+
+    // Net investment income $80k > $50k excess → tax $50k × 3.8% = $1,900.
+    expect(niit(80000, 300000, 'mfj')).toBeCloseTo(1900, 2);
+  });
+
+  it('uses single threshold ($200k) for single filers', () => {
+    // MAGI $250k single → excess $50k. Net investment $30k → tax $1,140.
+    expect(niit(30000, 250000, 'single')).toBeCloseTo(1140, 2);
+    // MAGI $200k single → at threshold, no tax.
+    expect(niit(30000, 200000, 'single')).toBe(0);
+  });
+
+  it('uses MFS threshold ($125k)', () => {
+    // MFS half of MFJ. MAGI $200k MFS → excess $75k. Net investment $40k → tax $1,520.
+    expect(niit(40000, 200000, 'mfs')).toBeCloseTo(1520, 2);
+  });
+
+  it('falls back to MFJ when filing status is unknown', () => {
+    expect(niit(30000, 300000, 'bogus')).toBeCloseTo(1140, 2);
   });
 });

--- a/shared/taxes.d.ts
+++ b/shared/taxes.d.ts
@@ -69,6 +69,31 @@ export interface LocationWithTaxes {
 export const FED_BRACKETS_2026_SOURCES: Source[];
 export const FED_STD_DEDUCTION_2026_SOURCES: Source[];
 export const OBBBA_SENIOR_SOURCES: Source[];
+export const LTCG_BRACKETS_2026_SOURCES: Source[];
+export const NIIT_SOURCES: Source[];
+
+export type FilingStatus = 'single' | 'mfj' | 'mfs' | 'hoh';
+
+export interface LtcgBracket {
+  zeroTop: number;
+  fifteenTop: number;
+}
+
+export const LTCG_BRACKETS_2026: Record<FilingStatus, LtcgBracket>;
+export const NIIT_THRESHOLDS: Record<FilingStatus, number>;
+export const NIIT_RATE: number;
+
+export function ltcgFederalTax(
+  ltcgIncome: number,
+  ordinaryTaxableIncome: number,
+  filingStatus: FilingStatus,
+): number;
+
+export function niit(
+  netInvestmentIncome: number,
+  magi: number,
+  filingStatus: FilingStatus,
+): number;
 
 export function calcBracketTax(income: number, brackets: TaxBracket[]): number;
 

--- a/shared/taxes.js
+++ b/shared/taxes.js
@@ -97,6 +97,129 @@ export var OBBBA_SENIOR_PHASEOUT = {
   hoh:    { start:  75000, end: 175000 },
 };
 
+// ─── 2026 Long-Term Capital Gains brackets ──────────────────────────────
+//
+// LTCG / qualified-dividend rates: 0% / 15% / 20%, with breakpoints set
+// by IRC § 1(h) and inflation-adjusted annually. 2026 values per IRS
+// Rev. Proc. 2025-32. NOT to be confused with the ordinary-income
+// brackets above — LTCG sits "on top" of ordinary income (see
+// `ltcgFederalTax` for the stacking logic).
+
+/** Citations for the 2026 LTCG / qualified-dividend bracket thresholds. */
+export var LTCG_BRACKETS_2026_SOURCES = [
+  {
+    title: 'IRS Rev. Proc. 2025-32 § 3.03 (2026 LTCG bracket thresholds)',
+    url: 'https://www.irs.gov/pub/irs-drop/rp-25-32.pdf',
+    accessed: '2026-04-30',
+  },
+  {
+    title: 'IRC § 1(h) — Maximum capital gains rate (statutory bracket structure)',
+    url: 'https://www.law.cornell.edu/uscode/text/26/1',
+    accessed: '2026-04-30',
+  },
+];
+
+/**
+ * Upper bounds (inclusive) of the 0% and 15% LTCG brackets, by filing
+ * status. Above the 15% upper bound, the rate is 20%. Income at or below
+ * the 0% upper bound is taxed at 0%.
+ *
+ * 2026 values from Rev. Proc. 2025-32:
+ *   - Single:  0% ≤ $49,450, 15% ≤ $545,500
+ *   - MFJ:     0% ≤ $98,900, 15% ≤ $613,700
+ *   - MFS:     0% ≤ $49,450, 15% ≤ $306,850
+ *   - HoH:     0% ≤ $66,200, 15% ≤ $579,600
+ */
+export var LTCG_BRACKETS_2026 = {
+  single: { zeroTop:  49450, fifteenTop: 545500 },
+  mfj:    { zeroTop:  98900, fifteenTop: 613700 },
+  mfs:    { zeroTop:  49450, fifteenTop: 306850 },
+  hoh:    { zeroTop:  66200, fifteenTop: 579600 },
+};
+
+/**
+ * Federal LTCG / qualified-dividend tax. LTCG sits on top of ordinary
+ * taxable income, so the rate that applies to each dollar of LTCG
+ * depends on where it falls in the *combined* (ordinary + LTCG) ladder.
+ *
+ * Worked example (MFJ, 2026): ordinary $80,000, LTCG $30,000.
+ *   Ordinary alone is below the $98,900 0% top — first $18,900 of LTCG
+ *   gets 0%; the remaining $11,100 falls in the 15% range. Tax =
+ *   $11,100 × 0.15 = $1,665.
+ *
+ * Returns 0 for non-positive LTCG. `ordinaryTaxableIncome` should be
+ * post-deduction (i.e. after standard / itemized deductions), since the
+ * IRS bracket thresholds are stated against taxable income.
+ *
+ * Does NOT include the 3.8% Net Investment Income Tax — call `niit()`
+ * separately and add. NIIT is MAGI-based, not taxable-income-based, so
+ * it has different inputs.
+ */
+export function ltcgFederalTax(ltcgIncome, ordinaryTaxableIncome, filingStatus) {
+  if (!(ltcgIncome > 0)) return 0;
+  var brackets = LTCG_BRACKETS_2026[filingStatus] || LTCG_BRACKETS_2026.mfj;
+  var O = Math.max(0, ordinaryTaxableIncome);
+  var L = ltcgIncome;
+  var combined = O + L;
+  // Dollars of LTCG that fall in each rate bucket (stacked on top of O).
+  // Both `inZero` and `inTwenty` need a min-with-L cap: when O already
+  // exceeds the corresponding bracket (zeroTop or fifteenTop), the raw
+  // arithmetic can return a value greater than L itself, double-counting.
+  var inZero = Math.max(0, Math.min(L, brackets.zeroTop - O));
+  var inTwenty = Math.max(0, Math.min(L, combined - brackets.fifteenTop));
+  var inFifteen = L - inZero - inTwenty;
+  return inFifteen * 0.15 + inTwenty * 0.20;
+}
+
+// ─── Net Investment Income Tax (NIIT, IRC § 1411) ────────────────────────
+//
+// 3.8% surtax on the lesser of (a) net investment income or (b) MAGI in
+// excess of a statutory threshold. Thresholds are NOT indexed for
+// inflation — they have been the same since 2013.
+
+/** Citations for the NIIT statutory threshold + rate. */
+export var NIIT_SOURCES = [
+  {
+    title: 'IRC § 1411 — Imposition of tax (Net Investment Income Tax)',
+    url: 'https://www.law.cornell.edu/uscode/text/26/1411',
+    accessed: '2026-04-30',
+  },
+  {
+    title: 'IRS Topic 559 — Net Investment Income Tax',
+    url: 'https://www.irs.gov/taxtopics/tc559',
+    accessed: '2026-04-30',
+  },
+];
+
+/** NIIT MAGI thresholds (statutory, unindexed since 2013). */
+export var NIIT_THRESHOLDS = {
+  single: 200000,
+  mfj:    250000,
+  mfs:    125000,
+  hoh:    200000,
+};
+
+/** NIIT rate — 3.8% on the lesser of net investment income or MAGI excess. */
+export var NIIT_RATE = 0.038;
+
+/**
+ * Net Investment Income Tax. 3.8% × min(netInvestmentIncome, MAGI − threshold).
+ * Returns 0 if MAGI is at or below the threshold for the filing status,
+ * or if net investment income is non-positive.
+ *
+ * `netInvestmentIncome` includes interest, dividends, LTCG/STCG, rental
+ * and royalty income (passive), and certain annuity income — but NOT
+ * wages, Social Security, qualified retirement-plan distributions, or
+ * tax-exempt municipal interest. Caller is responsible for the inclusion
+ * filter; this helper only does the surtax math.
+ */
+export function niit(netInvestmentIncome, magi, filingStatus) {
+  if (!(netInvestmentIncome > 0)) return 0;
+  var threshold = NIIT_THRESHOLDS[filingStatus] || NIIT_THRESHOLDS.mfj;
+  var excess = Math.max(0, magi - threshold);
+  return Math.min(netInvestmentIncome, excess) * NIIT_RATE;
+}
+
 /** Phased-out amount of the OBBBA senior bonus deduction at a given MAGI. */
 export function obbbaSeniorDeduction(filingStatus, age, magi, perAdult) {
   // `perAdult` = true when both MFJ spouses are 65+. Applied once per


### PR DESCRIPTION
## Summary

Adds the first piece of the tax-pipeline feature-gap todo ([Todos.md #33](../../SecondBrainData/Retirement/Todos.md)): 2026 long-term capital gains brackets and the 3.8% Net Investment Income Tax surtax.

**Pure additive — no existing call site changes.** This is a no-op until something routes LTCG income through `ltcgFederalTax()`. That wiring is #33 item 2 (income composition: split account withdrawals into ordinary vs QDI vs LTCG vs STCG and route each through the right tax pathway).

## What's added

| Export | Purpose |
|---|---|
| `LTCG_BRACKETS_2026` | 0% / 15% / 20% breakpoints for all 4 filing statuses |
| `ltcgFederalTax(ltcg, ordinary, fs)` | Stacked-on-top-of-ordinary tax calculation |
| `NIIT_THRESHOLDS`, `NIIT_RATE` | Statutory MAGI thresholds + 3.8% rate |
| `niit(nii, magi, fs)` | Lesser-of(NII, MAGI excess) × 3.8% |
| `LTCG_BRACKETS_2026_SOURCES`, `NIIT_SOURCES` | Citation arrays matching existing pattern |
| `FilingStatus` type alias | `'single' \| 'mfj' \| 'mfs' \| 'hoh'` |

## 2026 LTCG breakpoints (Rev. Proc. 2025-32)

| Filing status | 0% upper | 15% upper |
|---|---|---|
| Single | \$49,450 | \$545,500 |
| MFJ | \$98,900 | \$613,700 |
| MFS | \$49,450 | \$306,850 |
| HoH | \$66,200 | \$579,600 |

## NIIT thresholds (IRC § 1411, statutory, unindexed since 2013)

| Filing status | MAGI threshold |
|---|---|
| Single / HoH | \$200,000 |
| MFJ | \$250,000 |
| MFS | \$125,000 |

## Bracket-stacking algorithm

LTCG sits *on top of* ordinary income — the rate applied to each LTCG dollar depends on where it lands in the *combined* (ordinary + LTCG) ladder. Three buckets:

```js
// Dollars of L that fall in each rate band, given O = ordinary income.
const inZero    = max(0, min(L, zeroTop    - O));
const inTwenty  = max(0, min(L, combined   - fifteenTop));
const inFifteen = L - inZero - inTwenty;
const tax       = inFifteen * 0.15 + inTwenty * 0.20;
```

The `min(L, …)` caps on `inZero` and `inTwenty` are load-bearing: without them, when ordinary income already exceeds a bracket boundary, the raw arithmetic can exceed L itself and double-count. Initial implementation hit this for the all-20% case (ordinary \$700k, LTCG \$50k); fixed before landing.

## Verification

- [Rev. Proc. 2025-32 (IRS)](https://www.irs.gov/pub/irs-drop/rp-25-32.pdf) — primary source
- [Tax Foundation 2026 brackets](https://taxfoundation.org/data/all/federal/2026-tax-brackets/) — cross-checked all 4 statuses
- [IRC § 1(h)](https://www.law.cornell.edu/uscode/text/26/1) — statutory bracket structure
- [IRC § 1411](https://www.law.cornell.edu/uscode/text/26/1411) — NIIT statute
- [IRS Topic 559](https://www.irs.gov/taxtopics/tc559) — NIIT guidance

## Test plan

- [x] `npx vitest run` — 35,447 tests pass (was 35,421, **+26 new**)
- [x] `npx tsc --noEmit` — clean
- [x] Edge cases covered: zero/negative LTCG, all-0%, all-15%, all-20%, three-way splits, single/MFS lower thresholds, fallback on unknown filing status, NIIT cap on lesser-of(NII, MAGI excess), MAGI at threshold (no NIIT)

## Out of scope

- Wiring `ltcgFederalTax` / `niit` into `calcTaxesForLocation` or the Monte Carlo kernel — that requires income-composition modeling (#33 item 2)
- HSA triple-tax-advantage (#33 item 3)
- FEIE for foreign segments (#33 item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)