### PR TITLE
data: Italy 7% retiree flat tax + Atenas/Alicante rewords (#40 + #39)

### DIFF
--- a/data/locations/costa-rica-atenas/location.json
+++ b/data/locations/costa-rica-atenas/location.json
@@ -156,7 +156,21 @@
     "safetyRating": 7
   },
   "pros": [
-    "Claimed 'best climate in the world' by National Geographic",
+    {
+      "text": "Notably stable mild climate year-round (avg highs 28-30°C / 82-86°F, lows 18-20°C / 64-68°F; dry season Dec-April; ~700m elevation)",
+      "sources": [
+        {
+          "title": "Climate-Data.org — Atenas, Costa Rica (avg highs 28-30°C / lows 18-20°C, dry season Dec-April)",
+          "url": "https://en.climate-data.org/north-america/costa-rica/alajuela/atenas-22729/",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Instituto Meteorológico Nacional Costa Rica (IMN) — Climate stations",
+          "url": "https://www.imn.ac.cr/",
+          "accessed": "2026-05-03"
+        }
+      ]
+    },
     "Close to San José for healthcare and shopping",
     "Established expat community in small-town setting"
   ],

--- a/data/locations/italy-abruzzo/location.json
+++ b/data/locations/italy-abruzzo/location.json
@@ -165,7 +165,27 @@
   "pros": [
     "Among the most affordable regions in Italy",
     "Both mountains and coast within 30 minutes",
-    "Authentic Italian lifestyle without mass tourism"
+    "Authentic Italian lifestyle without mass tourism",
+    {
+      "text": "7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)",
+      "sources": [
+        {
+          "title": "Italian TUIR Art. 24-ter (Normattiva — opzione per imposta sostitutiva 7% sui redditi di fonte estera)",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1986-12-22;917!vig=",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Decreto-Legge 30 aprile 2019, n. 34 (Decreto Crescita) — introduces 7% flat-tax regime for foreign retirees",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legge:2019-04-30;34",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Agenzia delle Entrate — Regime opzionale per pensionati esteri (TUIR Art. 24-ter)",
+          "url": "https://www.agenziaentrate.gov.it/portale/web/guest/schede/agevolazioni/regimespecialepensionatiesteri/scheda-info-regime-pensionati-esteri",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/data/locations/italy-puglia/location.json
+++ b/data/locations/italy-puglia/location.json
@@ -174,6 +174,26 @@
           "accessed": "2026-05-03"
         }
       ]
+    },
+    {
+      "text": "7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)",
+      "sources": [
+        {
+          "title": "Italian TUIR Art. 24-ter (Normattiva — opzione per imposta sostitutiva 7% sui redditi di fonte estera)",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1986-12-22;917!vig=",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Decreto-Legge 30 aprile 2019, n. 34 (Decreto Crescita) — introduces 7% flat-tax regime for foreign retirees",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legge:2019-04-30;34",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Agenzia delle Entrate — Regime opzionale per pensionati esteri (TUIR Art. 24-ter)",
+          "url": "https://www.agenziaentrate.gov.it/portale/web/guest/schede/agevolazioni/regimespecialepensionatiesteri/scheda-info-regime-pensionati-esteri",
+          "accessed": "2026-05-03"
+        }
+      ]
     }
   ],
   "cons": [

--- a/data/locations/italy-sardinia/location.json
+++ b/data/locations/italy-sardinia/location.json
@@ -165,7 +165,27 @@
   "pros": [
     "Stunning beaches rivaling Caribbean quality",
     "Warm Mediterranean climate",
-    "Unique Sardinian culture and cuisine"
+    "Unique Sardinian culture and cuisine",
+    {
+      "text": "7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)",
+      "sources": [
+        {
+          "title": "Italian TUIR Art. 24-ter (Normattiva — opzione per imposta sostitutiva 7% sui redditi di fonte estera)",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1986-12-22;917!vig=",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Decreto-Legge 30 aprile 2019, n. 34 (Decreto Crescita) — introduces 7% flat-tax regime for foreign retirees",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legge:2019-04-30;34",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Agenzia delle Entrate — Regime opzionale per pensionati esteri (TUIR Art. 24-ter)",
+          "url": "https://www.agenziaentrate.gov.it/portale/web/guest/schede/agevolazioni/regimespecialepensionatiesteri/scheda-info-regime-pensionati-esteri",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/data/locations/italy-sicily/location.json
+++ b/data/locations/italy-sicily/location.json
@@ -165,7 +165,27 @@
   "pros": [
     "Among the cheapest places to live in Western Europe",
     "Incredible food, history, and natural beauty",
-    "Warm climate with mild winters"
+    "Warm climate with mild winters",
+    {
+      "text": "7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)",
+      "sources": [
+        {
+          "title": "Italian TUIR Art. 24-ter (Normattiva — opzione per imposta sostitutiva 7% sui redditi di fonte estera)",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1986-12-22;917!vig=",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Decreto-Legge 30 aprile 2019, n. 34 (Decreto Crescita) — introduces 7% flat-tax regime for foreign retirees",
+          "url": "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legge:2019-04-30;34",
+          "accessed": "2026-05-03"
+        },
+        {
+          "title": "Agenzia delle Entrate — Regime opzionale per pensionati esteri (TUIR Art. 24-ter)",
+          "url": "https://www.agenziaentrate.gov.it/portale/web/guest/schede/agevolazioni/regimespecialepensionatiesteri/scheda-info-regime-pensionati-esteri",
+          "accessed": "2026-05-03"
+        }
+      ]
+    }
   ],
   "cons": [
     {

--- a/data/locations/spain-alicante/location.json
+++ b/data/locations/spain-alicante/location.json
@@ -276,22 +276,22 @@
       ]
     },
     {
-      "text": "A2 Spanish required for permanent residency",
+      "text": "A2 Spanish + CCSE required for Spanish citizenship (after 10 years residency) — NOT for long-term-resident permit, which has no language test per EU Directive 2003/109/EC + RD 557/2011",
       "sources": [
         {
-          "title": "myspainvisa.com",
-          "url": "https://myspainvisa.com/non-lucrative-visa-spain/",
-          "accessed": "2026-04-23"
+          "title": "Ley 19/2015 + Real Decreto 1004/2015 — A2 Spanish + CCSE required for nationality (not residency)",
+          "url": "https://www.boe.es/buscar/act.php?id=BOE-A-2015-7391",
+          "accessed": "2026-05-03"
         },
         {
-          "title": "madridbullfighting.com",
-          "url": "https://madridbullfighting.com/blog/do-americans-need-a-visa-for-spain/",
-          "accessed": "2026-04-23"
+          "title": "Real Decreto 557/2011 — long-term residence permit (no language test, per EU Directive 2003/109/EC)",
+          "url": "https://www.boe.es/buscar/act.php?id=BOE-A-2011-7703",
+          "accessed": "2026-05-03"
         },
         {
-          "title": "etias.com",
-          "url": "https://etias.com/etias-requirements/etias-for-american-citizens",
-          "accessed": "2026-04-23"
+          "title": "Council Directive 2003/109/EC — long-term-resident third-country nationals (EU baseline)",
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32003L0109",
+          "accessed": "2026-05-03"
         }
       ]
     },

--- a/scripts/italy-7pct-and-procon-fixes.mjs
+++ b/scripts/italy-7pct-and-procon-fixes.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Two related data updates (Todos #39 + #40):
+ *
+ * 1. Italy 7% retiree flat tax (#40)
+ *    Adds a new pro to the 4 qualifying Italy locations (southern
+ *    regions + municipalities <20K population per TUIR Art. 24-ter
+ *    + Decreto Crescita 2019). Retirees electing this regime pay
+ *    a flat 7% on foreign-source income (pensions, dividends, etc.)
+ *    for 9 years from the year of relocation. Hugely retirement-
+ *    relevant; surfaced during the #19 Italy citation pass but
+ *    skipped because it's a NEW pro, not a citation to an existing
+ *    one.
+ *
+ *    Qualifying cities in our dataset: italy-abruzzo, italy-puglia,
+ *    italy-sardinia, italy-sicily.
+ *    NOT qualifying: italy-tuscany, italy-lake-region (northern/
+ *    central Italy — outside the eligible regions).
+ *
+ * 2. Pros/cons content rewords (#39)
+ *    Two bullets surfaced during the #19 country sweep where the
+ *    citation pass found the bullet text was imprecise or wrong:
+ *
+ *    a. Atenas (Costa Rica) pro: "Claimed 'best climate in the
+ *       world' by National Geographic" — the NatGeo attribution
+ *       is widely repeated but the original article isn't findable.
+ *       Rewrite to factual climate stats + cite Climate-Data.org +
+ *       IMN (Costa Rica's met office).
+ *
+ *    b. Alicante (Spain) con: "A2 Spanish required for permanent
+ *       residency" — claim is wrong. Spanish long-term residence
+ *       (residencia de larga duración) has NO language test per EU
+ *       Directive 2003/109/EC + RD 557/2011. A2 + CCSE is required
+ *       for *Spanish citizenship*, per Ley 19/2015 / RD 1004/2015.
+ *       Rewrite to clarify the citizenship distinction + cite both
+ *       sources.
+ *
+ * Run: node scripts/italy-7pct-and-procon-fixes.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const DATA_DIR = join(__dirname, '..', 'data', 'locations');
+const ACCESSED = '2026-05-03';
+
+// ─── Citation library ──────────────────────────────────────────────────
+
+// Italy 7% flat tax sources
+const ITALY_TUIR_24TER = {
+  title: 'Italian TUIR Art. 24-ter (Normattiva — opzione per imposta sostitutiva 7% sui redditi di fonte estera)',
+  url: 'https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:1986-12-22;917!vig=',
+  accessed: ACCESSED,
+};
+
+const ITALY_DECRETO_CRESCITA = {
+  title: 'Decreto-Legge 30 aprile 2019, n. 34 (Decreto Crescita) — introduces 7% flat-tax regime for foreign retirees',
+  url: 'https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.legge:2019-04-30;34',
+  accessed: ACCESSED,
+};
+
+const ITALY_AGENZIA_ENTRATE_24TER = {
+  title: 'Agenzia delle Entrate — Regime opzionale per pensionati esteri (TUIR Art. 24-ter)',
+  url: 'https://www.agenziaentrate.gov.it/portale/web/guest/schede/agevolazioni/regimespecialepensionatiesteri/scheda-info-regime-pensionati-esteri',
+  accessed: ACCESSED,
+};
+
+// Atenas climate rewrite sources
+const CR_IMN = {
+  title: 'Instituto Meteorológico Nacional Costa Rica (IMN) — Climate stations',
+  url: 'https://www.imn.ac.cr/',
+  accessed: ACCESSED,
+};
+
+const CLIMATE_DATA_ATENAS = {
+  title: 'Climate-Data.org — Atenas, Costa Rica (avg highs 28-30°C / lows 18-20°C, dry season Dec-April)',
+  url: 'https://en.climate-data.org/north-america/costa-rica/alajuela/atenas-22729/',
+  accessed: ACCESSED,
+};
+
+// Alicante A2 fix sources
+const ES_LEY_19_2015 = {
+  title: 'Ley 19/2015 + Real Decreto 1004/2015 — A2 Spanish + CCSE required for nationality (not residency)',
+  url: 'https://www.boe.es/buscar/act.php?id=BOE-A-2015-7391',
+  accessed: ACCESSED,
+};
+
+const ES_RD_557_2011 = {
+  title: 'Real Decreto 557/2011 — long-term residence permit (no language test, per EU Directive 2003/109/EC)',
+  url: 'https://www.boe.es/buscar/act.php?id=BOE-A-2011-7703',
+  accessed: ACCESSED,
+};
+
+const EU_DIRECTIVE_2003_109 = {
+  title: 'Council Directive 2003/109/EC — long-term-resident third-country nationals (EU baseline)',
+  url: 'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=celex%3A32003L0109',
+  accessed: ACCESSED,
+};
+
+// ─── #40: Italy 7% flat tax — APPEND new pro bullet ────────────────────
+
+/** Cities where the 24-ter regime applies (qualifying southern regions). */
+const ITALY_7PCT_CITIES = [
+  'italy-abruzzo',
+  'italy-puglia',
+  'italy-sardinia',
+  'italy-sicily',
+];
+
+const ITALY_7PCT_PRO = {
+  text: '7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)',
+  sources: [ITALY_TUIR_24TER, ITALY_DECRETO_CRESCITA, ITALY_AGENZIA_ENTRATE_24TER],
+};
+
+let italyAdded = 0;
+let italySkipped = 0;
+for (const city of ITALY_7PCT_CITIES) {
+  const path = join(DATA_DIR, city, 'location.json');
+  const raw = readFileSync(path, 'utf8');
+  const loc = JSON.parse(raw);
+  const pros = loc.pros;
+  if (!Array.isArray(pros)) {
+    console.warn(`SKIP ${city} — no pros array`);
+    continue;
+  }
+  // Idempotency: skip if a 24-ter / 7% bullet already exists.
+  const already = pros.some(b => {
+    const t = typeof b === 'string' ? b : b?.text ?? '';
+    return /24-ter|7%\s+flat\s+tax|Decreto\s+Crescita/i.test(t);
+  });
+  if (already) {
+    italySkipped++;
+    console.log(`-    italy/${city.replace('italy-', '')}: 7% bullet already present`);
+    continue;
+  }
+  pros.push(ITALY_7PCT_PRO);
+  italyAdded++;
+  console.log(`OK   italy/${city.replace('italy-', '')}: appended 7% flat tax pro`);
+  const hadTrailingNewline = raw.endsWith('\n');
+  writeFileSync(path, JSON.stringify(loc, null, 2) + (hadTrailingNewline ? '\n' : ''));
+}
+
+// ─── #39: Pros/cons content rewords ────────────────────────────────────
+
+const REWORDS = [
+  // Atenas climate — drop the unverified NatGeo attribution, replace with
+  // factual climate stats + sources.
+  {
+    city: 'costa-rica-atenas',
+    field: 'pros',
+    match: "Claimed 'best climate in the world' by National Geographic",
+    replacement: {
+      text: 'Notably stable mild climate year-round (avg highs 28-30°C / 82-86°F, lows 18-20°C / 64-68°F; dry season Dec-April; ~700m elevation)',
+      sources: [CLIMATE_DATA_ATENAS, CR_IMN],
+    },
+    reason: 'The "best climate by National Geographic" claim is widely repeated but the original NatGeo article is unverifiable. Replaced with factual climate stats from Climate-Data.org + IMN.',
+  },
+  // Alicante A2 — fix the citizenship-vs-residency conflation.
+  {
+    city: 'spain-alicante',
+    field: 'cons',
+    match: 'A2 Spanish required for permanent residency',
+    replacement: {
+      text: 'A2 Spanish + CCSE required for Spanish citizenship (after 10 years residency) — NOT for long-term-resident permit, which has no language test per EU Directive 2003/109/EC + RD 557/2011',
+      sources: [ES_LEY_19_2015, ES_RD_557_2011, EU_DIRECTIVE_2003_109],
+    },
+    reason: 'Original bullet conflated citizenship with permanent residency. Spanish long-term residence has no language test; A2+CCSE is for nationality (citizenship) only.',
+  },
+];
+
+let rewordCount = 0;
+let rewordNotFound = 0;
+for (const r of REWORDS) {
+  const path = join(DATA_DIR, r.city, 'location.json');
+  const raw = readFileSync(path, 'utf8');
+  const loc = JSON.parse(raw);
+  const list = loc[r.field];
+  if (!Array.isArray(list)) {
+    console.warn(`SKIP ${r.city} — no ${r.field} array`);
+    continue;
+  }
+  let found = false;
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i];
+    const text = typeof entry === 'string' ? entry : entry?.text;
+    if (text !== r.match) continue;
+    found = true;
+    list[i] = r.replacement;
+    rewordCount++;
+    console.log(`OK   reword ${r.city}.${r.field}: "${r.match}"`);
+    break;
+  }
+  if (!found) {
+    rewordNotFound++;
+    console.warn(`MISS ${r.city}.${r.field}: bullet not found — "${r.match}"`);
+    continue;
+  }
+  const hadTrailingNewline = raw.endsWith('\n');
+  writeFileSync(path, JSON.stringify(loc, null, 2) + (hadTrailingNewline ? '\n' : ''));
+}
+
+console.log(`\nDone.`);
+console.log(`  Italy 7% flat tax: added ${italyAdded}, skipped ${italySkipped}`);
+console.log(`  Rewords:           updated ${rewordCount}, not-found ${rewordNotFound}`);


### PR DESCRIPTION
## Summary

Two related cleanup batches in one PR — both surfaced during the [#19](https://github.com/justice8096/retirement-dashboard-angular/) country-citation sweep but deferred because they're content changes (new bullet additions or rewords), not citations to existing claims.

## #40: Italy 7% retiree flat tax — content addition (4 new pros)

Adds a new pro bullet to the 4 Italy locations that qualify for the **TUIR Art. 24-ter regime** (Decreto Crescita 2019). 7% flat tax on foreign-source income (pensions, dividends, interest, capital gains) for **9 years** for new residents in southern-region municipalities <20K population.

Hugely retirement-relevant — comparable in scope to Portugal's NHR or Spain's Beckham Law for foreign-pensioned movers.

**Cities updated** (4): \`italy-abruzzo\`, \`italy-puglia\`, \`italy-sardinia\`, \`italy-sicily\`

**Cities NOT updated** (don't qualify — wrong regions): \`italy-tuscany\` (central), \`italy-lake-region\` (northern)

**New bullet**: *"7% flat tax on foreign-source income for 9 years for new residents in qualifying southern-region municipalities <20K population (TUIR Art. 24-ter / Decreto Crescita 2019)"*

**Sources**: TUIR Art. 24-ter (Normattiva) + Decreto-Legge 34/2019 + Agenzia delle Entrate guidance.

## #39: Two pros/cons rewords flagged during the #19 sweep

### a. Atenas (Costa Rica) — UNVERIFIED CLAIM REPLACED
- **Old**: *"Claimed 'best climate in the world' by National Geographic"*
- **Issue**: NatGeo attribution is widely repeated but the original article is unfindable. Citing an unverifiable claim propagates the inaccuracy.
- **New**: *"Notably stable mild climate year-round (avg highs 28-30°C / 82-86°F, lows 18-20°C / 64-68°F; dry season Dec-April; ~700m elevation)"*
- Sources: Climate-Data.org + IMN (Costa Rica's met office)

### b. Alicante (Spain) — INCORRECT CLAIM CORRECTED
- **Old**: *"A2 Spanish required for permanent residency"*
- **Issue**: Conflated citizenship with residency. Spanish long-term residence permit (\`residencia de larga duración\`) has **no language test** per EU Directive 2003/109/EC + RD 557/2011. A2 + CCSE is required for **Spanish citizenship** per Ley 19/2015 / RD 1004/2015 — NOT for residency.
- **New**: *"A2 Spanish + CCSE required for Spanish citizenship (after 10 years residency) — NOT for long-term-resident permit, which has no language test per EU Directive 2003/109/EC + RD 557/2011"*
- Sources: Ley 19/2015 (BOE) + RD 557/2011 (BOE) + EU Directive 2003/109/EC (EUR-Lex)

## Running tally of factual corrections surfaced during the sweep

This brings the count to **4 factual fixes** as side benefits of the #19 citation work:

| # | Fix | PR |
|---|---|---|
| 1 | Portugal D7 visa figure (€705 stale → €870 current 2025 minimum wage) | [#96](https://github.com/justice8096/retirement-api/pull/96) |
| 2 | Cyprus pension-tax conflation (2.65% GeSY ≠ 5% pension flat) | [#104](https://github.com/justice8096/retirement-api/pull/104) |
| 3 | Atenas NatGeo claim (unverifiable → replaced with actual climate data) | this PR |
| 4 | Alicante residency-vs-citizenship language test (wrong regime) | this PR |

## Test plan

- [x] 6 location.json files round-trip cleanly
- [x] \`npm test\` (vitest): 35,517/35,517 pass
- [x] Idempotency confirmed: script's 24-ter regex match prevents duplicate Italy bullets on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)