### PR TITLE
feat(rental): persist rentalProperties on UserFinancialSettings (#36)

### DIFF
--- a/prisma/migrations/20260502000000_add_rental_properties/migration.sql
+++ b/prisma/migrations/20260502000000_add_rental_properties/migration.sql
@@ -1,0 +1,13 @@
+-- Add rental_properties JSONB column to user_financial_settings (Todo #36).
+-- Persists the RentalProperty[] portfolio that was session-only in PRs
+-- #118 (data model) and #120 (MC kernel integration). Default '[]' means
+-- existing rows get an empty portfolio — matches the session-only
+-- behavior they had before this column existed.
+--
+-- Shape is validated at the application boundary (Zod schema in
+-- src/routes/financial.ts), not at the database level — this is a
+-- passthrough column, same pattern as user_preferences.preferences and
+-- user_grocery_data.tagged_items.
+
+ALTER TABLE "user_financial_settings"
+  ADD COLUMN "rental_properties" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,6 +182,13 @@ model UserFinancialSettings {
   taxableFeesPct     Decimal @default(0) @map("taxable_fees_pct")
   hsaFeesPct         Decimal @default(0) @map("hsa_fees_pct")
 
+  // ─── Rental Properties (Schedule E portfolio) ─────────────────────
+  // JSONB array of RentalProperty objects (Todo #36, persistence for #29).
+  // Shape validated by financial.ts Zod schema; this column is a pass-
+  // through. Default '[]' means existing rows get an empty portfolio
+  // (matches the session-only behavior shipped in PRs #118 and #120).
+  rentalProperties   Json     @default("[]") @map("rental_properties")
+
   updatedAt        DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/__tests__/routes-financial.test.ts
+++ b/src/__tests__/routes-financial.test.ts
@@ -137,4 +137,154 @@ describe('Financial routes', () => {
       expect(res.statusCode).toBe(400);
     });
   });
+
+  describe('rentalProperties (Todo #36)', () => {
+    const validRental = {
+      id: 'rental-abc12345-xyz',
+      label: 'Boulder duplex',
+      monthlyGrossRent: 2500,
+      vacancyRatePct: 8,
+      propertyTaxAnnual: 4000,
+      otherOpExAnnual: 3000,
+      mortgageInterestAnnual: 0,
+      depreciableBasis: 200000,
+      depreciationStartYear: 0,
+      ownedFromYear: 0,
+    };
+
+    it('GET returns empty rentalProperties array when no settings exist', async () => {
+      prisma.userFinancialSettings.findUnique.mockResolvedValue(null);
+
+      const res = await app.inject({ method: 'GET', url: '/api/me/financial' });
+      const body = JSON.parse(res.payload);
+
+      expect(res.statusCode).toBe(200);
+      expect(body.rentalProperties).toEqual([]);
+    });
+
+    it('GET round-trips rentalProperties JSONB array verbatim', async () => {
+      const props = [validRental];
+      prisma.userFinancialSettings.findUnique.mockResolvedValue({
+        userId: 'test-user-id',
+        portfolioBalance: 'ENC:500000',
+        rentalProperties: props,
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/api/me/financial' });
+      const body = JSON.parse(res.payload);
+
+      expect(res.statusCode).toBe(200);
+      expect(body.rentalProperties).toEqual(props);
+    });
+
+    it('PUT persists valid rentalProperties array', async () => {
+      prisma.userFinancialSettings.upsert.mockResolvedValue({
+        userId: 'test-user-id',
+        rentalProperties: [validRental],
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [validRental] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const call = prisma.userFinancialSettings.upsert.mock.calls[0][0];
+      // Persisted verbatim — no PCT_FIELDS conversion or encryption
+      // touches the rental array.
+      expect(call.update.rentalProperties).toEqual([validRental]);
+    });
+
+    it('PUT accepts empty array (clears portfolio)', async () => {
+      prisma.userFinancialSettings.upsert.mockResolvedValue({
+        rentalProperties: [],
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('PUT accepts negative depreciationStartYear (pre-sim depreciation)', async () => {
+      // Property placed in service before sim window starts. The dashboard
+      // explicitly supports this; the api Zod schema must too.
+      prisma.userFinancialSettings.upsert.mockResolvedValue({
+        rentalProperties: [{ ...validRental, depreciationStartYear: -10 }],
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [{ ...validRental, depreciationStartYear: -10 }] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('PUT rejects rentalProperty with negative monthlyGrossRent', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [{ ...validRental, monthlyGrossRent: -100 }] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects rentalProperty with vacancyRatePct > 100', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [{ ...validRental, vacancyRatePct: 150 }] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects rentalProperty with extra fields (strict)', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [{ ...validRental, sneakyField: 'evil' }] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects rentalProperty with missing required field', async () => {
+      const incomplete = { ...validRental };
+      delete (incomplete as Record<string, unknown>).id;
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: [incomplete] },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects array with > 50 properties', async () => {
+      const tooMany = Array(51).fill(validRental).map((p, i) => ({ ...p, id: `rental-${i}` }));
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { rentalProperties: tooMany },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/src/routes/financial.ts
+++ b/src/routes/financial.ts
@@ -19,6 +19,32 @@ import { defaultCurrencyFor } from '../lib/locale.js';
  */
 const num = z.coerce.number();
 
+/**
+ * RentalProperty shape (Todo #36, persistence for #29). Mirrors the
+ * `RentalProperty` interface in the dashboard's `src/app/lib/rental-income.ts`.
+ * Validated at the request boundary; persisted as JSONB on
+ * `user_financial_settings.rental_properties`.
+ *
+ * Bounds chosen to match the dashboard input ranges:
+ *   - depreciationStartYear can be negative (property placed in service
+ *     before sim window) — see PR #118 fix for Codex P1.
+ *   - sim-year fields are bounded to ±100 to catch fat-fingered input
+ *     while still allowing realistic horizons.
+ */
+const rentalPropertySchema = z.object({
+  id: z.string().min(1).max(100),
+  label: z.string().max(200),
+  monthlyGrossRent: num.min(0).max(1_000_000),
+  vacancyRatePct: num.min(0).max(100),
+  propertyTaxAnnual: num.min(0).max(1_000_000),
+  otherOpExAnnual: num.min(0).max(1_000_000),
+  mortgageInterestAnnual: num.min(0).max(10_000_000),
+  depreciableBasis: num.min(0).max(100_000_000),
+  depreciationStartYear: num.int().min(-50).max(100),
+  ownedFromYear: num.int().min(0).max(100),
+  ownedThroughYear: num.int().min(0).max(100).optional(),
+}).strict();
+
 const financialSchema = z.object({
   portfolioBalance: num.min(0).max(100_000_000).optional(),
   fxDriftEnabled: z.boolean().optional(),
@@ -58,6 +84,11 @@ const financialSchema = z.object({
   rothFeesPct: num.min(0).max(10).optional(),
   taxableFeesPct: num.min(0).max(10).optional(),
   hsaFeesPct: num.min(0).max(10).optional(),
+
+  // Rental property portfolio (Todo #36). Bounded array; passes through
+  // to the rental_properties JSONB column on user_financial_settings.
+  // Empty array on a PUT clears the user's portfolio.
+  rentalProperties: z.array(rentalPropertySchema).max(50).optional(),
 }).strict();  // SAST M-02: reject unknown keys
 
 // Defaults sent to client when no DB record exists (client-side format).
@@ -75,6 +106,7 @@ const DEFAULTS = {
   expectedReturn: 7,
   expectedInflation: 2.5,
   retirementPath: 'traditional',
+  rentalProperties: [],
 };
 
 /** Encrypted balance field names. */


### PR DESCRIPTION
## Summary

Closes [Todo #36](https://github.com/justice8096/retirement-dashboard-angular/) — backend persistence for the rental-property portfolio that was session-only on the dashboard after [PR #118](https://github.com/justice8096/retirement-dashboard-angular/pull/118) (data model) and [PR #120](https://github.com/justice8096/retirement-dashboard-angular/pull/120) (MC kernel). Users no longer have to re-enter their rentals on every page load.

This is the **api PR**; a paired dashboard PR will follow once this merges and the migration is applied.

## Schema

New \`rentalProperties Json @default(\"[]\")\` column on \`user_financial_settings\`. JSONB chosen over a relational table — same pattern as \`user_preferences.preferences\` and \`user_grocery_data.tagged_items\`. Cheaper migration, schema-less storage matches the dashboard's existing session-state shape verbatim.

Forward-only migration \`20260502000000_add_rental_properties\` — additive \`ALTER TABLE\` with \`NOT NULL DEFAULT '[]'\`. Existing rows get an empty portfolio (matches their pre-column behavior). No backfill needed.

## Validation

New \`rentalPropertySchema\` Zod shape mirrors the dashboard's \`RentalProperty\` interface. \`.strict()\` rejects unknown fields per SAST M-02. Bounds:

| Field | Range | Rationale |
|---|---|---|
| \`monthlyGrossRent\` | 0..1M | dashboard input |
| \`vacancyRatePct\` | 0..100 | percentage |
| \`propertyTaxAnnual\`, \`otherOpExAnnual\` | 0..1M | reasonable max |
| \`mortgageInterestAnnual\` | 0..10M | larger range — multi-mil property mortgages |
| \`depreciableBasis\` | 0..100M | high-end property allowance |
| \`depreciationStartYear\` | **-50..100** | negative = pre-sim placement (per [#118](https://github.com/justice8096/retirement-dashboard-angular/pull/118) Codex P1 fix) |
| \`ownedFromYear\` / \`ownedThroughYear?\` | 0..100 | sim-year offsets |

Top-level \`rentalProperties: z.array(rentalPropertySchema).max(50)\` — bounded to 50 to prevent unbounded JSONB writes.

## Round-trip

JSONB column passes through verbatim — no \`PCT_FIELDS\` conversion, no encryption, no Decimal handling. The Prisma client deserializes JSONB to a JS array on GET; the Zod-validated array goes back as-is on PUT.

## Test plan

- [x] \`npx prisma generate\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — **35,509 passing** (+10 new):
  - GET empty default
  - GET round-trip verbatim
  - PUT persists valid array
  - PUT accepts empty (clears portfolio)
  - PUT accepts negative \`depreciationStartYear\`
  - PUT rejects negative \`monthlyGrossRent\`
  - PUT rejects \`vacancyRatePct > 100\`
  - PUT rejects extra fields on a rental row (strict)
  - PUT rejects rental missing required field
  - PUT rejects array > 50 properties
- [ ] **Reviewer step**: deploy host runs \`npm run db:migrate\` after merge to apply migration to prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)