### PR TITLE
data(cyprus): cite 2 falsifiable pros + fix pension tax conflation (#19)

### DIFF
--- a/data/locations/cyprus-larnaca/location.json
+++ b/data/locations/cyprus-larnaca/location.json
@@ -164,7 +164,16 @@
   },
   "pros": [
     "Most affordable Cypriot city",
-    "International airport for easy travel",
+    {
+      "text": "International airport for easy travel (Larnaca International — Cyprus' main gateway, ~7M annual passengers)",
+      "sources": [
+        {
+          "title": "Hermes Airports — Larnaca International Airport (LCA)",
+          "url": "https://www.hermesairports.com/larnaka",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "Relaxed beach town atmosphere"
   ],
   "cons": [

--- a/data/locations/cyprus-paphos/location.json
+++ b/data/locations/cyprus-paphos/location.json
@@ -165,7 +165,26 @@
   "pros": [
     "Massive British expat community, English widely spoken",
     "Warm year-round climate with 340 days of sunshine",
-    "Very favorable tax treatment for retirees (2.65% on pensions)"
+    {
+      "text": "Very favorable tax treatment for retirees: optional 5% flat tax on foreign pension income above €3,420/yr (or normal progressive brackets) + separate 2.65% GeSY health contribution",
+      "sources": [
+        {
+          "title": "Cyprus Tax Department — Income Tax Law (foreign pension special regime, Art. 13)",
+          "url": "https://www.mof.gov.cy/mof/tax/taxdep.nsf",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "PwC Cyprus — Pension income tax options for retirees",
+          "url": "https://taxsummaries.pwc.com/cyprus/individual/income-determination",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Health Insurance Organisation Cyprus — GeSY contribution rates (2.65% pensioner rate)",
+          "url": "https://www.gesy.org.cy/en-gb/contributions",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/scripts/add-cyprus-citations.mjs
+++ b/scripts/add-cyprus-citations.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Cyprus citations (Todo #19, ninth country sweep).
+ * 2 bullets across 2 cities, including a factual fix on Cyprus retiree
+ * pension tax (the bullet conflated the 5% pension flat tax with the
+ * 2.65% GeSY healthcare contribution).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DATA_DIR = join(__dirname, '..', 'data', 'locations');
+const ACCESSED = '2026-05-03';
+
+/** Cyprus Tax Department — pension income special regime (Article 13
+ *  of Income Tax Law). Retirees can elect 5% flat tax on foreign-source
+ *  pension income above €3,420/yr, or use normal progressive brackets —
+ *  whichever is lower. */
+const CY_TAX_DEPT = {
+  title: 'Cyprus Tax Department — Income Tax Law (foreign pension special regime, Art. 13)',
+  url: 'https://www.mof.gov.cy/mof/tax/taxdep.nsf',
+  accessed: ACCESSED,
+};
+
+const CY_INCOME_TAX_GUIDE = {
+  title: 'PwC Cyprus — Pension income tax options for retirees',
+  url: 'https://taxsummaries.pwc.com/cyprus/individual/income-determination',
+  accessed: ACCESSED,
+};
+
+/** GeSY (General Health System) contribution rate — 2.65% of income
+ *  for employees / pensioners. Separate from income tax. */
+const GESY_RATES = {
+  title: 'Health Insurance Organisation Cyprus — GeSY contribution rates (2.65% pensioner rate)',
+  url: 'https://www.gesy.org.cy/en-gb/contributions',
+  accessed: ACCESSED,
+};
+
+/** Larnaca International Airport (LCA) — Cyprus' main international
+ *  gateway, ~7M annual passengers, operated by Hermes Airports. */
+const LCA_AIRPORT = {
+  title: 'Hermes Airports — Larnaca International Airport (LCA)',
+  url: 'https://www.hermesairports.com/larnaka',
+  accessed: ACCESSED,
+};
+
+const UPDATES = [
+  {
+    city: 'cyprus-larnaca',
+    field: 'pros',
+    match: 'International airport for easy travel',
+    replacement: {
+      text: "International airport for easy travel (Larnaca International — Cyprus' main gateway, ~7M annual passengers)",
+      sources: [LCA_AIRPORT],
+    },
+  },
+  {
+    // FIX: bullet conflates GeSY (2.65%) with pension tax. Real pension
+    // regime is optional 5% flat above €3,420/yr or normal progressive.
+    city: 'cyprus-paphos',
+    field: 'pros',
+    match: 'Very favorable tax treatment for retirees (2.65% on pensions)',
+    replacement: {
+      text: 'Very favorable tax treatment for retirees: optional 5% flat tax on foreign pension income above €3,420/yr (or normal progressive brackets) + separate 2.65% GeSY health contribution',
+      sources: [CY_TAX_DEPT, CY_INCOME_TAX_GUIDE, GESY_RATES],
+    },
+  },
+];
+
+let updated = 0, alreadyCited = 0, notFound = 0;
+
+for (const u of UPDATES) {
+  const path = join(DATA_DIR, u.city, 'location.json');
+  const raw = readFileSync(path, 'utf8');
+  const loc = JSON.parse(raw);
+  const list = loc[u.field];
+  if (!Array.isArray(list)) { console.warn(`SKIP ${u.city} — no ${u.field}`); continue; }
+  let found = false;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i];
+    const text = typeof entry === 'string' ? entry : entry?.text;
+    if (text !== u.match) continue;
+    found = true;
+    if (typeof entry !== 'string' && entry?.sources?.length && !u.overwrite) {
+      alreadyCited++;
+      console.log(`-    ${u.city}.${u.field}: already cited`);
+      break;
+    }
+    list[i] = u.replacement;
+    updated++;
+    console.log(`OK   ${u.city}.${u.field}: cited "${u.match}"`);
+    break;
+  }
+  if (!found) { notFound++; console.warn(`MISS ${u.city}.${u.field}: "${u.match}"`); continue; }
+  const hadTrailingNewline = raw.endsWith('\n');
+  writeFileSync(path, JSON.stringify(loc, null, 2) + (hadTrailingNewline ? '\n' : ''));
+}
+
+console.log(`\nDone. Updated ${updated}, already-cited ${alreadyCited}, not-found ${notFound}`);


### PR DESCRIPTION
## Summary

Ninth country sweep for [Todo #19](https://github.com/justice8096/retirement-dashboard-angular/). Smaller batch (Cyprus has only 3 cities), but includes a **factual fix** — the second one in the citation sweep.

## The fix: Paphos pension tax was conflated

**Original**: *"Very favorable tax treatment for retirees (2.65% on pensions)"*

The 2.65% figure is the **GeSY healthcare contribution rate**, not the pension tax. Cyprus retirees can:
- Elect a **5% flat tax** on foreign pension income above €3,420/yr (Income Tax Law Art. 13), OR
- Use normal progressive brackets

The bullet conflated two separate Cyprus levies. Fixed + cited.

**Updated**: *"optional 5% flat tax on foreign pension income above €3,420/yr (or normal progressive brackets) + separate 2.65% GeSY health contribution"*

Sources: Cyprus Tax Dept Income Tax Law + PwC summary + Health Insurance Organisation Cyprus

## Other citations

- **Larnaca**: International airport — Hermes Airports / LCA (~7M annual passengers)

## Pattern milestone

This is the **second factual correction** surfaced during the citation sweep (after Portugal [#96](https://github.com/justice8096/retirement-api/pull/96) fixed €705 → €870 D7 visa figure). The "research-driven citation" approach continues to surface outdated/incorrect data alongside missing sources — a useful side effect.

## Test plan
- [x] Files round-trip cleanly
- [x] \`npm test\`: 35,517/35,517 pass

## Pattern progress
**37 cited across 9 countries × 31 cities.**

| Country | PR | Bullets |
|---|---|---|
| Portugal | [#96](https://github.com/justice8096/retirement-api/pull/96) | 5 |
| Spain | [#97](https://github.com/justice8096/retirement-api/pull/97) (merged) | 4 |
| France | [#98](https://github.com/justice8096/retirement-api/pull/98) | 6 |
| Italy | [#99](https://github.com/justice8096/retirement-api/pull/99) | 4 |
| Mexico | [#100](https://github.com/justice8096/retirement-api/pull/100) | 5 |
| Costa Rica | [#101](https://github.com/justice8096/retirement-api/pull/101) | 3 |
| Greece | [#102](https://github.com/justice8096/retirement-api/pull/102) | 4 |
| Croatia | [#103](https://github.com/justice8096/retirement-api/pull/103) | 4 |
| Cyprus | this PR | 2 (incl. fix) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)