### PR TITLE
feat(pentest): add ZAP + Shodan runtime attack-surface scan container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,10 @@ TS_AUTHKEY_FUNNEL_DASHBOARD=tskey-auth-...
 # NEVER set this in staging/prod — even if NODE_ENV is misconfigured, this guard keeps the
 # bypass path closed. Defaults to unset (auth required).
 DEV_AUTH_BYPASS=
+
+# ─── Shodan (pentest container) ──────────────────────────────────────────
+# Used by `pentest/run-scan.sh` for runtime + supply-chain attack-surface
+# checks. Free-tier account is fine (~100 queries/month). Sign up at
+# https://shodan.io and copy the API key from My Account.
+# Only required when running pentest scans; safe to leave unset otherwise.
+SHODAN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ api.log
 # Local dev tooling with personal data
 check-tier.mjs
 tools/seed-dev-user.sh
+__pycache__/

--- a/docs/PENTEST.md
+++ b/docs/PENTEST.md
@@ -1,0 +1,92 @@
+# Pentest operations
+
+Operational runbook for the runtime + supply-chain attack-surface scans of the rogue deploy. The mechanics live in [`pentest/`](../pentest/README.md); this doc covers cadence, triage, and what-the-findings-mean.
+
+## When to run
+
+| Trigger | Why |
+|---|---|
+| **Monthly** | Catch new CVEs against the running stack as upstream advisories drop. Free-tier Shodan budget supports 12+ runs/month. |
+| **After a major dependency bump** | nginx, postgres, redis, Tailscale, Node.js, Fastify version bump → re-baseline. |
+| **After any auth / CSP / Helmet config change** | ZAP baseline catches regressed headers / cookies / CSP directives. |
+| **Before exposing a new public endpoint** | Funnel surface change → re-run hostname + host checks. |
+| **After a security advisory hits any of our deps** | Targeted re-run of just Shodan CVE check (`shodan/check-cves.py` standalone). |
+
+## How to run
+
+From rogue (`ssh root@192.168.68.77`):
+
+```bash
+cd /srv/retirement/retirement-api/pentest
+env $(grep -v '^#' ../.env | xargs) ./run-scan.sh
+```
+
+Outputs to `/mnt/nas/disk1/containerBackup/pentest/scan-{date}/`. See [`pentest/README.md`](../pentest/README.md) for the env-var reference.
+
+## Reading the reports
+
+### `zap-*.html` — OWASP ZAP baseline (one per target)
+
+ZAP groups findings by **risk level** + **confidence**. Triage focus:
+
+| Level | Action |
+|---|---|
+| **High / Medium** | Always investigate. Most are real (missing CSP, weak ciphers, info disclosure in error pages, missing HSTS). |
+| **Low** | Skim. Common false positives: `Cookie No HttpOnly Flag` on Clerk-set cookies (Clerk handles its own CSRF), `Cross-Domain Misconfiguration` from CDN / Stripe / Clerk hosts (intentional). |
+| **Informational** | Read once, ignore in subsequent runs unless a category disappears (a header you intentionally set going missing). |
+
+Common findings on this stack and the canonical disposition:
+- `Strict-Transport-Security Header Not Set` on **LAN HTTP targets** — expected. HSTS is added only on HTTPS arrivals via the api's onSend hook (see retirement-api PR #84). LAN HTTP probes intentionally don't get HSTS.
+- `Content-Security-Policy: upgrade-insecure-requests Not Set` on **LAN HTTP targets** — same. Added only on HTTPS via the same hook (PR #84).
+- `Cookie No HttpOnly Flag` on `__clerk_db_jwt` — Clerk's design; not a finding.
+- `307 Temporary Redirect` chain pointing at `*.clerk.accounts.dev` — only on dev Clerk keys. PR #85 + PR #87 added an `Accept`-header guard for known-public paths to suppress this. Persistent presence on a non-public path is a finding.
+
+### `shodan-cves.json` + `.txt`
+
+Per-service CVE list. Triage:
+- `cves: []` → service is clean per Shodan's vuln DB. Good.
+- Non-empty → cross-check the CVE IDs against:
+  - The upstream changelog (was the version we pin actually patched?)
+  - NIST NVD (`https://nvd.nist.gov/vuln/detail/CVE-XXXX-YYYY`) for severity + exploitation
+  - Whether the vulnerable code path is reachable in our config
+
+Free-tier Shodan returns 5 example matches per query — `shodanHostCount` shows how many vulnerable hosts Shodan has globally indexed running this exact version. High counts mean an actively-exploited surface. Low/zero counts may mean the version is fresh enough that scanners haven't caught up — not necessarily safe.
+
+### `shodan-host.json` + `.txt`
+
+What the public internet sees on rogue's WAN IP. Expected output for a Tailscale-Funnel-only deploy:
+- `_status: "no_data"` — Shodan has never scanned the IP. Best case for a residential IP.
+- Or open ports limited to whatever the residential router exposes (often just nothing, sometimes UPnP / NAT-PMP / ISP-managed services).
+
+**Findings to escalate:**
+- Open port 80, 443, 3000, 8090 on the WAN IP → port forwarding leaked, deploy is bypassing the funnel. Audit the router immediately.
+- `vulns` array non-empty → the WAN-exposed service has a known CVE.
+- Service banners revealing internal stack details — review for info-leakage.
+
+### `shodan-hostname.json` + `.txt`
+
+What Shodan has indexed under the funnel hostname `retirement-dashboard.tailceab8.ts.net`. Expected: 0 hosts (Tailscale's edge IPs aren't typically indexed under user-tenant hostnames). Non-zero = something is publishing this hostname, worth investigating.
+
+## Free-tier Shodan budget
+
+- 100 queries/month
+- Each `run-scan.sh` uses 8 queries (6 CVE + 1 host + 1 hostname)
+- Budget: 12 full runs/month at the free tier. Plenty for monthly + ad-hoc cadence.
+- Manual partial runs (e.g. `python shodan/check-cves.py` after a dep bump) cost 6 queries.
+
+## Storing the API key
+
+Lives in `/srv/retirement/retirement-api/.env` on rogue:
+```
+SHODAN_API_KEY=<your-personal-key>
+```
+
+Mirrored to `/mnt/nas/disk1/containerBackup/retirement-rogue-secrets.env` (root:root 0600) per the existing secrets-backup convention. **Never** commit the key — `.env` is gitignored.
+
+## What this does NOT cover
+
+By design. Out of scope here, tracked elsewhere:
+- **Authenticated scans** — ZAP doesn't sign in via Clerk. Auth-gated routes are not crawled. (Tier 2.)
+- **Active SQL injection / XSS payloads** — `zap-active` service exists but is opt-in only, gated behind a separate compose profile. Production data risk.
+- **Internal-network LAN service scan** — the focus here is what's reachable from the public internet + via the funnel. LAN-only services (Portainer, Proxmox, etc.) are scanned by Uptime Kuma for liveness, not vulnerabilities.
+- **Static SAST/DAST against the source** — handled by the existing `audits/sast-dast-scan-*.md` workflow.

--- a/pentest/README.md
+++ b/pentest/README.md
@@ -1,0 +1,87 @@
+# `pentest/` — runtime + supply-chain attack-surface scans
+
+Local pentest infrastructure for the rogue deploy. Two surfaces:
+
+| Surface | Tool | Asks |
+|---|---|---|
+| Running app behavior | **OWASP ZAP** baseline | Does the app behave securely under crawling? Headers, cookies, CSP, CORS, error leakage. |
+| Service stack | **Shodan** CVE-by-version | Are any running services known-vulnerable per Shodan's vuln DB? |
+| Public exposure | **Shodan** host scan | What does the public internet see on rogue's WAN IP? |
+| Funnel hostname | **Shodan** hostname search | Is anything indexed under our Tailscale funnel name? |
+
+Brought up only when scanning — **NOT** part of the prod stack. Reports go to `/mnt/nas/disk1/containerBackup/pentest/scan-{date}/` on rogue.
+
+## Quick start (on rogue)
+
+```bash
+ssh root@192.168.68.77
+cd /srv/retirement/retirement-api/pentest
+
+# Loads SHODAN_API_KEY + other secrets from the prod .env file
+env $(grep -v '^#' ../.env | xargs) ./run-scan.sh
+```
+
+That's it. The script:
+1. Runs OWASP ZAP baseline against funnel + LAN dashboard + LAN api (3 targets)
+2. Runs the 3 Shodan checks
+3. Writes a `summary.md` rollup with quick stats + next steps
+4. Outputs everything to `/mnt/nas/disk1/containerBackup/pentest/scan-{date}/`
+
+Open the HTML reports in a browser to triage. ZAP exit codes:
+- `0` — no findings
+- `1` — warnings (review report)
+- `2` — errors (review report; usually means crawler hit something unexpected, not necessarily a vuln)
+
+## What's where
+
+```
+pentest/
+├── docker-compose.pentest.yml   # ZAP + Shodan services (compose profile = pentest)
+├── run-scan.sh                   # one-button orchestrator
+├── services.json                 # version manifest — drives Shodan CVE check
+├── shodan/                       # Python container source
+│   ├── Dockerfile                # python:3.13-alpine + requests + shodan
+│   ├── check-cves.py             # CVE-by-version against services.json
+│   ├── check-host.py             # `shodan host <wan-ip>` — auto-detects via ifconfig.me
+│   └── check-hostname.py         # `shodan host hostname:retirement-dashboard.tailceab8.ts.net`
+└── README.md                     # this file
+```
+
+See `../docs/PENTEST.md` for cadence, triage, and operational guidance.
+
+## Required env vars
+
+| Var | Required | Purpose |
+|---|---|---|
+| `SHODAN_API_KEY` | yes | Free-tier account is fine (~100 queries/month) |
+| `PENTEST_WAN_IP` | no | Override auto-detected WAN IP for the host scan |
+| `PENTEST_HOSTNAME` | no | Override default funnel hostname |
+| `ZAP_TARGETS` | no | Comma-separated URLs (default: 3 standard targets) |
+| `REPORTS_DIR` | no | Override output directory (default: NAS path on rogue) |
+
+`SHODAN_API_KEY` lives in `/srv/retirement/retirement-api/.env` alongside the prod-stack secrets, mirrored to `/mnt/nas/disk1/containerBackup/retirement-rogue-secrets.env`.
+
+## Active scans (Tier 2 — opt-in only)
+
+The compose file has a separate `zap-active` service gated behind a `pentest-active` profile. It runs ZAP's **full** scan with active payloads (SQL injection, XSS, command injection probes). **DO NOT run against production data.** Use only on staging or with explicit authorization.
+
+```bash
+# Example — only against staging:
+TARGET=https://staging.example.com docker compose \
+  -f docker-compose.pentest.yml --profile pentest-active \
+  run --rm zap-active
+```
+
+## Free-tier Shodan limits
+
+- 100 API queries per month
+- Each `run-scan.sh` invocation uses 6 (CVEs) + 1 (host) + 1 (hostname) = **8 queries**
+- Budget: ~12 manual scans per month at the free tier
+- Membership ($59/year) bumps the limit to 10K queries/month — worth it for any scheduled cadence
+
+## Next steps for the infra (Tier 2/3)
+
+- Add Nuclei for fast template-based CVE scans (smaller signal-to-noise than ZAP)
+- Add `schemathesis` for OpenAPI-driven API fuzzing (the api already serves `/api/openapi.json`)
+- Authenticated ZAP scans — set up a dedicated test Clerk user, ZAP scripts that sign in first
+- Schedule weekly via systemd timer on rogue, alert via Uptime Kuma when finding count regresses

--- a/pentest/docker-compose.pentest.yml
+++ b/pentest/docker-compose.pentest.yml
@@ -1,0 +1,73 @@
+# Pentest container stack — runtime + supply-chain attack-surface check.
+#
+# Brought up only when scanning, NOT part of the production stack:
+#   docker compose -f docker-compose.pentest.yml run --rm <service>
+#
+# Outputs go to /mnt/nas/disk1/containerBackup/pentest/scan-{date}/ on rogue,
+# bind-mounted via the REPORTS_DIR env var (defaults to ./reports if unset).
+#
+# Services:
+#   - zap-baseline     OWASP ZAP baseline scan (passive, safe). Targets default
+#                      to the funnel URL; override via TARGET env var.
+#   - zap-active       OWASP ZAP active scan (aggressive — sends payloads).
+#                      Opt-in only. Run on staging or with explicit auth.
+#   - shodan           Python container that runs the three Shodan checks
+#                      (CVE-by-version, public-exposure, hostname).
+#
+# Standalone — does not depend on the prod compose stack. Reads
+# SHODAN_API_KEY from the same .env file as the prod stack
+# (/srv/retirement/retirement-api/.env on rogue).
+
+services:
+  zap-baseline:
+    image: zaproxy/zap-stable:2.16.1
+    profiles: [pentest]
+    environment:
+      TARGET: ${TARGET:-https://retirement-dashboard.tailceab8.ts.net}
+    volumes:
+      - ${REPORTS_DIR:-./reports}:/zap/wrk:rw
+    # `zap-baseline.py` is a passive crawl + spider that flags HTTP-header /
+    # cookie / CSP issues without sending exploit payloads. Safe to run
+    # against production endpoints. Exit codes:
+    #   0 = no issues  1 = warnings  2 = errors
+    # `-J report.json -r report.html` writes both formats to /zap/wrk.
+    command: >-
+      zap-baseline.py
+      -t ${TARGET:-https://retirement-dashboard.tailceab8.ts.net}
+      -J zap-baseline.json
+      -r zap-baseline.html
+      -I
+
+  zap-active:
+    image: zaproxy/zap-stable:2.16.1
+    profiles: [pentest-active]
+    environment:
+      TARGET: ${TARGET:-https://retirement-dashboard.tailceab8.ts.net}
+    volumes:
+      - ${REPORTS_DIR:-./reports}:/zap/wrk:rw
+    # `zap-full-scan.py` performs an active attack — sends SQL injection / XSS
+    # / command-injection payloads. DO NOT run against production. Use only
+    # on staging or against an explicitly authorized test environment. Gated
+    # behind a separate compose profile (`pentest-active`) so the default
+    # `--profile pentest` invocation can't trigger it accidentally.
+    command: >-
+      zap-full-scan.py
+      -t ${TARGET:-https://retirement-dashboard.tailceab8.ts.net}
+      -J zap-active.json
+      -r zap-active.html
+      -I
+
+  shodan:
+    build: ./shodan
+    profiles: [pentest]
+    environment:
+      SHODAN_API_KEY: ${SHODAN_API_KEY}
+      PENTEST_WAN_IP: ${PENTEST_WAN_IP:-}
+      PENTEST_HOSTNAME: ${PENTEST_HOSTNAME:-retirement-dashboard.tailceab8.ts.net}
+    volumes:
+      - ./shodan:/pentest/shodan:ro
+      - ./services.json:/pentest/services.json:ro
+      - ${REPORTS_DIR:-./reports}:/pentest/reports:rw
+    # No default command — invoked explicitly by run-scan.sh which orchestrates
+    # the three check scripts and routes their output to the reports dir.
+    command: ["-c", "echo 'Run via pentest/run-scan.sh, not docker compose run.' && exit 1"]

--- a/pentest/run-scan.sh
+++ b/pentest/run-scan.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Orchestrate a complete pentest scan run.
+#
+# Sequence:
+#   1. Run OWASP ZAP baseline scan against three targets:
+#        - funnel public HTTPS URL
+#        - LAN dashboard nginx (bypass funnel)
+#        - LAN api direct (bypass nginx)
+#   2. Run Shodan checks (CVE-by-version, public-exposure, hostname).
+#   3. Roll up findings into reports/scan-{date}/summary.md.
+#
+# Outputs to /mnt/nas/disk1/containerBackup/pentest/scan-{date}/ when run
+# on rogue. Override via REPORTS_DIR env var.
+#
+# Requires SHODAN_API_KEY in env (or in a .env file alongside this script).
+# Reads other env vars optionally:
+#   PENTEST_WAN_IP    — override auto-detected WAN IP
+#   PENTEST_HOSTNAME  — override default funnel hostname
+#   ZAP_TARGETS       — comma-separated URLs (default: 3 standard targets)
+#
+# Usage (from rogue, in /srv/retirement/retirement-api/pentest/):
+#     ./run-scan.sh
+#
+# Or from anywhere with the env file:
+#     env $(cat /srv/retirement/retirement-api/.env | xargs) ./run-scan.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# ─── Configuration ────────────────────────────────────────────────────────
+
+DATE="$(date +%Y-%m-%d)"
+DEFAULT_REPORTS_DIR="/mnt/nas/disk1/containerBackup/pentest/scan-${DATE}"
+REPORTS_DIR="${REPORTS_DIR:-${DEFAULT_REPORTS_DIR}}"
+ZAP_TARGETS="${ZAP_TARGETS:-https://retirement-dashboard.tailceab8.ts.net,http://192.168.68.77:8090,http://192.168.68.77:3000}"
+
+if [[ -z "${SHODAN_API_KEY:-}" ]]; then
+  echo "ERROR: SHODAN_API_KEY env var is not set."
+  echo "       Add it to /srv/retirement/retirement-api/.env and rerun:"
+  echo "         env \$(cat ../.env | xargs) ./run-scan.sh"
+  exit 1
+fi
+
+mkdir -p "${REPORTS_DIR}"
+export REPORTS_DIR
+
+echo "============================================================"
+echo "Pentest scan starting"
+echo "  Date:        ${DATE}"
+echo "  Reports dir: ${REPORTS_DIR}"
+echo "  ZAP targets: ${ZAP_TARGETS}"
+echo "============================================================"
+echo
+
+# ─── 1. OWASP ZAP baseline against each target ─────────────────────────────
+
+IFS=',' read -ra TARGETS <<< "${ZAP_TARGETS}"
+for target in "${TARGETS[@]}"; do
+  # Slugify target URL for the report filename — strip scheme + path, replace
+  # `:` and `/` with `-`. Keeps reports diffable across runs.
+  slug="$(echo "${target}" | sed -E 's,https?://,,; s,[:/.],-,g; s,-+,-,g; s,-+$,,')"
+  echo "▸ ZAP baseline: ${target}"
+  echo "  → reports/zap-${slug}.{html,json}"
+
+  # ZAP exit codes 1-2 are findings, not script errors — we want to continue.
+  set +e
+  TARGET="${target}" REPORTS_DIR="${REPORTS_DIR}" \
+    docker compose -f docker-compose.pentest.yml run --rm \
+      -e "TARGET=${target}" \
+      zap-baseline \
+      zap-baseline.py -t "${target}" \
+        -J "zap-${slug}.json" \
+        -r "zap-${slug}.html" \
+        -I
+  zap_exit=$?
+  set -e
+  case ${zap_exit} in
+    0) echo "  ✓ No issues" ;;
+    1) echo "  ⚠ Warnings (review report)" ;;
+    2) echo "  ✗ Errors (review report)" ;;
+    *) echo "  ? Unexpected exit ${zap_exit}" ;;
+  esac
+  echo
+done
+
+# ─── 2. Shodan checks ──────────────────────────────────────────────────────
+
+run_shodan() {
+  local script="$1"
+  local outfile="$2"
+  echo "▸ Shodan: ${script}"
+  docker compose -f docker-compose.pentest.yml run --rm \
+    --entrypoint python3 \
+    shodan \
+    "/pentest/shodan/${script}" \
+    > "${REPORTS_DIR}/${outfile}.json" \
+    2> "${REPORTS_DIR}/${outfile}.txt"
+  echo "  → reports/${outfile}.{json,txt}"
+}
+
+run_shodan check-cves.py shodan-cves
+run_shodan check-host.py shodan-host
+run_shodan check-hostname.py shodan-hostname
+
+echo
+
+# ─── 3. Summary rollup ─────────────────────────────────────────────────────
+
+cat > "${REPORTS_DIR}/summary.md" <<EOF
+# Pentest scan — ${DATE}
+
+Reports in this directory:
+- \`zap-*.html\` — OWASP ZAP baseline reports (one per target)
+- \`zap-*.json\` — same data, JSON for diffing
+- \`shodan-cves.{json,txt}\` — Shodan CVE-by-version check
+- \`shodan-host.{json,txt}\` — Shodan public-exposure scan of WAN IP
+- \`shodan-hostname.{json,txt}\` — Shodan funnel-hostname index check
+
+## Quick stats
+
+EOF
+
+# ZAP findings (count "WARN-" and "FAIL-" prefixes in JSON output).
+for f in "${REPORTS_DIR}"/zap-*.json; do
+  [[ -e "${f}" ]] || continue
+  warns=$(grep -o '"riskdesc":"Medium\|High\|Informational"' "${f}" 2>/dev/null | wc -l || echo 0)
+  fname=$(basename "${f}")
+  echo "- **${fname}**: ${warns} alerts" >> "${REPORTS_DIR}/summary.md"
+done
+
+# Shodan CVE total.
+if [[ -f "${REPORTS_DIR}/shodan-cves.json" ]]; then
+  total=$(python3 -c "import json; print(json.load(open('${REPORTS_DIR}/shodan-cves.json')).get('totalCves', 0))" 2>/dev/null || echo "?")
+  echo "- **shodan-cves.json**: ${total} total CVEs across stack" >> "${REPORTS_DIR}/summary.md"
+fi
+
+cat >> "${REPORTS_DIR}/summary.md" <<EOF
+
+## Next steps
+
+1. Open each \`zap-*.html\` in a browser and triage Medium / High alerts.
+2. Cross-check \`shodan-cves.json\` against current upstream patch state.
+3. Review \`shodan-host.txt\` — non-empty open-ports list on a Tailscale-Funnel-only deploy is a leak signal.
+
+Generated by \`pentest/run-scan.sh\`.
+EOF
+
+echo "============================================================"
+echo "Pentest scan complete"
+echo "  Reports: ${REPORTS_DIR}"
+echo "  Summary: ${REPORTS_DIR}/summary.md"
+echo "============================================================"

--- a/pentest/services.json
+++ b/pentest/services.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Version manifest for the rogue deploy stack. Drives the Shodan CVE-by-version check (pentest/shodan/check-cves.py). Update when bumping the corresponding service in docker-compose.yml or Dockerfile. Versions should match what's actually running in production, not the latest available.",
+  "_lastVerified": "2026-04-30",
+  "services": [
+    {
+      "name": "nginx",
+      "version": "1.27.5",
+      "source": "retirement-dashboard-angular/Dockerfile (alpine base)",
+      "exposed": "funnel + LAN 8090",
+      "shodanProduct": "nginx"
+    },
+    {
+      "name": "postgres",
+      "version": "16-alpine",
+      "source": "retirement-api/docker-compose.yml",
+      "exposed": "internal only (docker bridge)",
+      "shodanProduct": "PostgreSQL"
+    },
+    {
+      "name": "redis",
+      "version": "7-alpine",
+      "source": "retirement-api/docker-compose.yml",
+      "exposed": "internal only (docker bridge)",
+      "shodanProduct": "Redis"
+    },
+    {
+      "name": "tailscale",
+      "version": "stable",
+      "source": "retirement-api/docker-compose.yml (tailscale-dashboard sidecar)",
+      "exposed": "tailnet + funnel edge",
+      "shodanProduct": "Tailscale"
+    },
+    {
+      "name": "node",
+      "version": "25-alpine",
+      "source": "retirement-api/Dockerfile",
+      "exposed": "wraps Fastify api on internal network + host-mapped 3000",
+      "shodanProduct": "Node.js"
+    },
+    {
+      "name": "fastify",
+      "version": "5.x",
+      "source": "retirement-api/package.json",
+      "exposed": "api on internal network + host-mapped 3000",
+      "shodanProduct": "Fastify"
+    }
+  ]
+}

--- a/pentest/shodan/Dockerfile
+++ b/pentest/shodan/Dockerfile
@@ -1,0 +1,15 @@
+# Minimal Python container for Shodan API queries.
+# Used by the pentest/run-scan.sh orchestrator. Brought up only when scanning
+# (compose profile = pentest); not part of the production stack.
+FROM python:3.13-alpine
+
+# `requests` for the Shodan REST API; `shodan` CLI as a fallback / convenience.
+RUN pip install --no-cache-dir --root-user-action=ignore \
+    requests==2.32.3 \
+    shodan==1.31.0
+
+WORKDIR /pentest
+
+# Scripts are bind-mounted from ../shodan/ at run time so edits don't require
+# a rebuild. `services.json` is also bind-mounted (../services.json).
+ENTRYPOINT ["/bin/sh"]

--- a/pentest/shodan/check-cves.py
+++ b/pentest/shodan/check-cves.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Shodan CVE-by-version check for the rogue deploy stack.
+
+For each service listed in pentest/services.json, query Shodan's vulnerability
+database and report known CVEs. Outputs JSON to stdout and a human-readable
+summary to stderr.
+
+Free-tier Shodan accounts allow ~100 queries/month; this script issues one
+query per service in services.json. With the current 6-service manifest that's
+6 queries per scan run.
+
+Reads SHODAN_API_KEY from the environment. Exits 1 if missing.
+
+Usage:
+    python check-cves.py > cves.json 2> cves-summary.txt
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+SERVICES_JSON = Path("/pentest/services.json")
+BASE = "https://api.shodan.io"
+
+
+def err(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def get_api_key() -> str:
+    key = os.environ.get("SHODAN_API_KEY", "").strip()
+    if not key:
+        err("ERROR: SHODAN_API_KEY env var is not set.")
+        err("Add it to /srv/retirement/retirement-api/.env on rogue.")
+        sys.exit(1)
+    return key
+
+
+def search_cves(api_key: str, product: str, version: str) -> dict:
+    """Query Shodan for hosts running this product+version that have known CVEs.
+
+    Returns the raw API response. Useful surface: `matches[].vulns` lists CVE
+    IDs with severity scores. We aggregate across hosts to get a unique CVE set
+    rather than counting exposed hosts (which depends on global scan coverage,
+    not directly relevant to our own posture).
+    """
+    query = f"product:{product} version:{version} has_vuln:true"
+    r = requests.get(
+        f"{BASE}/shodan/host/search",
+        params={"key": api_key, "query": query, "limit": 5},
+        timeout=15,
+    )
+    if r.status_code == 401:
+        err("ERROR: Shodan API key is invalid or expired.")
+        sys.exit(1)
+    if r.status_code == 402:
+        # Free tier doesn't allow filter queries on /host/search — fall back
+        # to /shodan/host/count which is free.
+        r = requests.get(
+            f"{BASE}/shodan/host/count",
+            params={"key": api_key, "query": query},
+            timeout=15,
+        )
+        return {"_endpoint": "host/count", **r.json()}
+    return {"_endpoint": "host/search", **r.json()}
+
+
+def aggregate_cves(response: dict) -> list[str]:
+    """Pull unique CVE IDs from a Shodan host/search response."""
+    cves: set[str] = set()
+    for match in response.get("matches", []):
+        vulns = match.get("vulns")
+        if isinstance(vulns, dict):
+            cves.update(vulns.keys())
+        elif isinstance(vulns, list):
+            cves.update(vulns)
+    return sorted(cves)
+
+
+def main() -> int:
+    api_key = get_api_key()
+    if not SERVICES_JSON.exists():
+        err(f"ERROR: services.json not found at {SERVICES_JSON}")
+        return 1
+
+    manifest = json.loads(SERVICES_JSON.read_text())
+    results: list[dict] = []
+    err(f"Querying Shodan CVE database for {len(manifest['services'])} services...\n")
+
+    for svc in manifest["services"]:
+        name = svc["name"]
+        version = svc["version"]
+        product = svc["shodanProduct"]
+        err(f"  - {product} {version} ({svc['exposed']})")
+        try:
+            response = search_cves(api_key, product, version)
+            cves = aggregate_cves(response)
+            results.append(
+                {
+                    "service": name,
+                    "shodanProduct": product,
+                    "version": version,
+                    "exposed": svc["exposed"],
+                    "cves": cves,
+                    "shodanHostCount": response.get("total", 0),
+                }
+            )
+            if cves:
+                err(f"    {len(cves)} CVE(s): {', '.join(cves[:5])}{'...' if len(cves) > 5 else ''}")
+            else:
+                err("    No CVEs reported by Shodan for this version.")
+        except requests.RequestException as e:
+            err(f"    ERROR: {e}")
+            results.append(
+                {"service": name, "shodanProduct": product, "version": version, "error": str(e)}
+            )
+
+    err("")
+    total_cves = sum(len(r.get("cves", [])) for r in results)
+    err(f"Total unique CVEs across all services: {total_cves}")
+
+    print(json.dumps({"services": results, "totalCves": total_cves}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pentest/shodan/check-host.py
+++ b/pentest/shodan/check-host.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Shodan public-exposure check for the rogue deploy's WAN IP.
+
+Queries Shodan's host endpoint for the deploy's public-facing IP to report:
+  - Open ports + service banners
+  - Detected service versions
+  - Known CVEs against those exact services
+
+This is the "what does the public internet see?" sanity check. The expected
+answer for a Tailscale-Funnel-only deploy is "very little" — Tailscale's
+edge handles HTTPS termination on Tailscale-owned IPs, not the user's WAN.
+But ISPs occasionally expose router ports (NAT-PMP, UPnP, IoT garbage), and
+Shodan flags those.
+
+Reads SHODAN_API_KEY from env. Auto-detects WAN IP via ifconfig.me unless
+PENTEST_WAN_IP is set explicitly.
+
+Usage:
+    python check-host.py > host.json 2> host-summary.txt
+    PENTEST_WAN_IP=203.0.113.42 python check-host.py
+"""
+
+import json
+import os
+import sys
+
+import requests
+
+BASE = "https://api.shodan.io"
+
+
+def err(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def get_api_key() -> str:
+    key = os.environ.get("SHODAN_API_KEY", "").strip()
+    if not key:
+        err("ERROR: SHODAN_API_KEY env var is not set.")
+        sys.exit(1)
+    return key
+
+
+def detect_wan_ip() -> str:
+    """Auto-detect the deploy's WAN IP via ifconfig.me. Caller can override
+    via PENTEST_WAN_IP env var to scan a specific address."""
+    override = os.environ.get("PENTEST_WAN_IP", "").strip()
+    if override:
+        err(f"Using PENTEST_WAN_IP override: {override}")
+        return override
+    try:
+        r = requests.get("https://ifconfig.me/ip", timeout=10)
+        r.raise_for_status()
+        ip = r.text.strip()
+        err(f"Auto-detected WAN IP: {ip}")
+        return ip
+    except requests.RequestException as e:
+        err(f"ERROR: failed to auto-detect WAN IP — {e}")
+        err("Set PENTEST_WAN_IP=<ip> to override.")
+        sys.exit(1)
+
+
+def query_host(api_key: str, ip: str) -> dict:
+    """Query Shodan's /shodan/host/{ip} endpoint. Returns the raw response.
+
+    Note: Shodan only has data for IPs it has previously scanned. A fresh /
+    rarely-scanned residential IP may return 404 ("No information available
+    for that IP"), which is itself a useful signal: the IP isn't on the
+    public radar. We treat 404 as a clean result, not an error.
+    """
+    r = requests.get(
+        f"{BASE}/shodan/host/{ip}",
+        params={"key": api_key},
+        timeout=15,
+    )
+    if r.status_code == 401:
+        err("ERROR: Shodan API key is invalid or expired.")
+        sys.exit(1)
+    if r.status_code == 404:
+        return {
+            "ip_str": ip,
+            "_status": "no_data",
+            "_message": "Shodan has no scan data for this IP. Likely a clean residential IP, or recently re-allocated.",
+        }
+    r.raise_for_status()
+    data = r.json()
+    data["_status"] = "scanned"
+    return data
+
+
+def summarize(response: dict) -> None:
+    if response.get("_status") == "no_data":
+        err("\n✓ Shodan has no scan data for this IP — clean exposure.")
+        return
+
+    err(f"\nShodan scan data for {response.get('ip_str', '?')}:")
+    err(f"  ISP:          {response.get('isp', '?')}")
+    err(f"  Country:      {response.get('country_name', '?')}")
+    err(f"  Org:          {response.get('org', '?')}")
+    err(f"  Last update:  {response.get('last_update', '?')}")
+
+    ports = response.get("ports", [])
+    err(f"\nOpen ports ({len(ports)}): {ports}")
+
+    vulns = response.get("vulns", [])
+    if vulns:
+        err(f"\n⚠ Known CVEs ({len(vulns)}):")
+        for v in sorted(vulns)[:20]:
+            err(f"  - {v}")
+        if len(vulns) > 20:
+            err(f"  ... and {len(vulns) - 20} more")
+    else:
+        err("\n✓ No CVEs flagged for any service on this IP.")
+
+    services = response.get("data", [])
+    if services:
+        err(f"\nServices banner-fingerprinted by Shodan ({len(services)}):")
+        for s in services[:10]:
+            port = s.get("port", "?")
+            product = s.get("product") or s.get("_shodan", {}).get("module", "?")
+            version = s.get("version") or ""
+            err(f"  - port {port}: {product} {version}".rstrip())
+
+
+def main() -> int:
+    api_key = get_api_key()
+    ip = detect_wan_ip()
+    err(f"\nQuerying Shodan host endpoint for {ip}...")
+    try:
+        response = query_host(api_key, ip)
+    except requests.RequestException as e:
+        err(f"ERROR: {e}")
+        return 1
+    summarize(response)
+    print(json.dumps(response, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pentest/shodan/check-hostname.py
+++ b/pentest/shodan/check-hostname.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Shodan funnel-hostname check.
+
+Queries Shodan for hosts indexed under the Tailscale Funnel hostname
+(retirement-dashboard.tailceab8.ts.net). The funnel terminates HTTPS at
+Tailscale's edge IPs, so this surface is what the world can reach via the
+public DNS name. Useful for spotting:
+  - Unexpected open ports beyond 443 (the only port the funnel should serve)
+  - Service banners that reveal stack details (server: nginx/X.Y.Z, etc.)
+  - Hosts in Shodan's index claiming this hostname that aren't actually us
+
+Reads SHODAN_API_KEY from env. Hostname defaults to the production funnel
+URL but can be overridden via PENTEST_HOSTNAME.
+
+Usage:
+    python check-hostname.py > hostname.json 2> hostname-summary.txt
+    PENTEST_HOSTNAME=staging.example.com python check-hostname.py
+"""
+
+import json
+import os
+import sys
+
+import requests
+
+BASE = "https://api.shodan.io"
+DEFAULT_HOSTNAME = "retirement-dashboard.tailceab8.ts.net"
+
+
+def err(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def get_api_key() -> str:
+    key = os.environ.get("SHODAN_API_KEY", "").strip()
+    if not key:
+        err("ERROR: SHODAN_API_KEY env var is not set.")
+        sys.exit(1)
+    return key
+
+
+def search_hostname(api_key: str, hostname: str) -> dict:
+    """Search Shodan for `hostname:<name>`. Returns raw API response."""
+    query = f"hostname:{hostname}"
+    err(f"\nSearching Shodan for {query}...")
+    r = requests.get(
+        f"{BASE}/shodan/host/search",
+        params={"key": api_key, "query": query, "limit": 10},
+        timeout=15,
+    )
+    if r.status_code == 401:
+        err("ERROR: Shodan API key is invalid or expired.")
+        sys.exit(1)
+    if r.status_code == 402:
+        # Free tier blocks some search queries — fall back to count-only.
+        r = requests.get(
+            f"{BASE}/shodan/host/count",
+            params={"key": api_key, "query": query},
+            timeout=15,
+        )
+        return {"_endpoint": "host/count", **r.json()}
+    r.raise_for_status()
+    return {"_endpoint": "host/search", **r.json()}
+
+
+def summarize(response: dict, hostname: str) -> None:
+    total = response.get("total", 0)
+    err(f"\nTotal Shodan-indexed hosts claiming hostname {hostname}: {total}")
+
+    if response.get("_endpoint") == "host/count":
+        err("(Free-tier API: counts only, no per-host detail. Upgrade to see banners.)")
+        return
+
+    matches = response.get("matches", [])
+    if not matches:
+        err("\n✓ No hosts found. Tailscale Funnel edge is not currently indexed under this hostname.")
+        return
+
+    err(f"\nMatches ({len(matches)}):")
+    for m in matches[:5]:
+        ip = m.get("ip_str", "?")
+        port = m.get("port", "?")
+        product = m.get("product") or m.get("_shodan", {}).get("module", "?")
+        org = m.get("org", "?")
+        err(f"  - {ip}:{port}  {product}  ({org})")
+        vulns = m.get("vulns")
+        if vulns:
+            cve_list = list(vulns.keys()) if isinstance(vulns, dict) else list(vulns)
+            err(f"      ⚠ {len(cve_list)} CVE(s): {', '.join(cve_list[:3])}{'...' if len(cve_list) > 3 else ''}")
+
+
+def main() -> int:
+    api_key = get_api_key()
+    hostname = os.environ.get("PENTEST_HOSTNAME", DEFAULT_HOSTNAME).strip()
+    try:
+        response = search_hostname(api_key, hostname)
+    except requests.RequestException as e:
+        err(f"ERROR: {e}")
+        return 1
+    summarize(response, hostname)
+    print(json.dumps(response, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Tier 1 of the pentest infrastructure flagged as a followup in [retirement-dashboard #98](https://github.com/justice8096/retirement-dashboard-angular/pull/98) post-commit audit. Two surfaces covered, both opt-in via a separate compose file:

| Surface | Tool | Question |
|---|---|---|
| Running app behavior | OWASP ZAP baseline | Does the app behave securely under crawling? |
| Service-stack CVEs | Shodan CVE-by-version | Are any running services known-vulnerable? |
| Public exposure | Shodan host scan | What does the public internet see on rogue's WAN IP? |
| Funnel hostname | Shodan hostname search | Is anything indexed under our funnel name? |

## How to run (on rogue)

```bash
ssh root@192.168.68.77
cd /srv/retirement/retirement-api/pentest
env $(grep -v '^#' ../.env | xargs) ./run-scan.sh
```

Outputs to `/mnt/nas/disk1/containerBackup/pentest/scan-{date}/` with a `summary.md` rollup.

## What's added

```
pentest/
├── docker-compose.pentest.yml    # zap-baseline + shodan services (profile: pentest)
├── services.json                  # version manifest — drives CVE check
├── run-scan.sh                    # one-button orchestrator
├── shodan/
│   ├── Dockerfile                 # python:3.13-alpine + requests + shodan
│   ├── check-cves.py              # CVE-by-version
│   ├── check-host.py              # WAN IP exposure (auto-detects via ifconfig.me)
│   └── check-hostname.py          # funnel hostname index
└── README.md                      # module-level
docs/PENTEST.md                    # operational runbook (cadence + triage)
.env.example                       # added SHODAN_API_KEY
.gitignore                         # added __pycache__/
```

## Default ZAP targets

1. `https://retirement-dashboard.tailceab8.ts.net` — full chain (funnel + nginx + api)
2. `http://192.168.68.77:8090` — LAN dashboard nginx (bypass funnel)
3. `http://192.168.68.77:3000` — LAN api direct (bypass nginx)

Override via `ZAP_TARGETS` env var.

## Operational design

- **Compose profile gating** — services are tagged `profile: pentest`, so they don't start with the prod compose stack. Brought up only via explicit `--profile pentest`.
- **Active scans separately gated** — `zap-full-scan` (sends SQL injection / XSS payloads) lives in a `pentest-active` profile. Opt-in only. Documented as Tier 2 work; **must not run against production data**.
- **Reports persist to NAS** — `/mnt/nas/disk1/containerBackup/pentest/scan-{date}/`. Diffable across runs.
- **Free-tier Shodan budget** — 8 queries per `run-scan.sh` invocation (6 CVE + 1 host + 1 hostname). 100 queries/month free → ~12 full runs/month. Ad-hoc partial runs available (e.g. just `check-cves.py` after a dep bump = 6 queries).
- **API key handling** — `SHODAN_API_KEY` lives in `/srv/retirement/retirement-api/.env` alongside `CLERK_SECRET_KEY` etc., mirrored to NAS at `/mnt/nas/disk1/containerBackup/retirement-rogue-secrets.env` per the existing secrets-backup convention. Never committed; `.env` is gitignored.

## What's NOT covered (by design)

- **Authenticated scans** — ZAP doesn't sign in via Clerk. Auth-gated routes are not crawled. (Tier 2.)
- **Active SQL injection / XSS payloads** — `zap-active` profile exists but opt-in only.
- **Internal-LAN service scans** — Portainer, Proxmox, etc. covered by Uptime Kuma liveness, not vuln scans.
- **Static SAST/DAST against source** — handled by the existing `audits/sast-dast-scan-*.md` workflow.

## Test plan

- [x] `python -m py_compile` on all 3 check scripts: clean
- [x] `bash -n run-scan.sh`: clean
- [x] YAML syntax matches existing prod-stack idiom
- [ ] **First-run verification on rogue** (post-merge): `git pull && cd pentest && env $(...) ./run-scan.sh`, confirm reports land in NAS dir

## Followups (Tier 2/3 — documented in pentest/README.md)

- Nuclei for fast template-based CVE scans (lower signal-to-noise than ZAP)
- `schemathesis` for OpenAPI-driven API fuzzing (api already serves `/api/openapi.json`)
- Authenticated ZAP scans with a dedicated test Clerk user
- Schedule weekly via systemd timer on rogue, alert via Uptime Kuma when finding count regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)