### PR TITLE
feat(tools): tier-get / tier-set admin shell scripts

### DIFF
--- a/tools/README-tier.md
+++ b/tools/README-tier.md
@@ -1,0 +1,55 @@
+# Tier admin scripts
+
+Two helpers for reading + updating a user's subscription tier on the rogue deploy. Saves the round trip of `docker compose exec postgres psql -c "..."` boilerplate.
+
+## When to use
+
+- A dev account is on `free` tier and hits `Requires basic tier or higher` gates while testing — elevate to `admin` for full access.
+- Need to reset a test user back to `free` to exercise the tier gates.
+- Need to verify a user's current tier without browsing into Clerk + the database manually.
+
+## Tier values
+
+Per `prisma/schema.prisma:enum SubscriptionTier`:
+
+- `free` — default for new signups; gates simulate-save, scenarios, custom locations, etc.
+- `basic` — paid tier 1; unlocks save scenarios + most user features.
+- `premium` — paid tier 2; unlocks the rest of the user-facing features.
+- `admin` — internal; bypasses all tier gates AND unlocks `/api/admin/*` endpoints.
+
+## Usage
+
+```bash
+# Read current tier
+./tier-get.sh justice8096@gmail.com
+
+# Elevate to admin (dev/testing)
+./tier-set.sh justice8096@gmail.com admin
+
+# Set back to free
+./tier-set.sh test@example.com free
+```
+
+Both scripts default to `COMPOSE_FILE=/srv/retirement/retirement-api/docker-compose.yml` (the rogue deploy). For other environments, override:
+
+```bash
+COMPOSE_FILE=/path/to/docker-compose.yml ./tier-get.sh someone@example.com
+```
+
+## Cache behavior
+
+The api caches user records for **10 seconds** (`USER_CACHE_TTL_MS` in `src/middleware/auth.ts`). After running `tier-set.sh`, the next request from that user will still see the OLD tier for up to 10 seconds. Either wait it out or refresh the browser to force a new auth round-trip.
+
+## Why shell scripts and not Prisma
+
+Prisma 7.8 changed `new PrismaClient()` to require explicit options, so the previous one-liner pattern (`node -e 'const{PrismaClient}=...'`) breaks without `{ datasourceUrl: ... }`. psql is simpler, has zero Node-version coupling, and the SQL is trivial.
+
+## Why not an admin endpoint
+
+A REST endpoint like `POST /api/admin/users/:id/tier` would be cleaner long-term. Tracked as a future improvement; for now the workflow is rare enough (only during dev / one-off support) that scripts are appropriate scope.
+
+## Related
+
+- `prisma/schema.prisma:User` — model definition + tier field
+- `src/middleware/auth.ts` — `requireAdmin` / `requireAuth` middleware that reads tier
+- `src/routes/scenarios.ts`, `src/routes/users.ts` — example callers of the tier gates

--- a/tools/tier-get.sh
+++ b/tools/tier-get.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# tier-get.sh — read a user's subscription tier from the deploy postgres.
+#
+# Usage:
+#   ./tier-get.sh <email>
+#
+# Example:
+#   ./tier-get.sh justice8096@gmail.com
+#
+# Runs psql via `docker compose exec postgres` against the live deploy
+# postgres. Defaults to the rogue compose file path; override via
+# COMPOSE_FILE env var for other environments.
+#
+# Read-only; safe to run anytime.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <email>" >&2
+  exit 2
+fi
+
+EMAIL="$1"
+COMPOSE_FILE="${COMPOSE_FILE:-/srv/retirement/retirement-api/docker-compose.yml}"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "ERROR: compose file not found at ${COMPOSE_FILE}" >&2
+  echo "       Set COMPOSE_FILE=<path> if running outside the rogue deploy." >&2
+  exit 1
+fi
+
+# `-T` disables pseudo-TTY; needed when called from non-interactive shells.
+docker compose -f "${COMPOSE_FILE}" exec -T postgres \
+  psql -U retirement -d retirement_saas \
+    -v "ON_ERROR_STOP=1" \
+    -c "SELECT email, tier, updated_at FROM users WHERE email = '${EMAIL}';"

