### PR TITLE
fix(taxes): harden filing-status lookups against prototype keys

### DIFF
--- a/shared/__tests__/taxes.test.js
+++ b/shared/__tests__/taxes.test.js
@@ -903,3 +903,81 @@ describe('ltcgHarvestingSummary (#27)', () => {
     expect(s.zeroTop).toBe(98900);
   });
 });
+
+describe('Codex P2: filing-status lookup hardened against prototype keys', () => {
+  // Without an own-property check, `table[filingStatus]` for keys like
+  // 'toString' / '__proto__' / 'constructor' resolves to inherited Object
+  // methods, which are truthy and bypass the `|| fallback` shortcut. That
+  // produces undefined bracket data and NaN downstream. The fix uses
+  // Object.prototype.hasOwnProperty.call so prototype keys correctly fall
+  // back to the documented default.
+
+  it.each(['toString', '__proto__', 'constructor', 'valueOf', 'hasOwnProperty'])(
+    'ltcgFederalTax falls back to MFJ on prototype key %s',
+    (key) => {
+      // Same MFJ-fallback behavior as the existing 'bogus' test:
+      // ordinary $120k > $98.9k → no 0% room. $30k LTCG all at 15% = $4,500.
+      expect(ltcgFederalTax(30000, 120000, key)).toBeCloseTo(4500, 2);
+    },
+  );
+
+  it.each(['toString', '__proto__', 'constructor'])(
+    'niit falls back to MFJ on prototype key %s',
+    (key) => {
+      // MFJ threshold $250k. MAGI $300k → excess $50k. NII $30k → $1,140.
+      expect(niit(30000, 300000, key)).toBeCloseTo(1140, 2);
+    },
+  );
+
+  it.each(['toString', '__proto__', 'constructor'])(
+    'ltcgZeroBracketHeadroom falls back to MFJ on prototype key %s',
+    (key) => {
+      // MFJ 0% top is $98,900. $40k ordinary → $58,900 headroom.
+      expect(ltcgZeroBracketHeadroom(40000, key)).toBe(58900);
+    },
+  );
+
+  it.each(['toString', '__proto__', 'constructor'])(
+    'ltcgHarvestingSummary falls back to MFJ on prototype key %s',
+    (key) => {
+      const s = ltcgHarvestingSummary(0, key);
+      expect(s.filingStatus).toBe('mfj');
+      expect(s.zeroTop).toBe(98900);
+      expect(s.fifteenTop).toBe(613700);
+      expect(s.zeroBracketHeadroom).toBe(98900);
+      // Critical: no NaN propagation. Pre-fix this would have been NaN.
+      expect(Number.isFinite(s.zeroBracketHeadroom)).toBe(true);
+      expect(Number.isFinite(s.fifteenBracketHeadroom)).toBe(true);
+    },
+  );
+
+  it('obbbaSeniorDeduction falls back to single on prototype key', () => {
+    // Single phaseout: start $75k. Below $75k → full $6,000 deduction.
+    expect(obbbaSeniorDeduction('toString', 70, 50000)).toBe(6000);
+    expect(obbbaSeniorDeduction('__proto__', 70, 50000)).toBe(6000);
+  });
+
+  it('calcTaxesForLocation falls back to MFJ standard deduction on prototype key', () => {
+    // MFJ default std deduction is $32,200. With ira $50k → AGI $17,800
+    // → 10% bracket → $1,780.
+    const loc = { taxes: {} };
+    const result = calcTaxesForLocation(loc, 0, 50000, 0, { filingStatus: 'toString' });
+    // Without the fix, result.federal would be NaN (deduction=undefined).
+    expect(Number.isFinite(result.federal)).toBe(true);
+    expect(result.federal).toBeCloseTo(1780, 2);
+  });
+
+  it('calcTaxesForLocation NIIT note text uses MFJ threshold on prototype key', () => {
+    // Without the fix, the .toLocaleString() call on the lookup result
+    // would either crash (toLocaleString on a function) or produce wrong
+    // text. With the fix, the note references "$250,000" (MFJ NIIT threshold).
+    const usFedOnly = { taxes: { federalIncomeTax: {} } };
+    const result = calcTaxesForLocation(usFedOnly, 0, 250000, 50000, {
+      filingStatus: 'toString',
+      investComposition: { ltcg: 50000 },
+    });
+    const niitDetail = result.details.find(d => d.label === 'US Net Investment Income Tax (NIIT)');
+    expect(niitDetail).toBeDefined();
+    expect(niitDetail.note).toContain('250,000');
+  });
+});

--- a/shared/taxes.js
+++ b/shared/taxes.js
@@ -9,6 +9,24 @@ export function calcBracketTax(income, brackets) {
   return tax;
 }
 
