### PR TITLE
feat(taxes): wire investment-income composition into calcTaxesForLocation (#33 item 2)

### DIFF
--- a/shared/__tests__/taxes.test.js
+++ b/shared/__tests__/taxes.test.js
@@ -632,4 +632,151 @@ describe('calcTaxesForLocation — investComposition routing (#33 item 2)', () =
     expect(niitDetail).toBeDefined();
     expect(niitDetail.note).toContain('200,000');
   });
+
+  // ─── Regressions for Codex findings on PR #87 ────────────────────────
+
+  describe('Codex P1: unused deduction applied to LTCG portion', () => {
+    it('low-ordinary + large-LTCG: unused deduction offsets preferential before bracket math', () => {
+      // MFJ ordinary $20k. Std deduction $32.2k → unused $12.2k.
+      // LTCG $200k → preferentialTaxable = $200k − $12.2k = $187.8k.
+      // ordinaryFedTax on AGI=0 → 0. LTCG stacked on AGI=0:
+      //   inZero  = min(187.8k, 98.9k − 0) = 98.9k → 0%
+      //   inFifteen = 187.8k − 98.9k = 88.9k → 15% = $13,335
+      //   inTwenty = 0
+      // Total federal = $13,335.
+      const result = calcTaxesForLocation(usFedOnly, 0, 20000, 200000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 200000 },
+      });
+      expect(result.federal).toBeCloseTo(13335, 2);
+    });
+
+    it('regression: prior buggy behavior would have taxed full LTCG without deduction offset', () => {
+      // Same input as the test above. Without the fix:
+      //   ltcgFederalTax(200000, 0, mfj):
+      //     inZero  = 98.9k → 0%
+      //     inFifteen = 200k − 98.9k = 101.1k → 15% = $15,165
+      //   Total = $15,165 (overstated by $1,830 vs the correct $13,335).
+      // The current (post-fix) behavior must NOT be $15,165.
+      const result = calcTaxesForLocation(usFedOnly, 0, 20000, 200000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 200000 },
+      });
+      expect(result.federal).not.toBeCloseTo(15165, 2);
+    });
+
+    it('LTCG row note surfaces the unused-deduction offset when it applies', () => {
+      const result = calcTaxesForLocation(usFedOnly, 0, 20000, 200000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 200000 },
+      });
+      const ltcgDetail = result.details.find(d => d.label === 'US Federal LTCG / QDI Tax');
+      expect(ltcgDetail).toBeDefined();
+      expect(ltcgDetail.note).toContain('unused deduction offset');
+    });
+
+    it('no offset note when ordinary income fully absorbs the deduction', () => {
+      // Ordinary $80k > $32.2k deduction → no unused. Note should NOT
+      // mention "unused deduction offset".
+      const result = calcTaxesForLocation(usFedOnly, 0, 80000, 30000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 30000 },
+      });
+      const ltcgDetail = result.details.find(d => d.label === 'US Federal LTCG / QDI Tax');
+      // ltcgDetail may not exist if all LTCG fits in 0% bracket — but in
+      // this case ordinary AGI = 80−32.2 = $47.8k, plus $30k LTCG stacks
+      // to $77.8k, all under 0% top → LTCG tax = 0. So detail row is
+      // absent. Just confirm no offset note ever surfaced.
+      if (ltcgDetail) {
+        expect(ltcgDetail.note).not.toContain('unused deduction offset');
+      }
+    });
+
+    it('unused deduction can fully zero-out preferentialTaxable (no LTCG row at all)', () => {
+      // MFJ, std deduction $32.2k, ordinary $0, LTCG $5k.
+      // unused = $32.2k. preferentialTaxable = max(0, 5k − 32.2k) = 0.
+      // → no LTCG row, no LTCG tax.
+      const result = calcTaxesForLocation(usFedOnly, 0, 0, 5000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 5000 },
+      });
+      expect(result.federal).toBe(0);
+      expect(result.details.some(d => d.label === 'US Federal LTCG / QDI Tax')).toBe(false);
+    });
+  });
+
+  describe('Codex P2: foreign tax credit preserves federal detail breakdown', () => {
+    it('FTC adds a separate negative detail row instead of mutating details[0]', () => {
+      const loc = {
+        taxes: {
+          federalIncomeTax: { foreignTaxCredit: true },
+          stateIncomeTax: { brackets: [{ min: 0, max: null, rate: 0.30 }] },
+        },
+      };
+      const result = calcTaxesForLocation(loc, 0, 0, 80000, {
+        filingStatus: 'mfj',
+      });
+      expect(result.details.some(d => d.label === 'US Foreign Tax Credit')).toBe(true);
+      const ftcRow = result.details.find(d => d.label === 'US Foreign Tax Credit');
+      // Negative amount — it's a credit
+      expect(ftcRow.amount).toBeLessThan(0);
+    });
+
+    it('detail rows reconcile to result.federal when investComposition + FTC both present', () => {
+      // MFJ ordinary $50k IRA + $40k LTCG. Std deduction $32.2k.
+      // ordinaryFedTax: AGI=$17.8k → $1,780.
+      // preferentialTaxable: $40k (no unused deduction).
+      // ltcgFedTax: stacked on $17.8k → all $40k at 0% (since $57.8k < $98.9k) = $0.
+      // niitTax: MAGI $90k < $250k MFJ threshold → $0.
+      // Pre-FTC federal = $1,780.
+      // Foreign country charges 30% state-equivalent tax on (ssTaxable + ira + invest)
+      //   = $0 + $50k + $40k = $90k → $27k state.
+      // FTC = min($27k, $1,780) = $1,780.
+      // Post-FTC federal = $0.
+      const loc = {
+        taxes: {
+          federalIncomeTax: { foreignTaxCredit: true },
+          stateIncomeTax: { brackets: [{ min: 0, max: null, rate: 0.30 }] },
+        },
+      };
+      const result = calcTaxesForLocation(loc, 0, 50000, 40000, {
+        filingStatus: 'mfj',
+        investComposition: { ltcg: 40000 },
+      });
+      // Detail rows that reflect *federal* tax components (ordinary, LTCG,
+      // NIIT, FTC) — exclude state/social/vehicle.
+      const fedComponents = result.details.filter((d) =>
+        d.label === 'US Federal Income Tax' ||
+        d.label === 'US Federal LTCG / QDI Tax' ||
+        d.label === 'US Net Investment Income Tax (NIIT)' ||
+        d.label === 'US Foreign Tax Credit'
+      );
+      const sumOfRows = fedComponents.reduce((s, d) => s + d.amount, 0);
+      // Reconciliation: sum of federal rows must equal result.federal.
+      expect(sumOfRows).toBeCloseTo(result.federal, 2);
+    });
+
+    it('does NOT mutate details[0] amount or note when FTC fires', () => {
+      // The ordinary federal row (details[0] when no rows precede it)
+      // must keep its original ordinaryFedTax amount and AGI note. The
+      // FTC effect lives in the separate FTC row.
+      const loc = {
+        taxes: {
+          federalIncomeTax: { foreignTaxCredit: true },
+          stateIncomeTax: { brackets: [{ min: 0, max: null, rate: 0.30 }] },
+        },
+      };
+      const result = calcTaxesForLocation(loc, 0, 0, 80000, {
+        filingStatus: 'mfj',
+      });
+      const ordRow = result.details.find(d => d.label === 'US Federal Income Tax');
+      expect(ordRow).toBeDefined();
+      // Pre-FTC ordinary federal: AGI $80k − $32.2k = $47.8k.
+      // 24800 * 0.10 + (47800 − 24800) * 0.12 = 2480 + 2760 = $5,240.
+      expect(ordRow.amount).toBeCloseTo(5240, 2);
+      // Note must NOT have been mutated to include "after $... foreign
+      // tax credit" — that text is gone with the new approach.
+      expect(ordRow.note).not.toContain('foreign tax credit');
+    });
+  });
 });

