### PR TITLE
feat(mortgage): persist primary-residence mortgage fields (#28)

### DIFF
--- a/prisma/migrations/20260503000000_add_mortgage/migration.sql
+++ b/prisma/migrations/20260503000000_add_mortgage/migration.sql
@@ -1,0 +1,14 @@
+-- Add primary-residence mortgage fields to user_financial_settings (Todo #28).
+-- Payment is in USD per month, NOT CPI-inflated (mortgage P+I is nominal,
+-- so the kernel applies it without multiplying by cumulative inflation).
+-- End year is the exclusive sim-year cutoff for natural payoff. Both
+-- default 0, meaning "no mortgage configured" — existing rows get this
+-- safe default and continue to behave as before this column existed.
+--
+-- Early payoff is modeled by the user as a oneTimeExpense LifeEvent for
+-- the remaining principal + setting mortgageEndYear to the payoff year.
+-- The api stores raw values; behavior lives in the dashboard kernel.
+
+ALTER TABLE "user_financial_settings"
+  ADD COLUMN "mortgage_monthly_payment" DECIMAL(65,30) NOT NULL DEFAULT 0,
+  ADD COLUMN "mortgage_end_year"        INTEGER         NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,6 +189,15 @@ model UserFinancialSettings {
   // (matches the session-only behavior shipped in PRs #118 and #120).
   rentalProperties   Json     @default("[]") @map("rental_properties")
 
+  // ─── Primary-residence mortgage (Todo #28) ────────────────────────
+  // P+I monthly payment (USD, NOT CPI-inflated — mortgage payments are
+  // nominal); both 0 means no mortgage configured. End year is the
+  // exclusive sim-year cutoff for natural payoff. Early payoff is
+  // modeled by the user as a oneTimeExpense LifeEvent + setting
+  // mortgageEndYear to the early-payoff year.
+  mortgageMonthlyPayment Decimal @default(0) @map("mortgage_monthly_payment")
+  mortgageEndYear        Int     @default(0) @map("mortgage_end_year")
+
   updatedAt        DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/__tests__/routes-financial.test.ts
+++ b/src/__tests__/routes-financial.test.ts
@@ -287,4 +287,116 @@ describe('Financial routes', () => {
       expect(res.statusCode).toBe(400);
     });
   });
+
+  describe('mortgage fields (Todo #28)', () => {
+    it('GET returns 0 defaults when no settings exist', async () => {
+      prisma.userFinancialSettings.findUnique.mockResolvedValue(null);
+
+      const res = await app.inject({ method: 'GET', url: '/api/me/financial' });
+      const body = JSON.parse(res.payload);
+
+      expect(res.statusCode).toBe(200);
+      expect(body.mortgageMonthlyPayment).toBe(0);
+      expect(body.mortgageEndYear).toBe(0);
+    });
+
+    it('GET coerces Decimal mortgageMonthlyPayment to number', async () => {
+      // Prisma's Decimal type round-trips as a String over JSON; the route's
+      // NUMERIC_FIELDS coercion must turn it back into a JS number.
+      prisma.userFinancialSettings.findUnique.mockResolvedValue({
+        userId: 'test-user-id',
+        portfolioBalance: 'ENC:500000',
+        mortgageMonthlyPayment: '2500.00',
+        mortgageEndYear: 12,
+      });
+
+      const res = await app.inject({ method: 'GET', url: '/api/me/financial' });
+      const body = JSON.parse(res.payload);
+
+      expect(res.statusCode).toBe(200);
+      expect(body.mortgageMonthlyPayment).toBe(2500);
+      expect(body.mortgageEndYear).toBe(12);
+    });
+
+    it('PUT persists valid mortgage fields', async () => {
+      prisma.userFinancialSettings.upsert.mockResolvedValue({
+        mortgageMonthlyPayment: '1850.50',
+        mortgageEndYear: 8,
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageMonthlyPayment: 1850.5, mortgageEndYear: 8 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const call = prisma.userFinancialSettings.upsert.mock.calls[0][0];
+      // Mortgage is NOT in PCT_FIELDS, so no /100 conversion. Stored
+      // verbatim as a Decimal-string-ish value Prisma will normalize.
+      expect(call.update.mortgageMonthlyPayment).toBe(1850.5);
+      expect(call.update.mortgageEndYear).toBe(8);
+    });
+
+    it('PUT accepts zero values (clears mortgage)', async () => {
+      prisma.userFinancialSettings.upsert.mockResolvedValue({
+        mortgageMonthlyPayment: '0',
+        mortgageEndYear: 0,
+      });
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageMonthlyPayment: 0, mortgageEndYear: 0 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('PUT rejects negative mortgageMonthlyPayment', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageMonthlyPayment: -100 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects mortgageMonthlyPayment > 100K', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageMonthlyPayment: 150_000 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects non-integer mortgageEndYear', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageEndYear: 5.5 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PUT rejects mortgageEndYear > 100', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: { mortgageEndYear: 150 },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });

--- a/src/routes/financial.ts
+++ b/src/routes/financial.ts
@@ -89,6 +89,13 @@ const financialSchema = z.object({
   // to the rental_properties JSONB column on user_financial_settings.
   // Empty array on a PUT clears the user's portfolio.
   rentalProperties: z.array(rentalPropertySchema).max(50).optional(),
+
+  // Primary-residence mortgage (Todo #28). Both 0 means no mortgage.
+  // Monthly payment is USD P+I (nominal — kernel does NOT inflate it).
+  // End year is exclusive sim-year cutoff (range matches RentalProperty
+  // year fields).
+  mortgageMonthlyPayment: num.min(0).max(100_000).optional(),
+  mortgageEndYear: num.int().min(0).max(100).optional(),
 }).strict();  // SAST M-02: reject unknown keys
 
 // Defaults sent to client when no DB record exists (client-side format).
@@ -107,6 +114,8 @@ const DEFAULTS = {
   expectedInflation: 2.5,
   retirementPath: 'traditional',
   rentalProperties: [],
+  mortgageMonthlyPayment: 0,
+  mortgageEndYear: 0,
 };
 
 /** Encrypted balance field names. */
@@ -143,6 +152,10 @@ const NUMERIC_FIELDS = new Set<string>([
   ...ENCRYPTED_FIELDS,
   ...PCT_FIELDS,
   'ssCola', 'ssCutYear', 'fireTargetAge', 'annualSavings',
+  // Mortgage fields (Todo #28). monthlyPayment is Decimal in DB, endYear
+  // is Int — both come back as String / number from Prisma but the
+  // dashboard expects JS numbers everywhere, so coerce on egress.
+  'mortgageMonthlyPayment', 'mortgageEndYear',
 ]);
 
 /** Decrypt sensitive fields and convert DB decimals to client percentages.
@@ -187,6 +200,7 @@ const LABELED_FIELDS = [
   'retirementPath', 'fireTargetAge', 'annualSavings', 'savingsRate',
   'traditionalLoadPct', 'rothLoadPct', 'taxableLoadPct', 'hsaLoadPct',
   'traditionalFeesPct', 'rothFeesPct', 'taxableFeesPct', 'hsaFeesPct',
+  'mortgageMonthlyPayment', 'mortgageEndYear',
 ] as const;
 
 /** Build the `_units` metadata block for a response.
@@ -221,6 +235,8 @@ function unitsMeta(locale: string, apiVersion: 1 | 2 = 1) {
     rothFeesPct: pct(ex('0.2 = 0.2% expense ratio', '0.002 = 0.2% expense ratio')),
     taxableFeesPct: pct(ex('0.2 = 0.2% expense ratio', '0.002 = 0.2% expense ratio')),
     hsaFeesPct: pct(ex('0.2 = 0.2% expense ratio', '0.002 = 0.2% expense ratio')),
+    mortgageMonthlyPayment: { encoding: 'amount', currency, periodicity: 'month' },
+    mortgageEndYear: { encoding: 'count', meaning: 'Sim-year (exclusive) when mortgage ends. 0 = no mortgage.' },
   };
 }
 


### PR DESCRIPTION
## Summary

Api side of [Todo #28](https://github.com/justice8096/retirement-dashboard-angular/) — mortgage in retirement (payoff decision + ongoing modeling). Two new scalar fields on \`UserFinancialSettings\`; dashboard kernel changes follow in a paired PR.

## Schema

- \`mortgage_monthly_payment Decimal @default(0)\` — P+I in USD/month. Decimal because dollars-and-cents matter.
- \`mortgage_end_year Int @default(0)\` — exclusive sim-year cutoff for natural payoff.

Both default 0 = "no mortgage configured" — existing rows get the safe default; no behavior change for users who don't have a mortgage.

## Validation

- \`mortgageMonthlyPayment\`: 0..100K (covers high-end NYC/SF).
- \`mortgageEndYear\`: int 0..100 (matches the sim-year range used elsewhere).
- Mortgage is **NOT in \`PCT_FIELDS\`** — no \`/100\` conversion. Stored verbatim.
- Both included in \`NUMERIC_FIELDS\` (Decimal → JS number on GET), \`LABELED_FIELDS\`, and \`unitsMeta\`.

## Kernel hint (lives in the dashboard PR, documented here)

Each year \`y\` where \`y < mortgageEndYear\`, the dashboard kernel will:

\`\`\`
bal -= mortgageMonthlyPayment × 12   // sticky — NO cumInfl multiplier
\`\`\`

P+I is nominal, not CPI-adjusted — that's the whole point of fixed-rate mortgages and the payoff timing planning lever the todo flags.

Early payoff: user models as a \`oneTimeExpense\` LifeEvent for remaining principal + sets \`mortgageEndYear\` to the payoff year. No new LifeEvent kind needed.

## Out of scope (deferred)

- Refinancing event
- Multiple mortgages / HELOC
- Schedule A mortgage interest deduction (most retirees take std deduction)
- Auto-amortized remaining balance helper (user looks up exact figure from lender)

## Test plan

- [x] \`npx prisma generate\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — **35,517 passing** (+8 new):
  - GET returns 0 defaults
  - GET coerces Decimal → JS number
  - PUT persists valid mortgage fields
  - PUT accepts zero (clears mortgage)
  - PUT rejects negative payment
  - PUT rejects payment > 100K
  - PUT rejects non-integer endYear
  - PUT rejects endYear > 100
- [ ] **Reviewer step**: deploy host runs \`npm run db:migrate\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)