### PR TITLE
data(france): cite 6 falsifiable pros/cons (#19, third country sweep)

### DIFF
--- a/data/locations/france-brittany/location.json
+++ b/data/locations/france-brittany/location.json
@@ -256,7 +256,21 @@
     "safetyRating": 8
   },
   "pros": [
-    "Excellent healthcare (PUMA)",
+    {
+      "text": "Excellent healthcare via PUMA (Protection Universelle Maladie) — universal access for residents under Code SS Art. L160-1",
+      "sources": [
+        {
+          "title": "Code de la sécurité sociale — Article L160-1 (Protection Universelle Maladie)",
+          "url": "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031672250",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "service-public.fr — Protection Universelle Maladie (PUMA)",
+          "url": "https://www.service-public.fr/particuliers/vosdroits/F34307",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "No pet fees",
     "Dog-friendly culture",
     "Good transit",
@@ -270,7 +284,19 @@
       "text": "Limited English"
     },
     {
-      "text": "Complex tax situation with US"
+      "text": "Complex tax situation: US persons remain subject to US tax under the 1994 US-France treaty (saving clause); FBAR/FATCA reporting still required",
+      "sources": [
+        {
+          "title": "Convention fiscale franco-américaine du 31 août 1994 (with 2004/2009 protocols)",
+          "url": "https://www.impots.gouv.fr/sites/default/files/media/10_conventions/etats_unis/etats-unis_convention-avec-les-etats-unis_fd_3160.pdf",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "IRS — France Tax Treaty Documents",
+          "url": "https://www.irs.gov/businesses/international-businesses/france-tax-treaty-documents",
+          "accessed": "2026-05-03"
+        }
+      ]
     },
     {
       "text": "Distance from US"

--- a/data/locations/france-languedoc/location.json
+++ b/data/locations/france-languedoc/location.json
@@ -165,7 +165,16 @@
   "pros": [
     "Warm Mediterranean climate in southern France",
     "Affordable by French standards",
-    "Montpellier is a vibrant university city with tram system"
+    {
+      "text": "Montpellier is a vibrant university city with the TaM tram (4 lines, ~83 km — among the largest French tram networks outside Paris)",
+      "sources": [
+        {
+          "title": "TaM — Tramway de Montpellier (4 lines, ~83 km)",
+          "url": "https://www.tam-voyages.com/le-reseau/tramway",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/data/locations/france-paris/location.json
+++ b/data/locations/france-paris/location.json
@@ -164,7 +164,21 @@
   },
   "pros": [
     "Unmatched cultural offerings (museums, theater, cuisine)",
-    "World-class public transit (metro, RER, buses)",
+    {
+      "text": "World-class public transit: 16-line métro + RER + bus network operated under Île-de-France Mobilités (~1.5 billion annual métro riders)",
+      "sources": [
+        {
+          "title": "Île-de-France Mobilités — Paris regional transit network",
+          "url": "https://www.iledefrance-mobilites.fr/en/discover/transport-network",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "RATP — Métro de Paris (16 lines, ~225 km, ~1.5 billion annual riders)",
+          "url": "https://www.ratp.fr/en/metro",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "International city with huge expat community"
   ],
   "cons": [

--- a/data/locations/france-toulouse/location.json
+++ b/data/locations/france-toulouse/location.json
@@ -246,7 +246,16 @@
   },
   "pros": [
     "4th largest city with lower costs than Paris/Lyon",
-    "Aerospace hub (Airbus HQ) with international community",
+    {
+      "text": "Aerospace hub: Airbus corporate HQ in Toulouse-Blagnac (final assembly for A320/A330/A350)",
+      "sources": [
+        {
+          "title": "Airbus — Toulouse-Blagnac corporate headquarters",
+          "url": "https://www.airbus.com/en/about-us/our-locations/france",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "Warmer than Lyon/Paris",
     "Excellent transit (metro + tram)",
     "Pink city charm and vibrant food scene",
@@ -263,7 +272,19 @@
       "text": "Less English spoken than major tourist cities"
     },
     {
-      "text": "Complex French tax situation with US"
+      "text": "Complex French tax situation: US persons remain subject to US tax under the 1994 US-France treaty (saving clause); FBAR/FATCA reporting still required",
+      "sources": [
+        {
+          "title": "Convention fiscale franco-américaine du 31 août 1994 (with 2004/2009 protocols)",
+          "url": "https://www.impots.gouv.fr/sites/default/files/media/10_conventions/etats_unis/etats-unis_convention-avec-les-etats-unis_fd_3160.pdf",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "IRS — France Tax Treaty Documents",
+          "url": "https://www.irs.gov/businesses/international-businesses/france-tax-treaty-documents",
+          "accessed": "2026-05-03"
+        }
+      ]
     },
     {
       "text": "Safety & crime: see cited reports for current figures by city and country",

--- a/scripts/add-france-citations.mjs
+++ b/scripts/add-france-citations.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * One-shot data migration: add structured `Source[]` citations to
+ * falsifiable France pros/cons bullets (Todo #19, third country sweep
+ * after Portugal #96 and Spain #97).
+ *
+ * Same pattern as the prior two:
+ *   - Per-city, per-bullet exact-string match (defensive)
+ *   - Idempotent (skips bullets that already have sources, unless
+ *     `overwrite: true` is set)
+ *   - Shared `Source` constants reusable across cities
+ *
+ * Falsifiable bullets targeted (5 + a shared cite applied to 2 cities):
+ *   - Brittany pro:  "Excellent healthcare (PUMA)"
+ *   - Brittany con:  "Complex tax situation with US" (shared US-FR tax cite)
+ *   - Toulouse con:  "Complex French tax situation with US" (same shared cite)
+ *   - Toulouse pro:  "Aerospace hub (Airbus HQ) with international community"
+ *   - Paris pro:     "World-class public transit (metro, RER, buses)"
+ *   - Languedoc pro: "Montpellier is a vibrant university city with tram system"
+ *
+ * Run: node scripts/add-france-citations.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DATA_DIR = join(__dirname, '..', 'data', 'locations');
+
+const ACCESSED = '2026-05-03';
+
+// ─── Citation library ──────────────────────────────────────────────────
+
+/** Code de la sécurité sociale Article L160-1 — establishes PUMA
+ *  (Protection Universelle Maladie). Universal access for residents
+ *  with stable residence, regardless of work status. */
+const FR_PUMA_CSS = {
+  title: 'Code de la sécurité sociale — Article L160-1 (Protection Universelle Maladie)',
+  url: 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031672250',
+  accessed: ACCESSED,
+};
+
+/** service-public.fr — citizen-facing PUMA explainer. */
+const FR_PUMA_EXPLAINER = {
+  title: 'service-public.fr — Protection Universelle Maladie (PUMA)',
+  url: 'https://www.service-public.fr/particuliers/vosdroits/F34307',
+  accessed: ACCESSED,
+};
+
+/** US-France income tax treaty. The 1994 convention + 2004 + 2009
+ *  protocols govern dual-tax situations for US persons in France
+ *  (saving clause, foreign earned income, retirement accounts, etc.). */
+const US_FR_TAX_TREATY = {
+  title: 'Convention fiscale franco-américaine du 31 août 1994 (with 2004/2009 protocols)',
+  url: 'https://www.impots.gouv.fr/sites/default/files/media/10_conventions/etats_unis/etats-unis_convention-avec-les-etats-unis_fd_3160.pdf',
+  accessed: ACCESSED,
+};
+
+const US_FR_IRS_TREATY_PAGE = {
+  title: 'IRS — France Tax Treaty Documents',
+  url: 'https://www.irs.gov/businesses/international-businesses/france-tax-treaty-documents',
+  accessed: ACCESSED,
+};
+
+/** Airbus Group — corporate HQ in Toulouse-Blagnac (final assembly
+ *  lines for A320/A330/A350 also in Toulouse). */
+const AIRBUS_HQ = {
+  title: 'Airbus — Toulouse-Blagnac corporate headquarters',
+  url: 'https://www.airbus.com/en/about-us/our-locations/france',
+  accessed: ACCESSED,
+};
+
+/** Île-de-France Mobilités — Paris transit network operator. RATP
+ *  + SNCF Transilien combined network statistics. */
+const PARIS_IDFM = {
+  title: 'Île-de-France Mobilités — Paris regional transit network',
+  url: 'https://www.iledefrance-mobilites.fr/en/discover/transport-network',
+  accessed: ACCESSED,
+};
+
+const PARIS_RATP = {
+  title: 'RATP — Métro de Paris (16 lines, ~225 km, ~1.5 billion annual riders)',
+  url: 'https://www.ratp.fr/en/metro',
+  accessed: ACCESSED,
+};
+
+/** TaM (Transports de l'agglomération de Montpellier) — Montpellier
+ *  tram network. 4 lines, ~83 km — among the largest French tram
+ *  systems outside Paris. */
+const MONTPELLIER_TAM = {
+  title: "TaM — Tramway de Montpellier (4 lines, ~83 km)",
+  url: 'https://www.tam-voyages.com/le-reseau/tramway',
+  accessed: ACCESSED,
+};
+
+// ─── Per-city bullet updates ───────────────────────────────────────────
+
+const UPDATES = [
+  // Brittany — PUMA universal healthcare
+  {
+    city: 'france-brittany',
+    field: 'pros',
+    match: 'Excellent healthcare (PUMA)',
+    replacement: {
+      text: 'Excellent healthcare via PUMA (Protection Universelle Maladie) — universal access for residents under Code SS Art. L160-1',
+      sources: [FR_PUMA_CSS, FR_PUMA_EXPLAINER],
+    },
+  },
+  // Brittany — US-France tax treaty
+  {
+    city: 'france-brittany',
+    field: 'cons',
+    match: 'Complex tax situation with US',
+    replacement: {
+      text: 'Complex tax situation: US persons remain subject to US tax under the 1994 US-France treaty (saving clause); FBAR/FATCA reporting still required',
+      sources: [US_FR_TAX_TREATY, US_FR_IRS_TREATY_PAGE],
+    },
+  },
+  // Toulouse — Airbus HQ
+  {
+    city: 'france-toulouse',
+    field: 'pros',
+    match: 'Aerospace hub (Airbus HQ) with international community',
+    replacement: {
+      text: 'Aerospace hub: Airbus corporate HQ in Toulouse-Blagnac (final assembly for A320/A330/A350)',
+      sources: [AIRBUS_HQ],
+    },
+  },
+  // Toulouse — same US-FR tax treaty cite, slightly different bullet wording
+  {
+    city: 'france-toulouse',
+    field: 'cons',
+    match: 'Complex French tax situation with US',
+    replacement: {
+      text: 'Complex French tax situation: US persons remain subject to US tax under the 1994 US-France treaty (saving clause); FBAR/FATCA reporting still required',
+      sources: [US_FR_TAX_TREATY, US_FR_IRS_TREATY_PAGE],
+    },
+  },
+  // Paris — public transit
+  {
+    city: 'france-paris',
+    field: 'pros',
+    match: 'World-class public transit (metro, RER, buses)',
+    replacement: {
+      text: 'World-class public transit: 16-line métro + RER + bus network operated under Île-de-France Mobilités (~1.5 billion annual métro riders)',
+      sources: [PARIS_IDFM, PARIS_RATP],
+    },
+  },
+  // Languedoc — Montpellier tram
+  {
+    city: 'france-languedoc',
+    field: 'pros',
+    match: 'Montpellier is a vibrant university city with tram system',
+    replacement: {
+      text: 'Montpellier is a vibrant university city with the TaM tram (4 lines, ~83 km — among the largest French tram networks outside Paris)',
+      sources: [MONTPELLIER_TAM],
+    },
+  },
+];
+
+// ─── Apply (same harness as Spain script — idempotent, overwrite-aware) ──
+
+let updated = 0;
+let alreadyCited = 0;
+let notFound = 0;
+
+for (const u of UPDATES) {
+  const path = join(DATA_DIR, u.city, 'location.json');
+  const raw = readFileSync(path, 'utf8');
+  const loc = JSON.parse(raw);
+  const list = loc[u.field];
+  if (!Array.isArray(list)) {
+    console.warn(`SKIP ${u.city} — no ${u.field} array`);
+    continue;
+  }
+  let found = false;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i];
+    const text = typeof entry === 'string' ? entry : entry?.text;
+    if (text !== u.match) continue;
+    found = true;
+    if (typeof entry !== 'string' && entry?.sources?.length && !u.overwrite) {
+      alreadyCited++;
+      console.log(`-    ${u.city}.${u.field}: already cited — "${u.match}"`);
+      break;
+    }
+    const wasOverwrite = !!u.overwrite && typeof entry !== 'string' && entry?.sources?.length;
+    list[i] = u.replacement;
+    updated++;
+    console.log(
+      `${wasOverwrite ? 'OVR ' : 'OK  '} ${u.city}.${u.field}: ` +
+      `${wasOverwrite ? 'replaced low-quality citations' : 'cited'} "${u.match}"`,
+    );
+    break;
+  }
+  if (!found) {
+    notFound++;
+    console.warn(`MISS ${u.city}.${u.field}: bullet not found — "${u.match}"`);
+    continue;
+  }
+  const hadTrailingNewline = raw.endsWith('\n');
+  writeFileSync(path, JSON.stringify(loc, null, 2) + (hadTrailingNewline ? '\n' : ''));
+}
+
+console.log(`\nDone. Updated ${updated}, already-cited ${alreadyCited}, not-found ${notFound}`);


### PR DESCRIPTION
## Summary

Third slice of [Todo #19](https://github.com/justice8096/retirement-dashboard-angular/) — same per-bullet exact-string match + idempotent script + shared \`Source\` constants pattern as Portugal ([#96](https://github.com/justice8096/retirement-api/pull/96)) and Spain ([#97](https://github.com/justice8096/retirement-api/pull/97)).

## Citations added (6 bullets, 4 cities)

### Brittany (2)
- **`Excellent healthcare (PUMA)`** — cited
  - Sources: Code SS Article L160-1 (Légifrance) + service-public.fr explainer
- **`Complex tax situation with US`** — cited
  - Sources: 1994 US-FR tax convention (impots.gouv.fr) + IRS France treaty page

### Toulouse (2)
- **`Aerospace hub (Airbus HQ) with international community`** — cited
  - New text: *"Airbus corporate HQ in Toulouse-Blagnac (final assembly for A320/A330/A350)"*
  - Source: Airbus official locations page
- **`Complex French tax situation with US`** — cited
  - **Same shared US-FR treaty cite as Brittany** — programmatic reuse of \`Source[]\` constants validates the script's design.

### Paris (1)
- **`World-class public transit (metro, RER, buses)`** — cited
  - New text: *"16-line métro + RER + bus network operated under Île-de-France Mobilités (~1.5 billion annual métro riders)"*
  - Sources: IDFM network page + RATP métro page

### Languedoc (1)
- **`Montpellier is a vibrant university city with tram system`** — cited
  - New text: *"TaM tram (4 lines, ~83 km — among the largest French tram networks outside Paris)"*
  - Source: TaM official tram page

## Test plan

- [x] 4 location.json files round-trip cleanly (key order + indent preserved)
- [x] \`npm test\` (vitest): 35,499/35,499 pass
- [x] Idempotency confirmed: re-running script produces no further changes

## Pattern progress

| Country | PR | Bullets cited |
|---|---|---|
| Portugal | [#96](https://github.com/justice8096/retirement-api/pull/96) | 5 (incl. €705→€870 D7 fix) |
| Spain | [#97](https://github.com/justice8096/retirement-api/pull/97) | 4 (incl. low-quality source replacement) |
| France | this PR | 6 |
| **Total** | | **15 across 3 countries × 10 cities** |

Scripts archived in \`scripts/\` for reuse + as documentation of which authoritative sources were chosen for which claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)