--- a/shared/__tests__/taxes.test.js
+++ b/shared/__tests__/taxes.test.js
@@ -480,3 +480,156 @@ describe('NIIT_THRESHOLDS / niit', () => {
     expect(niit(30000, 300000, 'bogus')).toBeCloseTo(1140, 2);
   });
 });
+
+describe('calcTaxesForLocation — investComposition routing (#33 item 2)', () => {
+  // Plain US-federal-only location for isolating the federal pipeline.
+  const usFedOnly = { taxes: { federalIncomeTax: {} } };
+
+  it('omitting investComposition matches pre-#33 behavior (back-compat)', () => {
+    // 50k IRA + 20k investIncome + no SS, MFJ, both under 65
+    const before = calcTaxesForLocation(usFedOnly, 0, 50000, 20000, {
+      filingStatus: 'mfj',
+    });
+    // Same household passing investComposition with the entire amount
+    // tagged as ordinary interest should produce the SAME federal tax.
+    const after = calcTaxesForLocation(usFedOnly, 0, 50000, 20000, {
+      filingStatus: 'mfj',
+      investComposition: { ordinaryInterest: 20000 },
+    });
+    expect(after.federal).toBeCloseTo(before.federal, 2);
+    expect(after.totalIncome).toBeCloseTo(before.totalIncome, 2);
+  });
+
+  it('all-LTCG composition routes through 0% bracket below threshold', () => {
+    // MFJ, 0% LTCG bracket top is $98,900. 50k IRA + 30k LTCG.
+    // Ordinary AGI = 50k − 32.2k = $17,800 (well under 98.9k).
+    // LTCG sits on top: ordinaryFedTax on $17,800 + LTCG taxed at 0% on
+    // the entire $30k (since $17,800 + $30,000 = $47,800 < $98,900).
+    const result = calcTaxesForLocation(usFedOnly, 0, 50000, 30000, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 30000 },
+    });
+    const ordinaryAGI = 50000 - 32200; // $17,800
+    const expectedOrdFed = ordinaryAGI * 0.10; // entirely in 10% bracket
+    expect(result.federal).toBeCloseTo(expectedOrdFed, 2);
+    // Detail row for LTCG should NOT appear (LTCG tax = 0)
+    expect(result.details.some(d => d.label === 'US Federal LTCG / QDI Tax')).toBe(false);
+  });
+
+  it('split 0%/15% LTCG when ordinary AGI is below 0% top but stack exceeds it', () => {
+    // MFJ, IRA $90k. Ordinary AGI = 90k − 32.2k = $57,800.
+    // LTCG $80k stacks on top → combined $137,800. 0% top is $98,900.
+    // First $98.9k − $57.8k = $41,100 of LTCG at 0%.
+    // Remaining $80k − $41.1k = $38,900 at 15% = $5,835.
+    const result = calcTaxesForLocation(usFedOnly, 0, 90000, 80000, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 80000 },
+    });
+    const ordinaryAGI = 90000 - 32200;
+    // Ordinary fed tax on $57,800: 24800*0.10 + (57800-24800)*0.12
+    const expectedOrdFed = 24800 * 0.10 + (ordinaryAGI - 24800) * 0.12;
+    const expectedLtcg = 38900 * 0.15;
+    expect(result.federal).toBeCloseTo(expectedOrdFed + expectedLtcg, 2);
+    expect(result.details.some(d => d.label === 'US Federal LTCG / QDI Tax')).toBe(true);
+  });
+
+  it('mixed composition: ordinary interest + STCG taxed as ordinary, LTCG/QDI preferential', () => {
+    // 40k IRA + 10k ordinary interest + 5k STCG + 8k QDI + 12k LTCG
+    // Ordinary base = 40k + 10k + 5k = $55k. AGI = 55k − 32.2k = $22.8k.
+    // Preferential = 8k + 12k = $20k.
+    // AGI $22.8k < 0% top $98.9k, AGI + preferential = $42.8k < $98.9k →
+    //   all $20k preferential at 0%.
+    const result = calcTaxesForLocation(usFedOnly, 0, 40000, 35000, {
+      filingStatus: 'mfj',
+      investComposition: { ordinaryInterest: 10000, stcg: 5000, qdi: 8000, ltcg: 12000 },
+    });
+    const expectedOrdFed = 22800 * 0.10;
+    expect(result.federal).toBeCloseTo(expectedOrdFed, 2); // LTCG = 0, NIIT = 0
+  });
+
+  it('NIIT applies above MAGI threshold', () => {
+    // MFJ NIIT threshold $250k. Construct: IRA $250k + LTCG $50k.
+    // MAGI ≈ ordinary federalTaxable ($250k) + LTCG ($50k) = $300k.
+    // Excess $50k. NII $50k. NIIT = min(50k, 50k) * 3.8% = $1,900.
+    const result = calcTaxesForLocation(usFedOnly, 0, 250000, 50000, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 50000 },
+    });
+    expect(result.details.some(d => d.label === 'US Net Investment Income Tax (NIIT)')).toBe(true);
+    const niitDetail = result.details.find(d => d.label === 'US Net Investment Income Tax (NIIT)');
+    expect(niitDetail.amount).toBeCloseTo(1900, 2);
+  });
+
+  it('NIIT does NOT apply below MAGI threshold', () => {
+    // MAGI $150k MFJ < $250k → no NIIT, even with $50k investment income.
+    const result = calcTaxesForLocation(usFedOnly, 0, 100000, 50000, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 50000 },
+    });
+    expect(result.details.some(d => d.label === 'US Net Investment Income Tax (NIIT)')).toBe(false);
+  });
+
+  it('seed-data fed-bracket override skips LTCG and NIIT (territorial systems etc.)', () => {
+    // Some locations encode their own federal regime. Don't double-tax
+    // by also applying LTCG/NIIT — those are US-federal-specific.
+    const territorial = {
+      taxes: {
+        federalIncomeTax: { brackets: [{ min: 0, max: null, rate: 0.0 }] },
+      },
+    };
+    const result = calcTaxesForLocation(territorial, 0, 100000, 200000, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 200000 },
+    });
+    expect(result.federal).toBe(0);
+    expect(result.details.some(d => d.label === 'US Federal LTCG / QDI Tax')).toBe(false);
+    expect(result.details.some(d => d.label === 'US Net Investment Income Tax (NIIT)')).toBe(false);
+  });
+
+  it('investIncome param is ignored when composition is provided (composition is authoritative)', () => {
+    // Pass investIncome=99999 but composition with $30k → final totalInvest
+    // should be $30k. Use this to confirm the composition wins.
+    const r1 = calcTaxesForLocation(usFedOnly, 0, 50000, 99999, {
+      filingStatus: 'mfj',
+      investComposition: { ordinaryInterest: 30000 },
+    });
+    const r2 = calcTaxesForLocation(usFedOnly, 0, 50000, 30000, {
+      filingStatus: 'mfj',
+      investComposition: { ordinaryInterest: 30000 },
+    });
+    expect(r1.federal).toBeCloseTo(r2.federal, 2);
+    expect(r1.totalIncome).toBeCloseTo(r2.totalIncome, 2);
+  });
+
+  it('state pipeline uses composition total (not the bogus investIncome param)', () => {
+    const stateLoc = {
+      taxes: {
+        federalIncomeTax: {},
+        stateIncomeTax: {
+          label: 'Test State',
+          brackets: [{ min: 0, max: null, rate: 0.05 }],
+        },
+      },
+    };
+    // Pass investIncome=99999 but composition $20k LTCG. State bracket
+    // should tax against $20k (+ IRA + 85% SS), NOT $99,999.
+    const result = calcTaxesForLocation(stateLoc, 0, 30000, 99999, {
+      filingStatus: 'mfj',
+      investComposition: { ltcg: 20000 },
+    });
+    // State income = IRA $30k + LTCG $20k = $50k → state tax $2,500.
+    expect(result.state).toBeCloseTo(2500, 2);
+  });
+
+  it('NIIT detail row references the right threshold for the filing status', () => {
+    // Single threshold $200k. MAGI $250k single → excess $50k.
+    // NII $30k → NIIT = $1,140. Note should reference $200,000.
+    const result = calcTaxesForLocation(usFedOnly, 0, 220000, 30000, {
+      filingStatus: 'single',
+      investComposition: { ordinaryInterest: 30000 },
+    });
+    const niitDetail = result.details.find(d => d.label === 'US Net Investment Income Tax (NIIT)');
+    expect(niitDetail).toBeDefined();
+    expect(niitDetail.note).toContain('200,000');
+  });
+});