+/**
+ * Safe filing-status table lookup. Returns `table[filingStatus]` only when
+ * `filingStatus` is an own-property of the table; otherwise returns
+ * `table[fallbackKey]`. Guards against prototype keys like `'toString'`,
+ * `'__proto__'`, `'constructor'` — without an own-property check, those
+ * resolve to inherited Object methods, which are truthy and bypass the
+ * `|| fallback` shortcut, causing downstream `undefined`/NaN propagation.
+ *
+ * Used by every helper in this module that branches on filing status, to
+ * keep the documented "unknown status falls back to MFJ (or single, for
+ * OBBBA)" contract from breaking on prototype-key inputs.
+ */
+function pickByFilingStatus(table, filingStatus, fallbackKey) {
+  return Object.prototype.hasOwnProperty.call(table, filingStatus)
+    ? table[filingStatus]
+    : table[fallbackKey];
+}
+
 // ─── 2026 tax constants (US) ────────────────────────────────────────────
 //
 // Sources: see structured arrays (FED_BRACKETS_2026_SOURCES,
@@ -157,7 +175,7 @@ export var LTCG_BRACKETS_2026 = {
  */
 export function ltcgFederalTax(ltcgIncome, ordinaryTaxableIncome, filingStatus) {
   if (!(ltcgIncome > 0)) return 0;
-  var brackets = LTCG_BRACKETS_2026[filingStatus] || LTCG_BRACKETS_2026.mfj;
+  var brackets = pickByFilingStatus(LTCG_BRACKETS_2026, filingStatus, 'mfj');
   var O = Math.max(0, ordinaryTaxableIncome);
   var L = ltcgIncome;
   var combined = O + L;
@@ -215,7 +233,7 @@ export var NIIT_RATE = 0.038;
  */
 export function niit(netInvestmentIncome, magi, filingStatus) {
   if (!(netInvestmentIncome > 0)) return 0;
-  var threshold = NIIT_THRESHOLDS[filingStatus] || NIIT_THRESHOLDS.mfj;
+  var threshold = pickByFilingStatus(NIIT_THRESHOLDS, filingStatus, 'mfj');
   var excess = Math.max(0, magi - threshold);
   return Math.min(netInvestmentIncome, excess) * NIIT_RATE;
 }
@@ -245,7 +263,7 @@ export function niit(netInvestmentIncome, magi, filingStatus) {
  * the 0% bracket top — the next dollar of LTCG would be at 15% or 20%.
  */
 export function ltcgZeroBracketHeadroom(ordinaryTaxableIncome, filingStatus, alreadyPreferential) {
-  var brackets = LTCG_BRACKETS_2026[filingStatus] || LTCG_BRACKETS_2026.mfj;
+  var brackets = pickByFilingStatus(LTCG_BRACKETS_2026, filingStatus, 'mfj');
   var O = Math.max(0, ordinaryTaxableIncome);
   var P = Math.max(0, alreadyPreferential || 0);
   return Math.max(0, brackets.zeroTop - O - P);
@@ -270,7 +288,7 @@ export function ltcgZeroBracketHeadroom(ordinaryTaxableIncome, filingStatus, alr
  * amount, use `ltcgFederalTax(amount, ordinaryTaxableIncome + alreadyPreferential, fs)`.
  */
 export function ltcgHarvestingSummary(ordinaryTaxableIncome, filingStatus, alreadyPreferential) {
-  var brackets = LTCG_BRACKETS_2026[filingStatus] || LTCG_BRACKETS_2026.mfj;
+  var brackets = pickByFilingStatus(LTCG_BRACKETS_2026, filingStatus, 'mfj');
   var O = Math.max(0, ordinaryTaxableIncome);
   var P = Math.max(0, alreadyPreferential || 0);
   var stackBase = O + P;
@@ -284,7 +302,7 @@ export function ltcgHarvestingSummary(ordinaryTaxableIncome, filingStatus, alrea
   else if (stackBase < brackets.fifteenTop) marginal = 0.15;
   else                                      marginal = 0.20;
   return {
-    filingStatus: filingStatus in LTCG_BRACKETS_2026 ? filingStatus : 'mfj',
+    filingStatus: Object.prototype.hasOwnProperty.call(LTCG_BRACKETS_2026, filingStatus) ? filingStatus : 'mfj',
     zeroTop: brackets.zeroTop,
     fifteenTop: brackets.fifteenTop,
     alreadyPreferential: P,
@@ -299,7 +317,7 @@ export function obbbaSeniorDeduction(filingStatus, age, magi, perAdult) {
   // `perAdult` = true when both MFJ spouses are 65+. Applied once per
   // qualifying adult. Caller is responsible for counting adults.
   if (age === undefined || age < 65) return 0;
-  var band = OBBBA_SENIOR_PHASEOUT[filingStatus] || OBBBA_SENIOR_PHASEOUT.single;
+  var band = pickByFilingStatus(OBBBA_SENIOR_PHASEOUT, filingStatus, 'single');
   if (magi <= band.start) return OBBBA_SENIOR_DEDUCTION_AMOUNT;
   if (magi >= band.end)   return 0;
   var phaseRange = band.end - band.start;
@@ -353,8 +371,7 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
   // for retirement planning cost-comparison math.
   var magi = ordinaryFederalTaxableIncome + ltcgPortion;
   var fedDeduction = (taxes.federalIncomeTax && taxes.federalIncomeTax.standardDeduction)
-    || FED_STD_DEDUCTION_2026[filingStatus]
-    || FED_STD_DEDUCTION_2026.mfj;
+    || pickByFilingStatus(FED_STD_DEDUCTION_2026, filingStatus, 'mfj');
 
   // OBBBA senior bonus deduction (2025–2028). Applied once per qualifying
   // adult aged 65+, subject to MAGI phase-out. Uses MAGI (which includes
@@ -425,7 +442,7 @@ export function calcTaxesForLocation(loc, ssIncome, iraIncome, investIncome, opt
     result.details.push({
       label: 'US Net Investment Income Tax (NIIT)',
       amount: niitTax,
-      note: '3.8% on lesser of net investment income ($' + Math.round(totalInvest).toLocaleString() + ') or MAGI excess over $' + (NIIT_THRESHOLDS[filingStatus] || NIIT_THRESHOLDS.mfj).toLocaleString(),
+      note: '3.8% on lesser of net investment income ($' + Math.round(totalInvest).toLocaleString() + ') or MAGI excess over $' + pickByFilingStatus(NIIT_THRESHOLDS, filingStatus, 'mfj').toLocaleString(),
     });
   }
 


### PR DESCRIPTION
## Context

Codex P2 finding on the now-merged [#88](https://github.com/justice8096/retirement-api/pull/88) (LTCG harvesting helpers). Codex flagged the issue *after* #88 merged, so this is a follow-up PR rather than an amendment.

## The bug

`LTCG_BRACKETS_2026[filingStatus] || LTCG_BRACKETS_2026.mfj` short-circuits incorrectly when `filingStatus` is a prototype key like `'toString'`, `'__proto__'`, `'constructor'`, etc. The bracket access resolves to an inherited Object method (truthy), bypassing the `|| fallback` shortcut. Then `brackets.zeroTop` is `undefined` and NaN propagates through the math.

The same `table[fs] || table.mfj` pattern lived at **7 call sites** in `shared/taxes.js`:

- `ltcgFederalTax` (#86)
- `niit` (#86)
- `obbbaSeniorDeduction` (pre-existing)
- `ltcgZeroBracketHeadroom` (#88)
- `ltcgHarvestingSummary` (#88)
- `calcTaxesForLocation` — `FED_STD_DEDUCTION_2026` lookup
- `calcTaxesForLocation` — NIIT note-text threshold lookup

Plus one `filingStatus in LTCG_BRACKETS_2026` echo-back in `ltcgHarvestingSummary` (the `in` operator has the same prototype-walking behavior).

TypeScript callers can't pass these values (`FilingStatus = 'single' | 'mfj' | 'mfs' | 'hoh'`), so production callers don't hit it. But JS callers can, the contract is documented, and existing tests pin the fallback behavior — so this is a real correctness gap.

## Fix

Single internal helper, replaces every site:

```js
function pickByFilingStatus(table, filingStatus, fallbackKey) {
  return Object.prototype.hasOwnProperty.call(table, filingStatus)
    ? table[filingStatus]
    : table[fallbackKey];
}
```

Plus the `in` check replaced by `Object.prototype.hasOwnProperty.call(...)`.

This delivers the documented "unknown status falls back to MFJ (or single, for OBBBA)" contract for **all** inputs, including prototype keys.

## Tests

17 new regression tests using `it.each(['toString', '__proto__', 'constructor', 'valueOf', 'hasOwnProperty'])` lock the contract for each affected helper:

- `ltcgFederalTax` falls back to MFJ on prototype key (5 cases)
- `niit` falls back to MFJ on prototype key (3 cases)
- `ltcgZeroBracketHeadroom` falls back to MFJ on prototype key (3 cases)
- `ltcgHarvestingSummary` falls back to MFJ + asserts no NaN propagation (3 cases)
- `obbbaSeniorDeduction` falls back to single on prototype key (2 cases)
- `calcTaxesForLocation` produces finite federal + correct NIIT note text on prototype key (2 cases)

## Test plan

- [x] `npx vitest run` — 35,499 tests pass (was 35,482, **+17 new**)
- [x] `npx tsc --noEmit` — clean
- [x] Cherry-picked cleanly onto fresh master after #88 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)