### PR TITLE
feat(financial): persist transition-year ACA extra income (#38)

### DIFF
--- a/prisma/migrations/20260505000000_add_transition_year_extra_income/migration.sql
+++ b/prisma/migrations/20260505000000_add_transition_year_extra_income/migration.sql
@@ -1,0 +1,10 @@
+-- Add first-year transition extra-income field to user_financial_settings.
+-- This is a one-shot dollar amount that boosts MAGI in sim year 0 only —
+-- captures severance, unused PTO, final-year bonuses, and year-of-retirement
+-- RMDs that can blow up ACA subsidies if a user retires mid-year.
+--
+-- Default 0 means "no transition spike" — existing rows continue to behave
+-- as they did before this column existed (steady-state MAGI only).
+
+ALTER TABLE "user_financial_settings"
+  ADD COLUMN "transition_year_extra_income" DECIMAL(65,30) NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,13 @@ model UserFinancialSettings {
   mortgageMonthlyPayment Decimal @default(0) @map("mortgage_monthly_payment")
   mortgageEndYear        Int     @default(0) @map("mortgage_end_year")
 
+  // ─── First-year ACA transition income (Todo #38) ──────────────────
+  // One-shot extra income in sim year 0 only — captures W-2 wages
+  // earned Jan-retirement, severance, unused PTO, final-year bonuses,
+  // and year-of-retirement RMDs. Drives ACA MAGI for year 1; never
+  // persisted to MAGI baseline (it's a spike, not a steady-state).
+  transitionYearExtraIncome Decimal @default(0) @map("transition_year_extra_income")
+
   updatedAt        DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -63,6 +63,9 @@ const FIELD_LABELS: Record<string, string> = {
   retirementPath: 'Retirement path',
   fireTargetAge: 'FIRE target age',
   annualSavings: 'Yearly savings amount',
+  mortgageMonthlyPayment: 'Mortgage payment per month',
+  mortgageEndYear: 'Year the mortgage ends',
+  transitionYearExtraIncome: 'Extra income in first retirement year',
 
   // fees.ts
   brokerageFeePct: 'Advisor or brokerage fee',

--- a/src/routes/financial.ts
+++ b/src/routes/financial.ts
@@ -96,6 +96,11 @@ const financialSchema = z.object({
   // year fields).
   mortgageMonthlyPayment: num.min(0).max(100_000).optional(),
   mortgageEndYear: num.int().min(0).max(100).optional(),
+
+  // First-year ACA transition extra income (Todo #38). One-shot MAGI
+  // bump in sim year 0 only (severance, unused PTO, final-year bonuses,
+  // year-of-retirement RMDs). 0 = no transition spike configured.
+  transitionYearExtraIncome: num.min(0).max(10_000_000).optional(),
 }).strict();  // SAST M-02: reject unknown keys
 
 // Defaults sent to client when no DB record exists (client-side format).
@@ -116,6 +121,7 @@ const DEFAULTS = {
   rentalProperties: [],
   mortgageMonthlyPayment: 0,
   mortgageEndYear: 0,
+  transitionYearExtraIncome: 0,
 };
 
 /** Encrypted balance field names. */
@@ -156,6 +162,8 @@ const NUMERIC_FIELDS = new Set<string>([
   // is Int — both come back as String / number from Prisma but the
   // dashboard expects JS numbers everywhere, so coerce on egress.
   'mortgageMonthlyPayment', 'mortgageEndYear',
+  // Transition-year ACA spike (Todo #38). Decimal in DB → JS number.
+  'transitionYearExtraIncome',
 ]);
 
 /** Decrypt sensitive fields and convert DB decimals to client percentages.
@@ -201,6 +209,7 @@ const LABELED_FIELDS = [
   'traditionalLoadPct', 'rothLoadPct', 'taxableLoadPct', 'hsaLoadPct',
   'traditionalFeesPct', 'rothFeesPct', 'taxableFeesPct', 'hsaFeesPct',
   'mortgageMonthlyPayment', 'mortgageEndYear',
+  'transitionYearExtraIncome',
 ] as const;
 
 /** Build the `_units` metadata block for a response.
@@ -237,6 +246,7 @@ function unitsMeta(locale: string, apiVersion: 1 | 2 = 1) {
     hsaFeesPct: pct(ex('0.2 = 0.2% expense ratio', '0.002 = 0.2% expense ratio')),
     mortgageMonthlyPayment: { encoding: 'amount', currency, periodicity: 'month' },
     mortgageEndYear: { encoding: 'count', meaning: 'Sim-year (exclusive) when mortgage ends. 0 = no mortgage.' },
+    transitionYearExtraIncome: { encoding: 'amount', currency, periodicity: 'year' },
   };
 }
 


### PR DESCRIPTION
## Summary
- New `transitionYearExtraIncome` Decimal column on `user_financial_settings` (default 0)
- Migration `20260505000000_add_transition_year_extra_income`
- Zod schema accepts optional [0, 10_000_000]
- `_units` exposes amount/year encoding; `_labels` returns "Extra income in first retirement year"

## Why
Sim-year-0 MAGI bump captures severance, unused PTO, final-year bonuses, and year-of-retirement RMDs that can blow up ACA subsidies for mid-year retirees. Dashboard previously held this as a UI-only signal — see paired PR.

## Migration safety
- Additive `ADD COLUMN` with `DEFAULT 0`
- Existing rows behave identically (no transition spike)
- `prisma migrate deploy` is idempotent and forward-only

## Pairs with
- Dashboard: https://github.com/justice8096/retirement-dashboard-angular/pull/127

## Test plan
- [x] 25 existing financial route tests pass
- [ ] Run \`prisma migrate deploy\` on prod
- [ ] PUT /api/me/financial with \`transitionYearExtraIncome: 5000\` round-trips
- [ ] GET /api/me/financial includes the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)