--- a/shared/taxes.d.ts
+++ b/shared/taxes.d.ts
@@ -97,9 +97,41 @@ export function niit(
 
 export function calcBracketTax(income: number, brackets: TaxBracket[]): number;
 
+/**
+ * Splits investment income into tax-treatment components. When provided
+ * to `calcTaxesForLocation` via `opts.investComposition`, this is
+ * AUTHORITATIVE — the `investIncome` positional argument is ignored and
+ * totals are derived from the components below.
+ */
+export interface InvestComposition {
+  /** Long-term capital gains. Routed through 0%/15%/20% LTCG brackets. */
+  ltcg?: number;
+  /** Qualified dividends. Same preferential treatment as LTCG. */
+  qdi?: number;
+  /** Bond/cash interest, non-qualified dividends. Ordinary brackets. */
+  ordinaryInterest?: number;
+  /** Short-term capital gains. Ordinary brackets. */
+  stcg?: number;
+}
+
+export interface CalcTaxesOptions {
+  filingStatus?: FilingStatus;
+  primaryAge?: number;
+  spouseAge?: number;
+  /**
+   * Optional income-composition split. When provided, ordinary interest
+   * + STCG join SS / IRA in the ordinary-bracket pipeline; LTCG + QDI
+   * are stacked on top via the LTCG ladder; and NIIT 3.8% applies to
+   * the lesser of total investment income or MAGI excess. When omitted,
+   * the entire `investIncome` is treated as ordinary (back-compat).
+   */
+  investComposition?: InvestComposition;
+}
+
 export function calcTaxesForLocation(
   loc: LocationWithTaxes,
   ssIncome: number,
   iraIncome: number,
   investIncome: number,
+  opts?: CalcTaxesOptions,
 ): TaxResult | null;

--- a/shared/taxes.js
+++ b/shared/taxes.js
@@ -296,6 +296,12 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   fedDeduction += seniorDeduction;
 
   var fedAGI = Math.max(0, ordinaryFederalTaxableIncome - fedDeduction);
+  // When the standard / itemized deduction exceeds ordinary income, the
+  // unused portion offsets LTCG/QDI before bracket math (IRS Schedule D
+  // Tax Worksheet, line 11). Without this, low-ordinary-income +
+  // large-LTCG households get overtaxed. (Codex P1 on PR #87.)
+  var unusedDeduction = Math.max(0, fedDeduction - ordinaryFederalTaxableIncome);
+  var preferentialTaxable = Math.max(0, ltcgPortion - unusedDeduction);
   var fedBrackets;
   if (taxes.federalIncomeTax && taxes.federalIncomeTax.brackets) {
     // Seed-data override — for locations that want to simulate a different
@@ -311,8 +317,8 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   // jurisdictions have their own capital-gains regime.
   var ltcgFedTax = 0;
   var niitTax = 0;
-  if (ic && ltcgPortion > 0 && !(taxes.federalIncomeTax && taxes.federalIncomeTax.brackets)) {
-    ltcgFedTax = ltcgFederalTax(ltcgPortion, fedAGI, filingStatus);
+  if (ic && preferentialTaxable > 0 && !(taxes.federalIncomeTax && taxes.federalIncomeTax.brackets)) {
+    ltcgFedTax = ltcgFederalTax(preferentialTaxable, fedAGI, filingStatus);
   }
   // NIIT 3.8% — applies to ALL net investment income (LTCG + QDI + ordinary
   // interest + STCG), gated on MAGI. Standalone surtax, statutory unindexed
@@ -331,10 +337,14 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
     note: deductionNote,
   });
   if (ltcgFedTax > 0) {
+    var ltcgNote = '$' + Math.round(preferentialTaxable).toLocaleString() + ' at 0%/15%/20% (Rev Proc 2025-32, stacked on AGI)';
+    if (unusedDeduction > 0 && preferentialTaxable < ltcgPortion) {
+      ltcgNote += ' — $' + Math.round(unusedDeduction).toLocaleString() + ' unused deduction offset against LTCG';
+    }
     result.details.push({
       label: 'US Federal LTCG / QDI Tax',
       amount: ltcgFedTax,
-      note: '$' + Math.round(ltcgPortion).toLocaleString() + ' at 0%/15%/20% (Rev Proc 2025-32, stacked on AGI)',
+      note: ltcgNote,
     });
   }
   if (niitTax > 0) {
@@ -375,12 +385,22 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
       result.details.push({ label: stLabel, amount: result.state, note: st.exemptions || '' });
     }
 
-    // Foreign tax credit
+    // Foreign tax credit (IRC § 901). Reduces total US federal liability
+    // by the lesser of (host country tax, US federal tax). Modeled as a
+    // separate negative detail row rather than mutating `details[0]` —
+    // when investComposition is provided, `details[0]` is the ordinary
+    // federal row only, with separate LTCG/NIIT rows after it. Mutating
+    // `details[0].amount = result.federal` (post-FTC total) would break
+    // reconciliation between the row breakdown and `result.federal`.
+    // (Codex P2 on PR #87.)
     if (taxes.federalIncomeTax && taxes.federalIncomeTax.foreignTaxCredit && result.state > 0) {
       var ftc = Math.min(result.state, result.federal);
       result.federal = Math.max(0, result.federal - ftc);
-      result.details[0].amount = result.federal;
-      result.details[0].note += ' (after $' + Math.round(ftc).toLocaleString() + ' foreign tax credit)';
+      result.details.push({
+        label: 'US Foreign Tax Credit',
+        amount: -ftc,
+        note: '$' + Math.round(ftc).toLocaleString() + ' offset against state/foreign income tax (IRC § 901)',
+      });
     }
   } else if (st && st.type === 'none') {
     result.details.push({ label: 'State Income Tax', amount: 0, note: st.exemptions || 'No state income tax' });

--- a/shared/taxes.js
+++ b/shared/taxes.js
@@ -240,7 +240,28 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   var filingStatus = (opts && opts.filingStatus) || 'mfj';
   var primaryAge = opts && opts.primaryAge;
   var spouseAge = opts && opts.spouseAge;
-  var totalIncome = ssIncome + iraIncome + investIncome;
+
+  // Income-composition routing (#33 item 2): when `opts.investComposition`
+  // is provided, split investIncome into its tax-treatment components.
+  //   - `ltcg` + `qdi`            → preferential 0%/15%/20% LTCG ladder
+  //   - `ordinaryInterest` + `stcg` → ordinary brackets (same as iraIncome)
+  // When composition is provided it is AUTHORITATIVE — `investIncome` is
+  // ignored, and the totals are derived from the composition components.
+  // When composition is omitted, behavior matches the pre-#33 path:
+  // entire investIncome flows through ordinary brackets (back-compat).
+  var ic = opts && opts.investComposition;
+  var ltcgPortion = 0;          // ltcg + qdi → LTCG bracket ladder
+  var ordinaryInvest = 0;       // ordinaryInterest + stcg → ordinary brackets
+  var totalInvest;
+  if (ic) {
+    ltcgPortion    = (ic.ltcg || 0) + (ic.qdi || 0);
+    ordinaryInvest = (ic.ordinaryInterest || 0) + (ic.stcg || 0);
+    totalInvest    = ltcgPortion + ordinaryInvest;
+  } else {
+    ordinaryInvest = investIncome;
+    totalInvest    = investIncome;
+  }
+  var totalIncome = ssIncome + iraIncome + totalInvest;
   var result = { federal: 0, state: 0, socialCharges: 0, salesVat: 0, vehicleTax: 0, total: 0, details: [] };
 
   // Federal income tax (US citizens everywhere)
@@ -250,25 +271,31 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   // for location-comparison cost-of-living math where the heuristic is
   // acceptable. See docs/METHODOLOGY.md §2.
   var ssTaxable = ssIncome * 0.85;
-  var federalTaxableIncome = ssTaxable + iraIncome + investIncome;
+  // Ordinary-bracket base = SS taxable portion + IRA + ordinary investment.
+  // LTCG/QDI is excluded here — it's taxed separately on top of this.
+  var ordinaryFederalTaxableIncome = ssTaxable + iraIncome + ordinaryInvest;
+  // MAGI for OBBBA phase-out + NIIT threshold uses the FULL income (incl.
+  // LTCG/QDI). Without FEIE in this model, MAGI ≈ AGI here; close enough
+  // for retirement planning cost-comparison math.
+  var magi = ordinaryFederalTaxableIncome + ltcgPortion;
   var fedDeduction = (taxes.federalIncomeTax && taxes.federalIncomeTax.standardDeduction)
     || FED_STD_DEDUCTION_2026[filingStatus]
     || FED_STD_DEDUCTION_2026.mfj;
 
   // OBBBA senior bonus deduction (2025–2028). Applied once per qualifying
-  // adult aged 65+, subject to MAGI phase-out. Uses federalTaxableIncome
-  // as the MAGI approximation — exact OBBBA MAGI definition includes
-  // foreign-income add-backs which this model doesn't carry.
+  // adult aged 65+, subject to MAGI phase-out. Uses MAGI (which includes
+  // LTCG/QDI when composition is provided) — closer to the statutory
+  // definition than the prior pure-ordinary base.
   var seniorDeduction = 0;
   if (primaryAge && primaryAge >= 65) {
-    seniorDeduction += obbbaSeniorDeduction(filingStatus, primaryAge, federalTaxableIncome);
+    seniorDeduction += obbbaSeniorDeduction(filingStatus, primaryAge, magi);
   }
   if (filingStatus === 'mfj' && spouseAge && spouseAge >= 65) {
-    seniorDeduction += obbbaSeniorDeduction(filingStatus, spouseAge, federalTaxableIncome);
+    seniorDeduction += obbbaSeniorDeduction(filingStatus, spouseAge, magi);
   }
   fedDeduction += seniorDeduction;
 
-  var fedAGI = Math.max(0, federalTaxableIncome - fedDeduction);
+  var fedAGI = Math.max(0, ordinaryFederalTaxableIncome - fedDeduction);
   var fedBrackets;
   if (taxes.federalIncomeTax && taxes.federalIncomeTax.brackets) {
     // Seed-data override — for locations that want to simulate a different
@@ -277,20 +304,58 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   } else {
     fedBrackets = filingStatus === 'single' ? FED_BRACKETS_2026_SINGLE : FED_BRACKETS_2026_MFJ;
   }
-  result.federal = calcBracketTax(fedAGI, fedBrackets);
+  var ordinaryFedTax = calcBracketTax(fedAGI, fedBrackets);
+  // LTCG/QDI portion (only when composition provided). Stacked on top of
+  // ordinary AGI per IRC § 1(h). When the seed data overrides the federal
+  // brackets entirely (territorial systems etc.), skip LTCG too — those
+  // jurisdictions have their own capital-gains regime.
+  var ltcgFedTax = 0;
+  var niitTax = 0;
+  if (ic && ltcgPortion > 0 && !(taxes.federalIncomeTax && taxes.federalIncomeTax.brackets)) {
+    ltcgFedTax = ltcgFederalTax(ltcgPortion, fedAGI, filingStatus);
+  }
+  // NIIT 3.8% — applies to ALL net investment income (LTCG + QDI + ordinary
+  // interest + STCG), gated on MAGI. Standalone surtax, statutory unindexed
+  // thresholds. Only applied when income composition is provided (caller
+  // opted into the richer model).
+  if (ic && totalInvest > 0 && !(taxes.federalIncomeTax && taxes.federalIncomeTax.brackets)) {
+    niitTax = niit(totalInvest, magi, filingStatus);
+  }
+  result.federal = ordinaryFedTax + ltcgFedTax + niitTax;
   var deductionNote = 'AGI $' + Math.round(fedAGI).toLocaleString() + ' after $' + fedDeduction.toLocaleString() + ' standard deduction';
   if (seniorDeduction > 0) {
     deductionNote += ' (includes $' + seniorDeduction.toLocaleString() + ' OBBBA senior bonus)';
   }
   result.details.push({
-    label: 'US Federal Income Tax', amount: result.federal,
+    label: 'US Federal Income Tax', amount: ordinaryFedTax,
     note: deductionNote,
   });
+  if (ltcgFedTax > 0) {
+    result.details.push({
+      label: 'US Federal LTCG / QDI Tax',
+      amount: ltcgFedTax,
+      note: '$' + Math.round(ltcgPortion).toLocaleString() + ' at 0%/15%/20% (Rev Proc 2025-32, stacked on AGI)',
+    });
+  }
+  if (niitTax > 0) {
+    result.details.push({
+      label: 'US Net Investment Income Tax (NIIT)',
+      amount: niitTax,
+      note: '3.8% on lesser of net investment income ($' + Math.round(totalInvest).toLocaleString() + ') or MAGI excess over $' + (NIIT_THRESHOLDS[filingStatus] || NIIT_THRESHOLDS.mfj).toLocaleString(),
+    });
+  }
 
   // State/country income tax
+  // State pipeline uses `totalInvest` rather than `investIncome` so that
+  // when income composition is provided (federal mode), the state base
+  // also reflects the composition's actual investment-income total.
+  // Most US states tax LTCG as ordinary at the state level — that's
+  // intentional here. The handful of states with preferential LTCG
+  // treatment (e.g. WA capital-gains-only tax, MA STCG surtax) encode
+  // those rules in their seed data.
   var st = taxes.stateIncomeTax;
   if (st && st.brackets && st.brackets.length > 0) {
-    var stateIncome = iraIncome + investIncome;
+    var stateIncome = iraIncome + totalInvest;
     if (!taxes.ssExempt && !taxes.ssTaxedInCountry) {
       stateIncome += ssTaxable;
     }
@@ -298,7 +363,7 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
     var stateAGI = Math.max(0, stateIncome - stDeduction);
 
     if (taxes.retirementExempt) {
-      stateAGI = Math.max(0, investIncome - stDeduction);
+      stateAGI = Math.max(0, totalInvest - stDeduction);
       result.state = calcBracketTax(stateAGI, st.brackets);
       result.details.push({
         label: (st.label || 'State Income Tax'), amount: result.state,
@@ -323,9 +388,10 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
     result.details.push({ label: st.label || 'Local Income Tax', amount: 0, note: st.exemptions || 'Territorial system: foreign income not taxed' });
   }
 
-  // Social charges (France CSM etc.)
+  // Social charges (France CSM etc.) — uses totalInvest for the same
+  // reason as the state pipeline above.
   if (taxes.socialCharges && taxes.socialCharges.rate > 0) {
-    var scBase = iraIncome + investIncome;
+    var scBase = iraIncome + totalInvest;
     var scThreshold = taxes.socialCharges.annualThreshold || 0;
     var scTaxable = Math.max(0, scBase - scThreshold);
     result.socialCharges = scTaxable * taxes.socialCharges.rate;


### PR DESCRIPTION
## Summary

Wires the LTCG / NIIT helpers from [#86](https://github.com/justice8096/retirement-api/pull/86) into the main tax pipeline by adding an optional `investComposition` parameter to `calcTaxesForLocation`. When provided, investment income is split by tax-treatment component and routed through the correct pathway:

| Component | Pathway |
|---|---|
| `ltcg` + `qdi` | 0%/15%/20% LTCG ladder (stacked on ordinary AGI) |
| `ordinaryInterest` + `stcg` | Ordinary brackets (joined with SS + IRA) |
| All four | NIIT 3.8% surtax above MAGI threshold |

When the parameter is omitted, behavior is **unchanged**: the entire `investIncome` flows through ordinary brackets exactly as before. All 55 pre-existing tests pass without modification, confirming back-compat.

## Architecture note

[Code-explorer dive](https://github.com/justice8096/retirement-api/pull/86) revealed that the Monte Carlo kernel itself is tax-agnostic — it consumes a pre-baked `monthlyIncomeTax` field on each `LocationMove` segment, computed offline by `calcTaxesForLocation`. So this PR completes the federal-side income-composition routing. A follow-up will pass the composition from whoever constructs the `LocationMove` once households have their account-mix configured.

## API contract

```ts
calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, {
  filingStatus: 'mfj',
  primaryAge: 67,
  investComposition: {
    ltcg: 12000,             // qualified LTCG → ltcgFederalTax
    qdi: 3000,               // qualified dividends → ltcgFederalTax
    ordinaryInterest: 1000,  // bond interest, non-qual divs → ordinary
    stcg: 2000,              // short-term gains → ordinary
  },
})
```

When `investComposition` is provided, it is **authoritative** — the positional `investIncome` argument is ignored, and totals (state pipeline, social charges, totalIncome, effectiveRate) are derived from the composition sum. Documented in JSDoc.

## What changed

**Federal pipeline:**
- Ordinary base = SS taxable + IRA + (ordinaryInterest + STCG) instead of SS taxable + IRA + investIncome
- LTCG/QDI stacked on AGI via `ltcgFederalTax` — only when composition provided AND the location does NOT override the federal brackets (territorial systems etc.)
- NIIT 3.8% — same gating as LTCG. Threshold lookup uses `NIIT_THRESHOLDS` by filing status
- MAGI = ordinary federalTaxableIncome + LTCG portion. Used for both OBBBA senior phase-out (closer to the statutory definition than the prior pure-ordinary base) and NIIT excess
- `result.details` now includes separate "US Federal LTCG / QDI Tax" and "US Net Investment Income Tax (NIIT)" rows when nonzero

**State + social-charges pipelines:**
- Use `totalInvest` (composition sum) instead of `investIncome`
- Most states tax LTCG as ordinary at the state level — that's intentional. States with preferential / surtax treatment (WA, MA) encode it in the seed data per-location

## Test coverage

10 new tests, all passing:

- Omitting composition matches pre-#33 behavior (back-compat)
- All-LTCG composition routes through 0% bracket below threshold
- Split 0%/15% LTCG when ordinary AGI is below 0% top but stack exceeds it
- Mixed composition with all 4 components
- NIIT applies above MAGI threshold
- NIIT does NOT apply below MAGI threshold
- Seed-data fed-bracket override skips LTCG/NIIT (territorial preserve)
- `investIncome` param is ignored when composition is provided
- State pipeline uses composition total (not the bogus `investIncome`)
- NIIT detail row references the right threshold for filing status

## Test plan

- [x] `npx vitest run` — 35,457 tests pass (was 35,447, **+10**)
- [x] `npx tsc --noEmit` — clean
- [x] All 55 existing `calcTaxesForLocation` tests pass without modification (back-compat)

## Out of scope (next on #33)

- **Caller-side wiring** — the dashboard's `LocationMove` constructor needs to pass `investComposition` based on the household's account mix (taxable brokerage % vs IRA % vs Roth %). This is per-household data not currently captured. Probably a separate PR with UI for setting account splits.
- **HSA triple-tax-advantage** (#33 item 3) — needs its own balance bucket in MC state
- **FEIE for foreign segments** (#33 item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)