### PR TITLE
feat(financial): persist income composition + ACA assumptions

### DIFF
--- a/prisma/migrations/20260610000000_add_income_composition/migration.sql
+++ b/prisma/migrations/20260610000000_add_income_composition/migration.sql
@@ -1,0 +1,17 @@
+-- Income composition + ACA assumptions on UserFinancialSettings.
+-- Dollar amounts are encrypted at rest (stored as TEXT ciphertext, like the
+-- balance columns). The rest are plain assumption fields with defaults so
+-- existing rows backfill to the same values the dashboard used session-only.
+
+ALTER TABLE "user_financial_settings"
+  ADD COLUMN "traditional_annual"            TEXT,
+  ADD COLUMN "roth_annual"                   TEXT,
+  ADD COLUMN "taxable_brokerage_annual"      TEXT,
+  ADD COLUMN "pension_annual"                TEXT,
+  ADD COLUMN "ss_annual"                     TEXT,
+  ADD COLUMN "total_annual_need"             TEXT,
+  ADD COLUMN "taxable_brokerage_taxable_pct" DECIMAL(65,30) NOT NULL DEFAULT 0.5,
+  ADD COLUMN "filing_status"                 TEXT    NOT NULL DEFAULT 'joint',
+  ADD COLUMN "apportion_strategy"            TEXT    NOT NULL DEFAULT 'manual',
+  ADD COLUMN "subsidy_regime"                TEXT    NOT NULL DEFAULT 'cliff',
+  ADD COLUMN "first_year_unsubsidized"       BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,6 +205,23 @@ model UserFinancialSettings {
   // persisted to MAGI baseline (it's a spike, not a steady-state).
   transitionYearExtraIncome Decimal @default(0) @map("transition_year_extra_income")
 
+  // ─── Income composition + ACA assumptions (Assumptions screen) ────
+  // Annual income split + total cash need that drive the MAGI / ACA-subsidy
+  // calc and auto-apportionment. Dollar amounts are financial PII → encrypted
+  // at rest (AES-256-GCM), same as the balance fields above.
+  traditionalAnnual      String?  @map("traditional_annual")        // Encrypted
+  rothAnnual             String?  @map("roth_annual")               // Encrypted
+  taxableBrokerageAnnual String?  @map("taxable_brokerage_annual")  // Encrypted
+  pensionAnnual          String?  @map("pension_annual")            // Encrypted
+  ssAnnual               String?  @map("ss_annual")                 // Encrypted
+  totalAnnualNeed        String?  @map("total_annual_need")         // Encrypted
+  // Fraction (0..1) of taxable-brokerage withdrawals counted as taxable income.
+  taxableBrokerageTaxablePct Decimal @default(0.5) @map("taxable_brokerage_taxable_pct")
+  filingStatus           String   @default("joint")   @map("filing_status")          // single | joint
+  apportionStrategy      String   @default("manual")  @map("apportion_strategy")      // manual | proportional | tax-efficient | magi-targeted
+  subsidyRegime          String   @default("cliff")   @map("subsidy_regime")          // cliff | enhanced
+  firstYearUnsubsidized  Boolean  @default(true)      @map("first_year_unsubsidized")
+
   updatedAt        DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/__tests__/routes-financial.test.ts
+++ b/src/__tests__/routes-financial.test.ts
@@ -55,6 +55,12 @@ describe('Financial routes', () => {
       expect(body.portfolioBalance).toBe(500000);
       expect(body.ssCutYear).toBe(2033);
       expect(body.ssCola).toBe(2.8);
+      // Income-composition + ACA assumption defaults
+      expect(body.apportionStrategy).toBe('manual');
+      expect(body.subsidyRegime).toBe('cliff');
+      expect(body.firstYearUnsubsidized).toBe(true);
+      expect(body.filingStatus).toBe('joint');
+      expect(body.taxableBrokerageTaxablePct).toBe(0.5);
     });
 
     it('returns decrypted settings when they exist', async () => {
@@ -113,6 +119,29 @@ describe('Financial routes', () => {
 
       const call = prisma.userFinancialSettings.upsert.mock.calls[0][0];
       expect(call.update.portfolioBalance).toBe('ENC:800000');
+    });
+
+    it('persists income composition: encrypts $ amounts, passes assumptions through', async () => {
+      prisma.userFinancialSettings.upsert.mockResolvedValue({ traditionalAnnual: 'ENC:60000' });
+
+      await app.inject({
+        method: 'PUT',
+        url: '/api/me/financial',
+        payload: {
+          traditionalAnnual: 60000, ssAnnual: 30000, totalAnnualNeed: 90000,
+          taxableBrokerageTaxablePct: 0.5, filingStatus: 'single',
+          apportionStrategy: 'magi-targeted', subsidyRegime: 'cliff', firstYearUnsubsidized: false,
+        },
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const u = prisma.userFinancialSettings.upsert.mock.calls[0][0].update;
+      expect(u.traditionalAnnual).toBe('ENC:60000');   // encrypted
+      expect(u.ssAnnual).toBe('ENC:30000');             // encrypted
+      expect(u.taxableBrokerageTaxablePct).toBe(0.5);   // fraction, NOT %-converted
+      expect(u.filingStatus).toBe('single');            // pass-through
+      expect(u.apportionStrategy).toBe('magi-targeted');
+      expect(u.firstYearUnsubsidized).toBe(false);
     });
 
     it('rejects invalid schema (extra fields)', async () => {

--- a/src/routes/financial.ts
+++ b/src/routes/financial.ts
@@ -75,6 +75,20 @@ const financialSchema = z.object({
   taxableBalance: num.min(0).max(100_000_000).nullable().optional(),
   hsaBalance: num.min(0).max(100_000_000).nullable().optional(),
 
+  // Income composition + ACA assumptions (Assumptions screen). Dollar amounts
+  // are encrypted at rest; the rest are plain assumption fields.
+  traditionalAnnual: num.min(0).max(100_000_000).nullable().optional(),
+  rothAnnual: num.min(0).max(100_000_000).nullable().optional(),
+  taxableBrokerageAnnual: num.min(0).max(100_000_000).nullable().optional(),
+  pensionAnnual: num.min(0).max(100_000_000).nullable().optional(),
+  ssAnnual: num.min(0).max(100_000_000).nullable().optional(),
+  totalAnnualNeed: num.min(0).max(100_000_000).nullable().optional(),
+  taxableBrokerageTaxablePct: num.min(0).max(1).optional(), // fraction, not %
+  filingStatus: z.enum(['single', 'joint']).optional(),
+  apportionStrategy: z.enum(['manual', 'proportional', 'tax-efficient', 'magi-targeted']).optional(),
+  subsidyRegime: z.enum(['cliff', 'enhanced']).optional(),
+  firstYearUnsubsidized: z.boolean().optional(),
+
   // Per-Account Load % and Fees % (whole-number percent on wire, e.g. 0.5 = 0.5%)
   traditionalLoadPct: num.min(0).max(10).optional(),
   rothLoadPct: num.min(0).max(10).optional(),
@@ -122,6 +136,18 @@ const DEFAULTS = {
   mortgageMonthlyPayment: 0,
   mortgageEndYear: 0,
   transitionYearExtraIncome: 0,
+  // Income composition + ACA assumptions (Assumptions screen).
+  traditionalAnnual: 0,
+  rothAnnual: 0,
+  taxableBrokerageAnnual: 0,
+  pensionAnnual: 0,
+  ssAnnual: 0,
+  totalAnnualNeed: 0,
+  taxableBrokerageTaxablePct: 0.5,
+  filingStatus: 'joint',
+  apportionStrategy: 'manual',
+  subsidyRegime: 'cliff',
+  firstYearUnsubsidized: true,
 };
 
 /** Encrypted balance field names. */
@@ -131,6 +157,13 @@ const ENCRYPTED_FIELDS = [
   'rothBalance',
   'taxableBalance',
   'hsaBalance',
+  // Income composition (annual $ amounts) — financial PII, encrypted at rest.
+  'traditionalAnnual',
+  'rothAnnual',
+  'taxableBrokerageAnnual',
+  'pensionAnnual',
+  'ssAnnual',
+  'totalAnnualNeed',
 ] as const;
 
 /** Decimal-fraction fields stored as 0.60 in DB but sent as 60 to client. */
@@ -164,6 +197,9 @@ const NUMERIC_FIELDS = new Set<string>([
   'mortgageMonthlyPayment', 'mortgageEndYear',
   // Transition-year ACA spike (Todo #38). Decimal in DB → JS number.
   'transitionYearExtraIncome',
+  // Income composition: encrypted annual $ amounts + the taxable fraction.
+  'traditionalAnnual', 'rothAnnual', 'taxableBrokerageAnnual', 'pensionAnnual',
+  'ssAnnual', 'totalAnnualNeed', 'taxableBrokerageTaxablePct',
 ]);
 
 /** Decrypt sensitive fields and convert DB decimals to client percentages.
@@ -210,6 +246,8 @@ const LABELED_FIELDS = [
   'traditionalFeesPct', 'rothFeesPct', 'taxableFeesPct', 'hsaFeesPct',
   'mortgageMonthlyPayment', 'mortgageEndYear',
   'transitionYearExtraIncome',
+  'traditionalAnnual', 'rothAnnual', 'taxableBrokerageAnnual', 'pensionAnnual',
+  'ssAnnual', 'totalAnnualNeed',
 ] as const;
 
 /** Build the `_units` metadata block for a response.


### PR DESCRIPTION
## Problem
The Assumptions screen's income split, **Total Annual Need**, apportion strategy, subsidy regime, and first-year-unsubsidized flag were **session-only** — never persisted, so they reset on reload and the user couldn't save them.

## Fix (api side)
Adds them to `UserFinancialSettings`:
- Annual $ amounts (`traditionalAnnual`, `rothAnnual`, `taxableBrokerageAnnual`, `pensionAnnual`, `ssAnnual`, `totalAnnualNeed`) — **encrypted at rest** (AES-256-GCM), like the balance fields.
- `taxableBrokerageTaxablePct` (fraction), `filingStatus`, `apportionStrategy`, `subsidyRegime`, `firstYearUnsubsidized` — plain, with sensible defaults so existing rows backfill to the prior session-only behavior.

Migration `20260610000000_add_income_composition`. `financialSchema` + GET/PUT round-trip (encrypt/decrypt + numeric coercion) extended.

## Tests
Encrypted-$ round-trip (PUT encrypts amounts, passes assumptions through) + assumption defaults on GET. Full suite **36,013** pass; typecheck + build clean.

> Pairs with dashboard `feat/persist-income-assumptions`. Requires `prisma migrate deploy` on the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)