--- a/tools/tier-set.sh
+++ b/tools/tier-set.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# tier-set.sh — elevate (or downgrade) a user's subscription tier.
+#
+# Usage:
+#   ./tier-set.sh <email> <tier>
+#
+# Tier must be one of: free, basic, premium, admin.
+#
+# Examples:
+#   ./tier-set.sh justice8096@gmail.com admin
+#   ./tier-set.sh test@example.com basic
+#
+# Runs psql UPDATE via `docker compose exec postgres` against the live
+# deploy postgres. Defaults to the rogue compose file path; override
+# via COMPOSE_FILE env var for other environments.
+#
+# Cache caveat: the api caches user records for 10 seconds (see
+# USER_CACHE_TTL_MS in src/middleware/auth.ts). Wait ~10s after this
+# script returns before retrying tier-gated requests, or refresh the
+# browser to force a new auth round-trip.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <email> <tier>" >&2
+  echo "  tier must be one of: free, basic, premium, admin" >&2
+  exit 2
+fi
+
+EMAIL="$1"
+TIER="$2"
+COMPOSE_FILE="${COMPOSE_FILE:-/srv/retirement/retirement-api/docker-compose.yml}"
+
+# Validate tier arg up-front — clearer error than letting psql reject the
+# enum cast. Mirrors the SubscriptionTier enum in prisma/schema.prisma.
+case "${TIER}" in
+  free|basic|premium|admin) ;;
+  *)
+    echo "ERROR: invalid tier '${TIER}'." >&2
+    echo "       Must be one of: free, basic, premium, admin" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "ERROR: compose file not found at ${COMPOSE_FILE}" >&2
+  echo "       Set COMPOSE_FILE=<path> if running outside the rogue deploy." >&2
+  exit 1
+fi
+
+docker compose -f "${COMPOSE_FILE}" exec -T postgres \
+  psql -U retirement -d retirement_saas \
+    -v "ON_ERROR_STOP=1" \
+    -c "UPDATE users SET tier = '${TIER}' WHERE email = '${EMAIL}' RETURNING email, tier, updated_at;"
+
+echo
+echo "Done. The api caches user records for 10s — wait ~10s before retrying"
+echo "tier-gated requests, or refresh the browser to force a fresh auth."


### PR DESCRIPTION
## Summary

Two small helpers for reading + updating a user's `SubscriptionTier` on the rogue deploy. Saves the `docker compose exec postgres psql -c \"...\"` boilerplate that's been ad-hoc'd through chat tonight.

## Scripts

| File | Purpose |
|---|---|
| [`tools/tier-get.sh`](tools/tier-get.sh) | `./tier-get.sh <email>` — read current tier |
| [`tools/tier-set.sh`](tools/tier-set.sh) | `./tier-set.sh <email> <tier>` — update tier (validated against the SubscriptionTier enum) |
| [`tools/README-tier.md`](tools/README-tier.md) | Usage + tier values + cache caveat |

## Tier values

Per `prisma/schema.prisma:enum SubscriptionTier`:
- `free` — default for new signups; gates simulate-save, scenarios, custom locations, etc.
- `basic` — paid tier 1; unlocks save scenarios + most user features
- `premium` — paid tier 2; unlocks the rest of user-facing features
- `admin` — internal; bypasses all tier gates AND unlocks `/api/admin/*` endpoints

## Why shell + psql, not Node + Prisma

Prisma 7.8 changed `new PrismaClient()` to require explicit options (validated empirically via stack trace earlier tonight). The previous one-liner pattern \`node -e 'const{PrismaClient}=...'\` now errors with `non-empty, valid PrismaClientOptions`. psql is simpler, zero Node-version coupling, and the SQL is trivial.

## Cache caveat

Documented in both the `tier-set.sh` output and `README-tier.md`: the api caches user records for **10 seconds** (`USER_CACHE_TTL_MS` in [`src/middleware/auth.ts`](src/middleware/auth.ts)). Wait ~10s after `tier-set.sh` returns before retrying tier-gated requests, or refresh the browser to force a new auth round-trip.

## Path defaults

Both scripts default to `COMPOSE_FILE=/srv/retirement/retirement-api/docker-compose.yml` (rogue path). Override via env var for other environments:

```bash
COMPOSE_FILE=/local/path/to/docker-compose.yml ./tier-get.sh someone@example.com
```

## Test plan

- [x] `bash -n` syntax check on both scripts: clean
- [x] Both have executable bit set
- [x] Tier validation in `tier-set.sh` rejects invalid args before reaching psql

## Followup (out of scope)

A REST endpoint `POST /api/admin/users/:id/tier` would be cleaner long-term — discoverable, auditable, doesn't require shell access to the deploy. Tracked in `README-tier.md`'s "Why not an admin endpoint" section. The workflow is rare enough (dev / one-off support) that scripts are appropriate scope today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)