### PR TITLE
data(portugal): cite 5 falsifiable pros/cons + fix outdated D7 figure (#19 beachhead)

### DIFF
--- a/data/locations/portugal-cascais/location.json
+++ b/data/locations/portugal-cascais/location.json
@@ -164,7 +164,16 @@
   },
   "pros": [
     "Upscale beach town with excellent quality of life",
-    "Train connection to Lisbon (35 min)",
+    {
+      "text": "Train connection to Lisbon (~35 min on the CP Linha de Cascais)",
+      "sources": [
+        {
+          "title": "CP — Linha de Cascais timetable (Lisboa Cais do Sodré ↔ Cascais)",
+          "url": "https://www.cp.pt/passageiros/en/train-times/lines/cascais-line",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "Strong international community and English widely spoken"
   ],
   "cons": [

--- a/data/locations/portugal-lisbon/location.json
+++ b/data/locations/portugal-lisbon/location.json
@@ -268,8 +268,31 @@
     "safetyRating": 9
   },
   "pros": [
-    "Lowest visa threshold (EUR 705/mo)",
-    "High English proficiency",
+    {
+      "text": "Low D7 visa threshold: passive income at least €870/mo (2025 Portuguese minimum wage)",
+      "sources": [
+        {
+          "title": "AIMA — D7 (Passive Income / Retirement) Visa requirements",
+          "url": "https://www.aima.gov.pt/en/viver/vistos/d7---visto-de-residencia-para-aposentados-e-titulares-de-rendimentos",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Decreto-Lei n.º 87-A/2024 — 2025 RMG (€870/mo)",
+          "url": "https://diariodarepublica.pt/dr/detalhe/decreto-lei/87-a-2024-902317036",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
+    {
+      "text": "High English proficiency (Portugal ranks in EF EPI Very High Proficiency tier)",
+      "sources": [
+        {
+          "title": "EF English Proficiency Index 2024 — Portugal",
+          "url": "https://www.ef.com/wwen/epi/regions/europe/portugal/",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "Very safe",
     "Great climate (Algarve)",
     "Strong expat community"
@@ -282,7 +305,14 @@
       "text": "Longer healthcare waits"
     },
     {
-      "text": "Language barrier for permanent residency"
+      "text": "Permanent residency requires A2 Portuguese language certificate after 5 years",
+      "sources": [
+        {
+          "title": "AIMA — Permanent residence (Autorização de Residência Permanente)",
+          "url": "https://www.aima.gov.pt/en/viver/autorizacao-de-residencia/autorizacao-de-residencia-permanente",
+          "accessed": "2026-05-03"
+        }
+      ]
     },
     {
       "text": "Safety & crime: see cited reports for current figures by city and country",

--- a/data/locations/portugal-porto/location.json
+++ b/data/locations/portugal-porto/location.json
@@ -165,7 +165,16 @@
   "pros": [
     "More affordable than Lisbon with similar amenities",
     "World-famous wine region (Port wine)",
-    "UNESCO World Heritage riverside district"
+    {
+      "text": "UNESCO World Heritage riverside district (Historic Centre of Oporto, listed 1996)",
+      "sources": [
+        {
+          "title": "UNESCO World Heritage List — Historic Centre of Oporto, Luiz I Bridge and Monastery of Serra do Pilar",
+          "url": "https://whc.unesco.org/en/list/755",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/scripts/add-portugal-citations.mjs
+++ b/scripts/add-portugal-citations.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * One-shot data migration: add structured `Source[]` citations to
+ * falsifiable Portugal pros/cons bullets (Todo #19 beachhead).
+ *
+ * Strategy from #19: don't try to cite every bullet — most are
+ * lifestyle/climate subjectives that aren't source-able. Focus on
+ * falsifiable claims (specific numbers, named programs, government
+ * documents). This pass covers all 5 Portugal cities + sets the
+ * pattern for future country sweeps.
+ *
+ * What this script does:
+ *   1. Updates outdated `Lowest visa threshold (EUR 705/mo)` to
+ *      reflect the 2025 D7 minimum-passive-income figure.
+ *   2. Converts plain-string pros to `{ text, sources }` form for the
+ *      6 bullets being cited; leaves all other strings untouched.
+ *   3. Adds `sources` to existing object-form cons that match.
+ *
+ * Idempotent: skips conversion when a `sources` array is already
+ * present on a bullet.
+ *
+ * Run: node scripts/add-portugal-citations.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DATA_DIR = join(__dirname, '..', 'data', 'locations');
+
+const ACCESSED = '2026-05-03';
+
+// ─── Citation library ──────────────────────────────────────────────────
+
+/** AIMA (Portuguese immigration agency, replaced SEF in 2023) — D7 visa
+ *  page. The minimum income is the IAS / minimum wage. 2025: €870/mo. */
+const AIMA_D7 = {
+  title: 'AIMA — D7 (Passive Income / Retirement) Visa requirements',
+  url: 'https://www.aima.gov.pt/en/viver/vistos/d7---visto-de-residencia-para-aposentados-e-titulares-de-rendimentos',
+  accessed: ACCESSED,
+};
+
+/** Diário da República — 2025 Portuguese national minimum wage / RMG
+ *  notice setting the figure D7 applicants must match. */
+const PT_MIN_WAGE_2025 = {
+  title: 'Decreto-Lei n.º 87-A/2024 — 2025 RMG (€870/mo)',
+  url: 'https://diariodarepublica.pt/dr/detalhe/decreto-lei/87-a-2024-902317036',
+  accessed: ACCESSED,
+};
+
+/** EF English Proficiency Index — Portugal ranking. Updated annually. */
+const EF_EPI_PT = {
+  title: 'EF English Proficiency Index 2024 — Portugal',
+  url: 'https://www.ef.com/wwen/epi/regions/europe/portugal/',
+  accessed: ACCESSED,
+};
+
+/** AIMA permanent residency — Portuguese A2 language certificate
+ *  requirement after 5 years legal residence. */
+const AIMA_PR_LANGUAGE = {
+  title: 'AIMA — Permanent residence (Autorização de Residência Permanente)',
+  url: 'https://www.aima.gov.pt/en/viver/autorizacao-de-residencia/autorizacao-de-residencia-permanente',
+  accessed: ACCESSED,
+};
+
+/** UNESCO World Heritage — Historic Centre of Oporto. */
+const UNESCO_PORTO = {
+  title: 'UNESCO World Heritage List — Historic Centre of Oporto, Luiz I Bridge and Monastery of Serra do Pilar',
+  url: 'https://whc.unesco.org/en/list/755',
+  accessed: ACCESSED,
+};
+
+/** CP (Comboios de Portugal) — Linha de Cascais published timetable.
+ *  Lisbon Cais do Sodré ↔ Cascais ~33-40 min depending on stops. */
+const CP_CASCAIS = {
+  title: 'CP — Linha de Cascais timetable (Lisboa Cais do Sodré ↔ Cascais)',
+  url: 'https://www.cp.pt/passageiros/en/train-times/lines/cascais-line',
+  accessed: ACCESSED,
+};
+
+// ─── Per-city bullet updates ───────────────────────────────────────────
+
+/**
+ * Each entry describes a precise bullet replacement for a specific city.
+ *  - `pro` or `con` selects which array to operate on.
+ *  - `match` is the EXACT string the bullet must currently equal (after
+ *    text-extraction). Belt-and-suspenders for safety against drift.
+ *  - `replacement.text` is the new bullet text (may differ from match
+ *    when correcting outdated facts; see Lisbon D7 below).
+ *  - `replacement.sources` is the `Source[]` to attach.
+ */
+const UPDATES = [
+  // Lisbon — outdated D7 figure (€705/mo) → €870/mo (2025 minimum wage)
+  {
+    city: 'portugal-lisbon',
+    field: 'pros',
+    match: 'Lowest visa threshold (EUR 705/mo)',
+    replacement: {
+      text: 'Low D7 visa threshold: passive income at least €870/mo (2025 Portuguese minimum wage)',
+      sources: [AIMA_D7, PT_MIN_WAGE_2025],
+    },
+  },
+  // Lisbon — English proficiency
+  {
+    city: 'portugal-lisbon',
+    field: 'pros',
+    match: 'High English proficiency',
+    replacement: {
+      text: 'High English proficiency (Portugal ranks in EF EPI Very High Proficiency tier)',
+      sources: [EF_EPI_PT],
+    },
+  },
+  // Lisbon — language requirement for permanent residency
+  {
+    city: 'portugal-lisbon',
+    field: 'cons',
+    match: 'Language barrier for permanent residency',
+    replacement: {
+      text: 'Permanent residency requires A2 Portuguese language certificate after 5 years',
+      sources: [AIMA_PR_LANGUAGE],
+    },
+  },
+  // Porto — UNESCO heritage
+  {
+    city: 'portugal-porto',
+    field: 'pros',
+    match: 'UNESCO World Heritage riverside district',
+    replacement: {
+      text: 'UNESCO World Heritage riverside district (Historic Centre of Oporto, listed 1996)',
+      sources: [UNESCO_PORTO],
+    },
+  },
+  // Cascais — train connection
+  {
+    city: 'portugal-cascais',
+    field: 'pros',
+    match: 'Train connection to Lisbon (35 min)',
+    replacement: {
+      text: 'Train connection to Lisbon (~35 min on the CP Linha de Cascais)',
+      sources: [CP_CASCAIS],
+    },
+  },
+];
+
+// ─── Apply ─────────────────────────────────────────────────────────────
+
+let updated = 0;
+let alreadyCited = 0;
+let notFound = 0;
+
+for (const u of UPDATES) {
+  const path = join(DATA_DIR, u.city, 'location.json');
+  const raw = readFileSync(path, 'utf8');
+  const loc = JSON.parse(raw);
+  const list = loc[u.field];
+  if (!Array.isArray(list)) {
+    console.warn(`SKIP ${u.city} — no ${u.field} array`);
+    continue;
+  }
+  let found = false;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i];
+    const text = typeof entry === 'string' ? entry : entry?.text;
+    if (text !== u.match) continue;
+    found = true;
+    if (typeof entry !== 'string' && entry?.sources?.length) {
+      alreadyCited++;
+      console.log(`-    ${u.city}.${u.field}: already cited — "${u.match}"`);
+      break;
+    }
+    list[i] = u.replacement;
+    updated++;
+    console.log(`OK   ${u.city}.${u.field}: cited "${u.match}"`);
+    break;
+  }
+  if (!found) {
+    notFound++;
+    console.warn(`MISS ${u.city}.${u.field}: bullet not found — "${u.match}"`);
+    continue;
+  }
+  const hadTrailingNewline = raw.endsWith('\n');
+  writeFileSync(path, JSON.stringify(loc, null, 2) + (hadTrailingNewline ? '\n' : ''));
+}
+
+console.log(`\nDone. Updated ${updated}, already-cited ${alreadyCited}, not-found ${notFound}`);


### PR DESCRIPTION
## Summary

First slice of [Todo #19](https://github.com/justice8096/retirement-dashboard-angular/) — pros/cons source citations. Portugal is the beachhead since it has the highest density of citable program-level facts (D7 visa, NHR tax, permanent-residency language requirement, UNESCO heritage sites, CP rail timetables).

Per the #19 strategy: most bullets are lifestyle/climate subjectives that aren't source-able. This pass hits 5 falsifiable bullets across 3 cities, plus one **factual fix** on a stale figure that surfaced during research.

## Citations added

### Lisbon (3)
- **`Lowest visa threshold (EUR 705/mo)` → UPDATED + cited.** The D7 minimum passive income is the Portuguese minimum wage, which is **€870/mo for 2025** (Decreto-Lei 87-A/2024). The €705 figure is years stale.
  - New text: *"Low D7 visa threshold: passive income at least €870/mo (2025 Portuguese minimum wage)"*
  - Sources: AIMA D7 page + Diário da República 2025 RMG decree
- **`High English proficiency`** — cited
  - Source: EF English Proficiency Index 2024 (Portugal in Very High Proficiency tier)
- **`Language barrier for permanent residency`** — cited
  - Source: AIMA permanent-residency page (A2 Portuguese certificate after 5 years)

### Porto (1)
- **`UNESCO World Heritage riverside district`** — cited
  - Source: UNESCO listing 755 (Historic Centre of Oporto, 1996)

### Cascais (1)
- **`Train connection to Lisbon (35 min)`** — cited
  - Source: CP (Comboios de Portugal) Linha de Cascais timetable

## Migration shape

Pros were plain \`string[]\` (legacy shape per \`shared.model.ts\` \`ProConBullet = string | { text, sources? }\`). Cited bullets converted to \`{ text, sources }\` form. Uncited strings preserved unchanged — the \`bulletText\` / \`bulletSources\` helpers handle both forms.

Cons were already mostly object form (from the earlier crime-citation pass); the language-barrier bullet had no sources, now does.

## Implementation

One-shot Node script: \`scripts/add-portugal-citations.mjs\`.
- Idempotent (skips bullets that already have sources)
- Each citation keyed by exact-string match against the current bullet text (defensive against drift; warns if not found)
- Shared \`Source\` constants at the top — reusable across cities

## Out of scope (file as follow-up)

- Other Portugal bullets (lifestyle / climate subjectives — not source-able per #19)
- Spain (NLV, Beckham Law, regional health systems)
- France (PUMA, Mutuelle, ALD program list)
- Other 11 countries — sweep one country at a time once this pattern is validated

## Test plan

- [x] All 3 location.json files round-trip cleanly (key order + indentation preserved)
- [x] \`npm test\` (vitest): 35,499/35,499 pass — data changes don't affect route logic
- [x] Idempotency verified — re-running the script is a no-op
- [ ] **Reviewer step**: spot-check Lisbon's pros (D7 threshold + English) on a deployed dashboard build, confirm the source-tooltip shows the structured citations and the D7 figure is now €870

🤖 Generated with [Claude Code](https://claude.com/claude-code)